### PR TITLE
fix for ecr policies

### DIFF
--- a/terraform/aws/modules/composition/ecr/main.tf
+++ b/terraform/aws/modules/composition/ecr/main.tf
@@ -36,7 +36,7 @@ resource "aws_ecr_repository_policy" "policies" {
   for_each = { for k, v in var.repositories : k => v if v.repository_policy != null }
 
   repository = aws_ecr_repository.repositories[each.key].name
-  policy     = jsonencode(each.value.repository_policy)
+  policy     = each.value.repository_policy
 }
 
 # ECR Lifecycle Policies
@@ -44,5 +44,5 @@ resource "aws_ecr_lifecycle_policy" "lifecycle_policies" {
   for_each = { for k, v in var.repositories : k => v if v.lifecycle_policy != null }
 
   repository = aws_ecr_repository.repositories[each.key].name
-  policy     = jsonencode(each.value.lifecycle_policy)
+  policy     = each.value.lifecycle_policy
 }

--- a/terraform/aws/modules/composition/ecr/variables.tf
+++ b/terraform/aws/modules/composition/ecr/variables.tf
@@ -32,8 +32,8 @@ variable "repositories" {
     encryption_type      = optional(string, "AES256")
     kms_key              = optional(string)
     force_delete         = optional(bool, false)
-    repository_policy    = optional(any)
-    lifecycle_policy     = optional(any)
+    repository_policy    = optional(string)
+    lifecycle_policy     = optional(string)
     image_tag_mutability_exclusion_filters = optional(list(object({
       filter      = string
       filter_type = string


### PR DESCRIPTION
This pull request refines how repository and lifecycle policies are handled in the ECR Terraform module. The main focus is on improving type safety and removing unnecessary encoding, which simplifies usage and reduces potential errors.

Type definition improvements:

* Changed the type of `repository_policy` and `lifecycle_policy` variables from `any` to `string` in `variables.tf`, ensuring that only string values are accepted for these policies.

Policy handling simplification:

* Removed `jsonencode` calls from the `policy` attributes in both `aws_ecr_repository_policy.policies` and `aws_ecr_lifecycle_policy.lifecycle_policies` resources in `main.tf`, allowing policies to be passed directly as strings.