### PR TITLE
chore: update the output.tf for the db_cluster_identifier and db_cluster_instance_ids for locker module

### DIFF
--- a/terraform/aws/modules/composition/locker/outputs.tf
+++ b/terraform/aws/modules/composition/locker/outputs.tf
@@ -55,10 +55,10 @@ output "alb_listener_arns" {
 
 output "alb_listener_details" {
   description = "Details of the ALB listeners (port and protocol)"
-  value       = { for key, listener in var.alb_listeners : key => {
+  value = { for key, listener in var.alb_listeners : key => {
     port     = listener.port
     protocol = listener.protocol
-  }}
+  } }
 }
 
 # =========================================================================
@@ -102,6 +102,11 @@ output "db_cluster_arn" {
   value       = var.create_locker_database && var.database_config != null ? module.database[0].cluster_arn : null
 }
 
+output "db_cluster_identifier" {
+  description = "The cluster identifier of the RDS Aurora database for CloudWatch metrics"
+  value       = var.create_locker_database && var.database_config != null ? module.database[0].cluster_identifier : null
+}
+
 output "db_security_group_id" {
   description = "The security group ID of the RDS database"
   value       = var.create_locker_database && var.database_config != null ? module.database[0].security_group_id : null
@@ -115,4 +120,9 @@ output "db_subnet_group_id" {
 output "db_instance_endpoints" {
   description = "Map of instance endpoints for the RDS cluster"
   value       = var.create_locker_database && var.database_config != null ? module.database[0].cluster_instance_endpoints : null
+}
+
+output "db_cluster_instance_ids" {
+  description = "Map of RDS cluster instance identifiers for CloudWatch instance-level metrics"
+  value       = var.create_locker_database && var.database_config != null ? module.database[0].cluster_instance_ids : {}
 }


### PR DESCRIPTION
This pull request adds new Terraform outputs to improve observability and monitoring for the RDS Aurora database in the `locker` module. The main changes introduce outputs for the cluster identifier and instance IDs, which are useful for CloudWatch metrics and instance-level monitoring.

**Enhancements for monitoring and observability:**

* Added a new output `db_cluster_identifier` to expose the RDS Aurora cluster identifier, facilitating integration with CloudWatch metrics.
* Added a new output `db_cluster_instance_ids` to provide a map of RDS cluster instance identifiers, enabling instance-level CloudWatch monitoring.