### PR TITLE
feat: add ci checks for terraform

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -23,9 +23,53 @@ env:
   AWS_DEFAULT_REGION: eu-central-1
 
 jobs:
+  detect-changes:
+    name: Detect Changed Files
+    runs-on: ubuntu-latest
+    outputs:
+      terraform-files: ${{ steps.changed.outputs.terraform_files }}
+      terraform-dirs: ${{ steps.changed.outputs.terraform_dirs }}
+      has-changes: ${{ steps.changed.outputs.has_changes }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Get changed terraform files
+        id: changed
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- 'terraform/**/*.tf' 'terraform/**/*.tfvars' | grep -v '.terraform' || true)
+          
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "terraform_files=[]" >> $GITHUB_OUTPUT
+            echo "terraform_dirs=[]" >> $GITHUB_OUTPUT
+            echo "No terraform files changed"
+            exit 0
+          fi
+          
+          echo "has_changes=true" >> $GITHUB_OUTPUT
+          
+          TF_FILES=$(echo "$CHANGED_FILES" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "terraform_files=$TF_FILES" >> $GITHUB_OUTPUT
+          
+          TF_DIRS=$(echo "$CHANGED_FILES" | xargs -I{} dirname {} | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "terraform_dirs=$TF_DIRS" >> $GITHUB_OUTPUT
+          
+          echo "Changed terraform files:"
+          echo "$CHANGED_FILES"
+          echo ""
+          echo "Affected directories:"
+          echo "$TF_DIRS" | jq -r '.[]'
+
   terraform-fmt:
     name: Terraform Format Check
     runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has-changes == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -35,42 +79,35 @@ jobs:
         with:
           terraform_version: "~1.5"
 
-      - name: Find Terraform directories
-        id: find-dirs
-        run: |
-          # Find all directories containing .tf files (excluding .terraform directories)
-          DIRS=$(find terraform -name "*.tf" -not -path "*/.terraform/*" -exec dirname {} \; | sort -u | tr '\n' ' ')
-          echo "dirs=$DIRS" >> $GITHUB_OUTPUT
-          echo "Found directories:"
-          echo "$DIRS" | tr ' ' '\n'
-
-      - name: Run terraform fmt check
+      - name: Check formatting on changed files
         id: fmt
         run: |
           EXIT_CODE=0
-          FMT_OUTPUT=""
+          FAILED_FILES=""
           
-          for dir in ${{ steps.find-dirs.outputs.dirs }}; do
-            echo "Checking format in: $dir"
-            if ! OUTPUT=$(terraform fmt -check -recursive "$dir" 2>&1); then
+          FILES='${{ needs.detect-changes.outputs.terraform-files }}'
+          
+          for file in $(echo "$FILES" | jq -r '.[]'); do
+            if [ ! -f "$file" ]; then
+              continue
+            fi
+            
+            echo "Checking: $file"
+            if ! terraform fmt -check "$file" 2>&1; then
               EXIT_CODE=1
-              # Get list of files that need formatting
-              UNFORMATTED=$(terraform fmt -check -recursive "$dir" 2>&1 || true)
-              for file in $UNFORMATTED; do
-                if [[ -f "$file" ]]; then
-                  echo "::error file=$file::Terraform file needs formatting. Run 'terraform fmt' to fix."
-                  FMT_OUTPUT="${FMT_OUTPUT}${file}\n"
-                fi
-              done
+              FAILED_FILES="${FAILED_FILES}${file}\n"
+              echo "::error file=$file::Terraform file needs formatting. Run 'terraform fmt $file' to fix."
             fi
           done
           
           if [ $EXIT_CODE -ne 0 ]; then
             echo ""
-            echo "::error::Terraform format check failed. The following files need formatting:"
-            echo -e "$FMT_OUTPUT"
+            echo "::error::Terraform format check failed."
             echo ""
-            echo "Run 'terraform fmt -recursive terraform/' to fix formatting issues."
+            echo "Files needing formatting:"
+            echo -e "$FAILED_FILES"
+            echo ""
+            echo "Run locally: terraform fmt -recursive terraform/"
           fi
           
           exit $EXIT_CODE
@@ -78,7 +115,8 @@ jobs:
   terraform-validate:
     name: Terraform Validate
     runs-on: ubuntu-latest
-    needs: terraform-fmt
+    needs: [detect-changes, terraform-fmt]
+    if: needs.detect-changes.outputs.has-changes == 'true' && needs.terraform-fmt.result == 'success'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -96,34 +134,20 @@ jobs:
             skip_credentials_validation = true
             skip_metadata_api_check     = true
             skip_requesting_account_id  = true
-            
-            default_tags {
-              tags = {
-                Environment = "ci"
-                ManagedBy   = "terraform-ci"
-              }
-            }
           }
           EOF
 
-      - name: Find Terraform directories
-        id: find-dirs
-        run: |
-          DIRS=$(find terraform -name "*.tf" -not -path "*/.terraform/*" -exec dirname {} \; | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
-          echo "dirs=$DIRS" >> $GITHUB_OUTPUT
-          echo "Found directories: $DIRS"
-
-      - name: Initialize and Validate Terraform
+      - name: Validate changed directories
         id: validate
         run: |
           EXIT_CODE=0
-          FAILED_DIRS=""
           PASSED_DIRS=""
+          FAILED_DIRS=""
           
-          DIRS='${{ steps.find-dirs.outputs.dirs }}'
+          DIRS='${{ needs.detect-changes.outputs.terraform-dirs }}'
           
           for dir in $(echo "$DIRS" | jq -r '.[]'); do
-            if [ -z "$dir" ]; then
+            if [ -z "$dir" ] || [ ! -d "$dir" ]; then
               continue
             fi
             
@@ -168,7 +192,7 @@ jobs:
               FAILED_DIRS="${FAILED_DIRS}$dir (validation failed)\n"
               EXIT_CODE=1
             else
-              echo "✓ Validation passed for $dir"
+              echo "[PASS] Validation passed for $dir"
               PASSED_DIRS="${PASSED_DIRS}$dir\n"
             fi
             
@@ -194,7 +218,8 @@ jobs:
   terraform-plan:
     name: Terraform Plan
     runs-on: ubuntu-latest
-    needs: terraform-validate
+    needs: [detect-changes, terraform-validate]
+    if: needs.detect-changes.outputs.has-changes == 'true' && needs.terraform-validate.result == 'success'
     continue-on-error: true
     steps:
       - name: Checkout repository
@@ -213,34 +238,20 @@ jobs:
             skip_credentials_validation = true
             skip_metadata_api_check     = true
             skip_requesting_account_id  = true
-            
-            default_tags {
-              tags = {
-                Environment = "ci"
-                ManagedBy   = "terraform-ci"
-              }
-            }
           }
           EOF
 
-      - name: Find Terraform directories for planning
-        id: find-dirs
-        run: |
-          DIRS=$(find terraform -name "*.tf" -not -path "*/.terraform/*" -not -path "*/modules/*" -exec dirname {} \; | sort -u | grep -E "(live|bootstrap|oneclick)" | jq -R -s -c 'split("\n") | map(select(length > 0))')
-          echo "dirs=$DIRS" >> $GITHUB_OUTPUT
-          echo "Directories to plan: $DIRS"
-
-      - name: Run Terraform Plan
+      - name: Plan changed directories
         id: plan
         run: |
-          FAILED_DIRS=""
           PASSED_DIRS=""
+          FAILED_DIRS=""
           SKIPPED_DIRS=""
           
-          DIRS='${{ steps.find-dirs.outputs.dirs }}'
+          DIRS='${{ needs.detect-changes.outputs.terraform-dirs }}'
           
           for dir in $(echo "$DIRS" | jq -r '.[]'); do
-            if [ -z "$dir" ]; then
+            if [ -z "$dir" ] || [ ! -d "$dir" ]; then
               continue
             fi
             
@@ -248,9 +259,15 @@ jobs:
             echo "Planning: $dir"
             echo "=================================================="
             
-            if grep -r "terraform_remote_state" "$dir"/*.tf 2>/dev/null; then
-              echo "::warning file=$dir::Skipping plan - module uses terraform_remote_state which requires backend access"
-              SKIPPED_DIRS="${SKIPPED_DIRS}$dir (remote state dependency)\n"
+            if grep -rq "terraform_remote_state" "$dir"/*.tf 2>/dev/null; then
+              echo "::warning file=$dir::Skipping - uses terraform_remote_state"
+              SKIPPED_DIRS="${SKIPPED_DIRS}$dir (remote state)\n"
+              continue
+            fi
+            
+            if echo "$dir" | grep -q "/modules/"; then
+              echo "::warning file=$dir::Skipping - module directory (not deployable)"
+              SKIPPED_DIRS="${SKIPPED_DIRS}$dir (module)\n"
               continue
             fi
             
@@ -263,7 +280,7 @@ jobs:
             rm -f "$dir/ci_providers_override.tf" 2>/dev/null || true
             
             if [ $INIT_EXIT -ne 0 ]; then
-              echo "::warning file=$dir::Terraform init failed - skipping plan"
+              echo "::warning file=$dir::Init failed - skipping"
               echo "$INIT_OUTPUT"
               SKIPPED_DIRS="${SKIPPED_DIRS}$dir (init failed)\n"
               continue
@@ -274,20 +291,15 @@ jobs:
             PLAN_EXIT=$?
             
             if [ $PLAN_EXIT -eq 0 ]; then
-              echo "✓ Plan successful for $dir - no changes needed"
+              echo "[PASS] Plan passed for $dir - no changes"
               PASSED_DIRS="${PASSED_DIRS}$dir\n"
             elif [ $PLAN_EXIT -eq 2 ]; then
-              echo "✓ Plan successful for $dir - changes planned"
-              PASSED_DIRS="${PASSED_DIRS}$dir (has changes)\n"
-              echo "$PLAN_OUTPUT" | grep -E "Plan:|will be|created|destroyed|updated"
+              echo "[PASS] Plan passed for $dir - has changes"
+              PASSED_DIRS="${PASSED_DIRS}$dir (changes)\n"
             else
-              echo "::error file=$dir::Terraform plan failed"
+              echo "::error file=$dir::Plan failed"
               echo "$PLAN_OUTPUT"
               FAILED_DIRS="${FAILED_DIRS}$dir\n"
-              
-              echo "$PLAN_OUTPUT" | grep -E "Error:" | head -5 | while read -r error_line; do
-                echo "::error file=$dir::$error_line"
-              done
             fi
             
             rm -rf "$dir/.terraform" 2>/dev/null || true
@@ -304,7 +316,7 @@ jobs:
           echo "PASSED:"
           echo -e "$PASSED_DIRS" | grep -v "^$" || echo "None"
           echo ""
-          echo "SKIPPED (expected for modules with remote state):"
+          echo "SKIPPED:"
           echo -e "$SKIPPED_DIRS" | grep -v "^$" || echo "None"
           echo ""
           echo "FAILED:"
@@ -313,45 +325,78 @@ jobs:
   terraform-check-summary:
     name: Terraform Check Summary
     runs-on: ubuntu-latest
-    needs: [terraform-fmt, terraform-validate, terraform-plan]
+    needs: [detect-changes, terraform-fmt, terraform-validate, terraform-plan]
     if: always()
     steps:
-      - name: Check results
+      - name: Generate summary
         run: |
           echo "## Terraform CI Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          
+          HAS_CHANGES='${{ needs.detect-changes.outputs.has-changes }}'
+          
+          if [ "$HAS_CHANGES" != "true" ]; then
+            echo "No terraform files changed in this PR." >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
+          
           echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
           
-          if [ "${{ needs.terraform-fmt.result }}" == "success" ]; then
-            echo "| Format Check | ✅ Passed |" >> $GITHUB_STEP_SUMMARY
+          FMT_RESULT="${{ needs.terraform-fmt.result }}"
+          VALIDATE_RESULT="${{ needs.terraform-validate.result }}"
+          PLAN_RESULT="${{ needs.terraform-plan.result }}"
+          
+          if [ "$FMT_RESULT" == "success" ]; then
+            echo "| Format Check | PASSED |" >> $GITHUB_STEP_SUMMARY
+          elif [ "$FMT_RESULT" == "skipped" ]; then
+            echo "| Format Check | SKIPPED |" >> $GITHUB_STEP_SUMMARY
           else
-            echo "| Format Check | ❌ Failed |" >> $GITHUB_STEP_SUMMARY
+            echo "| Format Check | FAILED |" >> $GITHUB_STEP_SUMMARY
           fi
           
-          if [ "${{ needs.terraform-validate.result }}" == "success" ]; then
-            echo "| Validation | ✅ Passed |" >> $GITHUB_STEP_SUMMARY
+          if [ "$VALIDATE_RESULT" == "success" ]; then
+            echo "| Validation | PASSED |" >> $GITHUB_STEP_SUMMARY
+          elif [ "$VALIDATE_RESULT" == "skipped" ]; then
+            echo "| Validation | SKIPPED (fmt failed first) |" >> $GITHUB_STEP_SUMMARY
           else
-            echo "| Validation | ❌ Failed |" >> $GITHUB_STEP_SUMMARY
+            echo "| Validation | FAILED |" >> $GITHUB_STEP_SUMMARY
           fi
           
-          if [ "${{ needs.terraform-plan.result }}" == "success" ]; then
-            echo "| Plan | ✅ Passed |" >> $GITHUB_STEP_SUMMARY
-          elif [ "${{ needs.terraform-plan.result }}" == "failure" ]; then
-            echo "| Plan | ⚠️ Some modules failed (check logs) |" >> $GITHUB_STEP_SUMMARY
+          if [ "$PLAN_RESULT" == "success" ]; then
+            echo "| Plan | PASSED |" >> $GITHUB_STEP_SUMMARY
+          elif [ "$PLAN_RESULT" == "skipped" ]; then
+            echo "| Plan | SKIPPED |" >> $GITHUB_STEP_SUMMARY
           else
-            echo "| Plan | ⏭️ Skipped |" >> $GITHUB_STEP_SUMMARY
+            echo "| Plan | CHECK LOGS |" >> $GITHUB_STEP_SUMMARY
           fi
-          
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Required Status Check" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "This check is **required** for merging. Both format check and validation must pass." >> $GITHUB_STEP_SUMMARY
 
-      - name: Fail if required checks failed
+      - name: Check required results
         run: |
-          if [ "${{ needs.terraform-fmt.result }}" != "success" ] || [ "${{ needs.terraform-validate.result }}" != "success" ]; then
-            echo "::error::Required terraform checks failed. Please fix the issues above."
+          HAS_CHANGES='${{ needs.detect-changes.outputs.has-changes }}'
+          
+          if [ "$HAS_CHANGES" != "true" ]; then
+            echo "No terraform changes to check"
+            exit 0
+          fi
+          
+          FMT_RESULT="${{ needs.terraform-fmt.result }}"
+          VALIDATE_RESULT="${{ needs.terraform-validate.result }}"
+          
+          FAILED="false"
+          
+          if [ "$FMT_RESULT" != "success" ]; then
+            echo "::error::Format check failed or was skipped"
+            FAILED="true"
+          fi
+          
+          if [ "$VALIDATE_RESULT" != "success" ]; then
+            echo "::error::Validation failed or was skipped"
+            FAILED="true"
+          fi
+          
+          if [ "$FAILED" == "true" ]; then
             exit 1
           fi
+          
           echo "All required terraform checks passed!"

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -1,0 +1,357 @@
+name: Terraform Validate
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    paths:
+      - 'terraform/**/*.tf'
+      - 'terraform/**/*.tfvars'
+      - '.github/workflows/terraform-validate.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TF_IN_AUTOMATION: true
+  TF_INPUT: false
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID || 'mock' }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY || 'mock' }}
+  AWS_DEFAULT_REGION: eu-central-1
+
+jobs:
+  terraform-fmt:
+    name: Terraform Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~1.5"
+
+      - name: Find Terraform directories
+        id: find-dirs
+        run: |
+          # Find all directories containing .tf files (excluding .terraform directories)
+          DIRS=$(find terraform -name "*.tf" -not -path "*/.terraform/*" -exec dirname {} \; | sort -u | tr '\n' ' ')
+          echo "dirs=$DIRS" >> $GITHUB_OUTPUT
+          echo "Found directories:"
+          echo "$DIRS" | tr ' ' '\n'
+
+      - name: Run terraform fmt check
+        id: fmt
+        run: |
+          EXIT_CODE=0
+          FMT_OUTPUT=""
+          
+          for dir in ${{ steps.find-dirs.outputs.dirs }}; do
+            echo "Checking format in: $dir"
+            if ! OUTPUT=$(terraform fmt -check -recursive "$dir" 2>&1); then
+              EXIT_CODE=1
+              # Get list of files that need formatting
+              UNFORMATTED=$(terraform fmt -check -recursive "$dir" 2>&1 || true)
+              for file in $UNFORMATTED; do
+                if [[ -f "$file" ]]; then
+                  echo "::error file=$file::Terraform file needs formatting. Run 'terraform fmt' to fix."
+                  FMT_OUTPUT="${FMT_OUTPUT}${file}\n"
+                fi
+              done
+            fi
+          done
+          
+          if [ $EXIT_CODE -ne 0 ]; then
+            echo ""
+            echo "::error::Terraform format check failed. The following files need formatting:"
+            echo -e "$FMT_OUTPUT"
+            echo ""
+            echo "Run 'terraform fmt -recursive terraform/' to fix formatting issues."
+          fi
+          
+          exit $EXIT_CODE
+
+  terraform-validate:
+    name: Terraform Validate
+    runs-on: ubuntu-latest
+    needs: terraform-fmt
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~1.5"
+
+      - name: Create CI provider override
+        run: |
+          cat > /tmp/ci_providers_override.tf << 'EOF'
+          provider "aws" {
+            region                      = "eu-central-1"
+            skip_credentials_validation = true
+            skip_metadata_api_check     = true
+            skip_requesting_account_id  = true
+            
+            default_tags {
+              tags = {
+                Environment = "ci"
+                ManagedBy   = "terraform-ci"
+              }
+            }
+          }
+          EOF
+
+      - name: Find Terraform directories
+        id: find-dirs
+        run: |
+          DIRS=$(find terraform -name "*.tf" -not -path "*/.terraform/*" -exec dirname {} \; | sort -u | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "dirs=$DIRS" >> $GITHUB_OUTPUT
+          echo "Found directories: $DIRS"
+
+      - name: Initialize and Validate Terraform
+        id: validate
+        run: |
+          EXIT_CODE=0
+          FAILED_DIRS=""
+          PASSED_DIRS=""
+          
+          DIRS='${{ steps.find-dirs.outputs.dirs }}'
+          
+          for dir in $(echo "$DIRS" | jq -r '.[]'); do
+            if [ -z "$dir" ]; then
+              continue
+            fi
+            
+            echo "=================================================="
+            echo "Validating: $dir"
+            echo "=================================================="
+            
+            cp /tmp/ci_providers_override.tf "$dir/" 2>/dev/null || true
+            
+            echo "Running terraform init -backend=false..."
+            INIT_OUTPUT=$(terraform init -backend=false -get=true -upgrade "$dir" 2>&1)
+            INIT_EXIT=$?
+            
+            rm -f "$dir/ci_providers_override.tf" 2>/dev/null || true
+            
+            if [ $INIT_EXIT -ne 0 ]; then
+              echo "::error file=$dir::Terraform init failed"
+              echo "$INIT_OUTPUT"
+              FAILED_DIRS="${FAILED_DIRS}$dir (init failed)\n"
+              EXIT_CODE=1
+              continue
+            fi
+            
+            echo "Running terraform validate..."
+            VALIDATE_OUTPUT=$(terraform validate "$dir" 2>&1)
+            VALIDATE_EXIT=$?
+            
+            if [ $VALIDATE_EXIT -ne 0 ]; then
+              echo "::error file=$dir::Terraform validation failed"
+              echo "$VALIDATE_OUTPUT"
+              
+              echo "$VALIDATE_OUTPUT" | grep -E "Error:" | while read -r error_line; do
+                FILE_LINE=$(echo "$error_line" | grep -oE "on [^ ]+ line [0-9]+" || true)
+                if [ -n "$FILE_LINE" ]; then
+                  FILE=$(echo "$FILE_LINE" | awk '{print $2}')
+                  LINE=$(echo "$FILE_LINE" | awk '{print $4}')
+                  MSG=$(echo "$error_line" | sed 's/.*Error:/Error:/')
+                  echo "::error file=$dir/$FILE,line=$LINE::$MSG"
+                fi
+              done
+              
+              FAILED_DIRS="${FAILED_DIRS}$dir (validation failed)\n"
+              EXIT_CODE=1
+            else
+              echo "✓ Validation passed for $dir"
+              PASSED_DIRS="${PASSED_DIRS}$dir\n"
+            fi
+            
+            rm -rf "$dir/.terraform" 2>/dev/null || true
+            rm -f "$dir/.terraform.lock.hcl" 2>/dev/null || true
+            
+            echo ""
+          done
+          
+          echo ""
+          echo "=================================================="
+          echo "VALIDATION SUMMARY"
+          echo "=================================================="
+          echo ""
+          echo "PASSED:"
+          echo -e "$PASSED_DIRS" | grep -v "^$" || echo "None"
+          echo ""
+          echo "FAILED:"
+          echo -e "$FAILED_DIRS" | grep -v "^$" || echo "None"
+          
+          exit $EXIT_CODE
+
+  terraform-plan:
+    name: Terraform Plan
+    runs-on: ubuntu-latest
+    needs: terraform-validate
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~1.5"
+
+      - name: Create CI provider override
+        run: |
+          cat > /tmp/ci_providers_override.tf << 'EOF'
+          provider "aws" {
+            region                      = "eu-central-1"
+            skip_credentials_validation = true
+            skip_metadata_api_check     = true
+            skip_requesting_account_id  = true
+            
+            default_tags {
+              tags = {
+                Environment = "ci"
+                ManagedBy   = "terraform-ci"
+              }
+            }
+          }
+          EOF
+
+      - name: Find Terraform directories for planning
+        id: find-dirs
+        run: |
+          DIRS=$(find terraform -name "*.tf" -not -path "*/.terraform/*" -not -path "*/modules/*" -exec dirname {} \; | sort -u | grep -E "(live|bootstrap|oneclick)" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "dirs=$DIRS" >> $GITHUB_OUTPUT
+          echo "Directories to plan: $DIRS"
+
+      - name: Run Terraform Plan
+        id: plan
+        run: |
+          FAILED_DIRS=""
+          PASSED_DIRS=""
+          SKIPPED_DIRS=""
+          
+          DIRS='${{ steps.find-dirs.outputs.dirs }}'
+          
+          for dir in $(echo "$DIRS" | jq -r '.[]'); do
+            if [ -z "$dir" ]; then
+              continue
+            fi
+            
+            echo "=================================================="
+            echo "Planning: $dir"
+            echo "=================================================="
+            
+            if grep -r "terraform_remote_state" "$dir"/*.tf 2>/dev/null; then
+              echo "::warning file=$dir::Skipping plan - module uses terraform_remote_state which requires backend access"
+              SKIPPED_DIRS="${SKIPPED_DIRS}$dir (remote state dependency)\n"
+              continue
+            fi
+            
+            cp /tmp/ci_providers_override.tf "$dir/" 2>/dev/null || true
+            
+            echo "Running terraform init -backend=false..."
+            INIT_OUTPUT=$(terraform init -backend=false -get=true -upgrade "$dir" 2>&1)
+            INIT_EXIT=$?
+            
+            rm -f "$dir/ci_providers_override.tf" 2>/dev/null || true
+            
+            if [ $INIT_EXIT -ne 0 ]; then
+              echo "::warning file=$dir::Terraform init failed - skipping plan"
+              echo "$INIT_OUTPUT"
+              SKIPPED_DIRS="${SKIPPED_DIRS}$dir (init failed)\n"
+              continue
+            fi
+            
+            echo "Running terraform plan..."
+            PLAN_OUTPUT=$(terraform plan -input=false -detailed-exitcode "$dir" 2>&1)
+            PLAN_EXIT=$?
+            
+            if [ $PLAN_EXIT -eq 0 ]; then
+              echo "✓ Plan successful for $dir - no changes needed"
+              PASSED_DIRS="${PASSED_DIRS}$dir\n"
+            elif [ $PLAN_EXIT -eq 2 ]; then
+              echo "✓ Plan successful for $dir - changes planned"
+              PASSED_DIRS="${PASSED_DIRS}$dir (has changes)\n"
+              echo "$PLAN_OUTPUT" | grep -E "Plan:|will be|created|destroyed|updated"
+            else
+              echo "::error file=$dir::Terraform plan failed"
+              echo "$PLAN_OUTPUT"
+              FAILED_DIRS="${FAILED_DIRS}$dir\n"
+              
+              echo "$PLAN_OUTPUT" | grep -E "Error:" | head -5 | while read -r error_line; do
+                echo "::error file=$dir::$error_line"
+              done
+            fi
+            
+            rm -rf "$dir/.terraform" 2>/dev/null || true
+            rm -f "$dir/.terraform.lock.hcl" 2>/dev/null || true
+            
+            echo ""
+          done
+          
+          echo ""
+          echo "=================================================="
+          echo "PLAN SUMMARY"
+          echo "=================================================="
+          echo ""
+          echo "PASSED:"
+          echo -e "$PASSED_DIRS" | grep -v "^$" || echo "None"
+          echo ""
+          echo "SKIPPED (expected for modules with remote state):"
+          echo -e "$SKIPPED_DIRS" | grep -v "^$" || echo "None"
+          echo ""
+          echo "FAILED:"
+          echo -e "$FAILED_DIRS" | grep -v "^$" || echo "None"
+
+  terraform-check-summary:
+    name: Terraform Check Summary
+    runs-on: ubuntu-latest
+    needs: [terraform-fmt, terraform-validate, terraform-plan]
+    if: always()
+    steps:
+      - name: Check results
+        run: |
+          echo "## Terraform CI Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
+          
+          if [ "${{ needs.terraform-fmt.result }}" == "success" ]; then
+            echo "| Format Check | ✅ Passed |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| Format Check | ❌ Failed |" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          if [ "${{ needs.terraform-validate.result }}" == "success" ]; then
+            echo "| Validation | ✅ Passed |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| Validation | ❌ Failed |" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          if [ "${{ needs.terraform-plan.result }}" == "success" ]; then
+            echo "| Plan | ✅ Passed |" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ needs.terraform-plan.result }}" == "failure" ]; then
+            echo "| Plan | ⚠️ Some modules failed (check logs) |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| Plan | ⏭️ Skipped |" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Required Status Check" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "This check is **required** for merging. Both format check and validation must pass." >> $GITHUB_STEP_SUMMARY
+
+      - name: Fail if required checks failed
+        run: |
+          if [ "${{ needs.terraform-fmt.result }}" != "success" ] || [ "${{ needs.terraform-validate.result }}" != "success" ]; then
+            echo "::error::Required terraform checks failed. Please fix the issues above."
+            exit 1
+          fi
+          echo "All required terraform checks passed!"

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -215,117 +215,10 @@ jobs:
           
           exit $EXIT_CODE
 
-  terraform-plan:
-    name: Terraform Plan
-    runs-on: ubuntu-latest
-    needs: [detect-changes, terraform-validate]
-    if: needs.detect-changes.outputs.has-changes == 'true' && needs.terraform-validate.result == 'success'
-    continue-on-error: true
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: "~1.5"
-
-      - name: Create CI provider override
-        run: |
-          cat > /tmp/ci_providers_override.tf << 'EOF'
-          provider "aws" {
-            region                      = "eu-central-1"
-            skip_credentials_validation = true
-            skip_metadata_api_check     = true
-            skip_requesting_account_id  = true
-          }
-          EOF
-
-      - name: Plan changed directories
-        id: plan
-        run: |
-          PASSED_DIRS=""
-          FAILED_DIRS=""
-          SKIPPED_DIRS=""
-          
-          DIRS='${{ needs.detect-changes.outputs.terraform-dirs }}'
-          
-          for dir in $(echo "$DIRS" | jq -r '.[]'); do
-            if [ -z "$dir" ] || [ ! -d "$dir" ]; then
-              continue
-            fi
-            
-            echo "=================================================="
-            echo "Planning: $dir"
-            echo "=================================================="
-            
-            if grep -rq "terraform_remote_state" "$dir"/*.tf 2>/dev/null; then
-              echo "::warning file=$dir::Skipping - uses terraform_remote_state"
-              SKIPPED_DIRS="${SKIPPED_DIRS}$dir (remote state)\n"
-              continue
-            fi
-            
-            if echo "$dir" | grep -q "/modules/"; then
-              echo "::warning file=$dir::Skipping - module directory (not deployable)"
-              SKIPPED_DIRS="${SKIPPED_DIRS}$dir (module)\n"
-              continue
-            fi
-            
-            cp /tmp/ci_providers_override.tf "$dir/" 2>/dev/null || true
-            
-            echo "Running terraform init -backend=false..."
-            INIT_OUTPUT=$(terraform init -backend=false -get=true -upgrade "$dir" 2>&1)
-            INIT_EXIT=$?
-            
-            rm -f "$dir/ci_providers_override.tf" 2>/dev/null || true
-            
-            if [ $INIT_EXIT -ne 0 ]; then
-              echo "::warning file=$dir::Init failed - skipping"
-              echo "$INIT_OUTPUT"
-              SKIPPED_DIRS="${SKIPPED_DIRS}$dir (init failed)\n"
-              continue
-            fi
-            
-            echo "Running terraform plan..."
-            PLAN_OUTPUT=$(terraform plan -input=false -detailed-exitcode "$dir" 2>&1)
-            PLAN_EXIT=$?
-            
-            if [ $PLAN_EXIT -eq 0 ]; then
-              echo "[PASS] Plan passed for $dir - no changes"
-              PASSED_DIRS="${PASSED_DIRS}$dir\n"
-            elif [ $PLAN_EXIT -eq 2 ]; then
-              echo "[PASS] Plan passed for $dir - has changes"
-              PASSED_DIRS="${PASSED_DIRS}$dir (changes)\n"
-            else
-              echo "::error file=$dir::Plan failed"
-              echo "$PLAN_OUTPUT"
-              FAILED_DIRS="${FAILED_DIRS}$dir\n"
-            fi
-            
-            rm -rf "$dir/.terraform" 2>/dev/null || true
-            rm -f "$dir/.terraform.lock.hcl" 2>/dev/null || true
-            
-            echo ""
-          done
-          
-          echo ""
-          echo "=================================================="
-          echo "PLAN SUMMARY"
-          echo "=================================================="
-          echo ""
-          echo "PASSED:"
-          echo -e "$PASSED_DIRS" | grep -v "^$" || echo "None"
-          echo ""
-          echo "SKIPPED:"
-          echo -e "$SKIPPED_DIRS" | grep -v "^$" || echo "None"
-          echo ""
-          echo "FAILED:"
-          echo -e "$FAILED_DIRS" | grep -v "^$" || echo "None"
-
   terraform-check-summary:
     name: Terraform Check Summary
     runs-on: ubuntu-latest
-    needs: [detect-changes, terraform-fmt, terraform-validate, terraform-plan]
+    needs: [detect-changes, terraform-fmt, terraform-validate]
     if: always()
     steps:
       - name: Generate summary
@@ -345,7 +238,6 @@ jobs:
           
           FMT_RESULT="${{ needs.terraform-fmt.result }}"
           VALIDATE_RESULT="${{ needs.terraform-validate.result }}"
-          PLAN_RESULT="${{ needs.terraform-plan.result }}"
           
           if [ "$FMT_RESULT" == "success" ]; then
             echo "| Format Check | PASSED |" >> $GITHUB_STEP_SUMMARY
@@ -361,14 +253,6 @@ jobs:
             echo "| Validation | SKIPPED (fmt failed first) |" >> $GITHUB_STEP_SUMMARY
           else
             echo "| Validation | FAILED |" >> $GITHUB_STEP_SUMMARY
-          fi
-          
-          if [ "$PLAN_RESULT" == "success" ]; then
-            echo "| Plan | PASSED |" >> $GITHUB_STEP_SUMMARY
-          elif [ "$PLAN_RESULT" == "skipped" ]; then
-            echo "| Plan | SKIPPED |" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "| Plan | CHECK LOGS |" >> $GITHUB_STEP_SUMMARY
           fi
 
       - name: Check required results

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -112,6 +112,79 @@ jobs:
           
           exit $EXIT_CODE
 
+  tflint:
+    name: TFLint
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has-changes == 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup TFLint
+        uses: terraform-linters/setup-tflint@v4
+        with:
+          tflint_version: latest
+
+      - name: Init TFLint
+        run: tflint --init
+
+      - name: Run TFLint on changed directories
+        id: lint
+        run: |
+          EXIT_CODE=0
+          PASSED_DIRS=""
+          FAILED_DIRS=""
+          
+          DIRS='${{ needs.detect-changes.outputs.terraform-dirs }}'
+          
+          for dir in $(echo "$DIRS" | jq -r '.[]'); do
+            if [ -z "$dir" ] || [ ! -d "$dir" ]; then
+              continue
+            fi
+            
+            echo "=================================================="
+            echo "Linting: $dir"
+            echo "=================================================="
+            
+            LINT_OUTPUT=$(tflint --chdir="$dir" --format=compact 2>&1)
+            LINT_EXIT=$?
+            
+            if [ $LINT_EXIT -ne 0 ]; then
+              echo "::error file=$dir::TFLint found issues"
+              echo "$LINT_OUTPUT"
+              FAILED_DIRS="${FAILED_DIRS}$dir\n"
+              EXIT_CODE=1
+              
+              echo "$LINT_OUTPUT" | while read -r line; do
+                if echo "$line" | grep -qE "^[^:]+:[0-9]+:[0-9]+:"; then
+                  FILE=$(echo "$line" | cut -d: -f1)
+                  LINE=$(echo "$line" | cut -d: -f2)
+                  MSG=$(echo "$line" | cut -d: -f4-)
+                  echo "::error file=$dir/$FILE,line=$LINE::$MSG"
+                fi
+              done
+            else
+              echo "[PASS] No lint issues in $dir"
+              PASSED_DIRS="${PASSED_DIRS}$dir\n"
+            fi
+            
+            echo ""
+          done
+          
+          echo ""
+          echo "=================================================="
+          echo "TFLINT SUMMARY"
+          echo "=================================================="
+          echo ""
+          echo "PASSED:"
+          echo -e "$PASSED_DIRS" | grep -v "^$" || echo "None"
+          echo ""
+          echo "FAILED:"
+          echo -e "$FAILED_DIRS" | grep -v "^$" || echo "None"
+          
+          exit $EXIT_CODE
+
   terraform-validate:
     name: Terraform Validate
     runs-on: ubuntu-latest
@@ -218,7 +291,7 @@ jobs:
   terraform-check-summary:
     name: Terraform Check Summary
     runs-on: ubuntu-latest
-    needs: [detect-changes, terraform-fmt, terraform-validate]
+    needs: [detect-changes, terraform-fmt, tflint, terraform-validate]
     if: always()
     steps:
       - name: Generate summary
@@ -237,6 +310,7 @@ jobs:
           echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
           
           FMT_RESULT="${{ needs.terraform-fmt.result }}"
+          TFLINT_RESULT="${{ needs.tflint.result }}"
           VALIDATE_RESULT="${{ needs.terraform-validate.result }}"
           
           if [ "$FMT_RESULT" == "success" ]; then
@@ -245,6 +319,14 @@ jobs:
             echo "| Format Check | SKIPPED |" >> $GITHUB_STEP_SUMMARY
           else
             echo "| Format Check | FAILED |" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          if [ "$TFLINT_RESULT" == "success" ]; then
+            echo "| TFLint | PASSED |" >> $GITHUB_STEP_SUMMARY
+          elif [ "$TFLINT_RESULT" == "skipped" ]; then
+            echo "| TFLint | SKIPPED |" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "| TFLint | FAILED |" >> $GITHUB_STEP_SUMMARY
           fi
           
           if [ "$VALIDATE_RESULT" == "success" ]; then
@@ -265,12 +347,18 @@ jobs:
           fi
           
           FMT_RESULT="${{ needs.terraform-fmt.result }}"
+          TFLINT_RESULT="${{ needs.tflint.result }}"
           VALIDATE_RESULT="${{ needs.terraform-validate.result }}"
           
           FAILED="false"
           
           if [ "$FMT_RESULT" != "success" ]; then
             echo "::error::Format check failed or was skipped"
+            FAILED="true"
+          fi
+          
+          if [ "$TFLINT_RESULT" != "success" ]; then
+            echo "::error::TFLint check failed or was skipped"
             FAILED="true"
           fi
           


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow, `terraform-validate.yml`, to automate Terraform checks on pull requests. The workflow detects changes to Terraform files and runs formatting, linting, and validation checks, providing clear feedback in the PR summary and enforcing quality gates before merging.

Key improvements in CI/CD automation for Terraform:

**Automated Terraform Quality Checks**
* Adds `.github/workflows/terraform-validate.yml` to automatically detect changes in Terraform files and trigger CI jobs for format checking, linting with TFLint, and validation using Terraform, ensuring that only properly formatted and valid Terraform code is merged.

**Job Orchestration and Reporting**
* Implements a summary step that reports the results of all checks (format, lint, validation) directly in the PR, and enforces that all checks must pass before merging.

**Performance and Safety Enhancements**
* Uses concurrency controls to prevent overlapping runs for the same PR, and employs mock AWS credentials and provider overrides to safely run Terraform commands in CI without exposing real credentials.