### PR TITLE
feat(vpc-network): add support for vpc peering between Cross Account and Cross Region

### DIFF
--- a/terraform/aws/live/dev/eu-central-1/vpc-network/main.tf
+++ b/terraform/aws/live/dev/eu-central-1/vpc-network/main.tf
@@ -106,6 +106,11 @@ module "vpc_network" {
   manage_default_security_group = true
   manage_default_route_table    = true
 
+  # VPC Peering (cross-account, cross-region)
+  vpc_peering_connections          = var.vpc_peering_connections
+  vpc_peering_accepter_connections = var.vpc_peering_accepter_connections
+  enable_vpc_peering_routes        = var.enable_vpc_peering_routes
+
   tags = merge(
     var.tags,
     {

--- a/terraform/aws/live/dev/eu-central-1/vpc-network/outputs.tf
+++ b/terraform/aws/live/dev/eu-central-1/vpc-network/outputs.tf
@@ -72,3 +72,13 @@ output "nat_gateway_ips" {
   description = "NAT Gateway public IPs"
   value       = module.vpc_network.nat_gateway_public_ips
 }
+
+output "vpc_peering_connection_ids" {
+  description = "Map of VPC peering connection IDs"
+  value       = module.vpc_network.vpc_peering_connection_ids
+}
+
+output "vpc_peering_accepter_ids" {
+  description = "Map of accepted VPC peering connection IDs (accepter side)"
+  value       = module.vpc_network.vpc_peering_accepter_ids
+}

--- a/terraform/aws/live/dev/eu-central-1/vpc-network/terraform.tfvars
+++ b/terraform/aws/live/dev/eu-central-1/vpc-network/terraform.tfvars
@@ -175,6 +175,40 @@ tags = {
 }
 
 ###################
+# VPC Peering (Cross-Account, Cross-Region)
+###################
+# Example: Requester side - create peering connection to peer VPC
+# vpc_peering_connections = {
+#   peer-to-prod = {
+#     peer_vpc_id   = "vpc-abc12345"
+#     peer_vpc_cidr = "10.1.0.0/16"
+#     peer_region   = "us-east-1"
+#     peer_owner_id = "123456789012"
+#     route_tables  = ["private-nat", "eks-workers"]
+#     auto_accept   = false
+#     tags = {
+#       PeerName = "prod-vpc"
+#     }
+#   }
+# }
+vpc_peering_connections = {}
+
+# Example: Accepter side - accept incoming peering request (run in accepter account)
+# vpc_peering_accepter_connections = {
+#   accept-from-dev = {
+#     peering_connection_id = "pcx-abc12345"
+#     peer_vpc_cidr         = "10.0.0.0/16"
+#     route_tables          = ["all"]
+#     tags = {
+#       PeerName = "dev-vpc"
+#     }
+#   }
+# }
+vpc_peering_accepter_connections = {}
+
+enable_vpc_peering_routes = true
+
+###################
 # IP Allocation Summary
 ###################
 # Total Allocated:  13,824 IPs (21.1% of VPC)

--- a/terraform/aws/live/dev/eu-central-1/vpc-network/terraform.tfvars
+++ b/terraform/aws/live/dev/eu-central-1/vpc-network/terraform.tfvars
@@ -177,17 +177,17 @@ tags = {
 ###################
 # VPC Peering (Cross-Account, Cross-Region)
 ###################
-# Example: Requester side - create peering connection to peer VPC
+# Example: Requester side - create peering connection to peer VPC with multiple CIDRs
 # vpc_peering_connections = {
-#   peer-to-prod = {
+#   corporate-network = {
 #     peer_vpc_id   = "vpc-abc12345"
-#     peer_vpc_cidr = "10.1.0.0/16"
+#     peer_vpc_cidr = ["10.1.0.0/16", "10.2.0.0/16", "172.16.0.0/16", "192.168.0.0/16"]
 #     peer_region   = "us-east-1"
 #     peer_owner_id = "123456789012"
 #     route_tables  = ["private-nat", "eks-workers"]
 #     auto_accept   = false
 #     tags = {
-#       PeerName = "prod-vpc"
+#       PeerName = "corporate-vpc"
 #     }
 #   }
 # }
@@ -195,12 +195,12 @@ vpc_peering_connections = {}
 
 # Example: Accepter side - accept incoming peering request (run in accepter account)
 # vpc_peering_accepter_connections = {
-#   accept-from-dev = {
+#   accept-from-hyperswitch = {
 #     peering_connection_id = "pcx-abc12345"
-#     peer_vpc_cidr         = "10.0.0.0/16"
+#     peer_vpc_cidr         = ["10.0.0.0/16", "10.100.0.0/16"]
 #     route_tables          = ["all"]
 #     tags = {
-#       PeerName = "dev-vpc"
+#       PeerName = "hyperswitch-dev"
 #     }
 #   }
 # }

--- a/terraform/aws/live/dev/eu-central-1/vpc-network/variables.tf
+++ b/terraform/aws/live/dev/eu-central-1/vpc-network/variables.tf
@@ -278,6 +278,37 @@ variable "tags" {
   }
 }
 
+variable "vpc_peering_connections" {
+  description = "Map of VPC peering connection configurations (cross-account, cross-region supported)"
+  type = map(object({
+    peer_vpc_id   = string
+    peer_vpc_cidr = string
+    peer_region   = optional(string)
+    peer_owner_id = optional(string)
+    route_tables  = optional(list(string), ["all"])
+    auto_accept   = optional(bool, false)
+    tags          = optional(map(string), {})
+  }))
+  default = {}
+}
+
+variable "vpc_peering_accepter_connections" {
+  description = "Map of VPC peering connection IDs to accept (for cross-account peering)"
+  type = map(object({
+    peering_connection_id = string
+    route_tables          = optional(list(string), ["all"])
+    peer_vpc_cidr         = string
+    tags                  = optional(map(string), {})
+  }))
+  default = {}
+}
+
+variable "enable_vpc_peering_routes" {
+  description = "Whether to create routes for VPC peering connections"
+  type        = bool
+  default     = true
+}
+
 ###################
 # Subnet Allocation Summary
 ###################

--- a/terraform/aws/live/dev/eu-central-1/vpc-network/variables.tf
+++ b/terraform/aws/live/dev/eu-central-1/vpc-network/variables.tf
@@ -282,7 +282,7 @@ variable "vpc_peering_connections" {
   description = "Map of VPC peering connection configurations (cross-account, cross-region supported)"
   type = map(object({
     peer_vpc_id   = string
-    peer_vpc_cidr = string
+    peer_vpc_cidr = list(string)
     peer_region   = optional(string)
     peer_owner_id = optional(string)
     route_tables  = optional(list(string), ["all"])
@@ -297,7 +297,7 @@ variable "vpc_peering_accepter_connections" {
   type = map(object({
     peering_connection_id = string
     route_tables          = optional(list(string), ["all"])
-    peer_vpc_cidr         = string
+    peer_vpc_cidr         = list(string)
     tags                  = optional(map(string), {})
   }))
   default = {}

--- a/terraform/aws/modules/composition/vpc-network/outputs.tf
+++ b/terraform/aws/modules/composition/vpc-network/outputs.tf
@@ -320,3 +320,18 @@ output "vpc_endpoint_security_group_id" {
   description = "Security group ID for VPC endpoints"
   value       = try(module.vpc_endpoint_sg[0].sg_id, "")
 }
+
+output "vpc_peering_connection_ids" {
+  description = "Map of VPC peering connection IDs (requester side)"
+  value       = { for k, v in aws_vpc_peering_connection.requester : k => v.id }
+}
+
+output "vpc_peering_connection_accept_status" {
+  description = "Map of VPC peering connection accept statuses"
+  value       = { for k, v in aws_vpc_peering_connection.requester : k => v.accept_status }
+}
+
+output "vpc_peering_accepter_ids" {
+  description = "Map of accepted VPC peering connection IDs (accepter side)"
+  value       = { for k, v in aws_vpc_peering_connection_accepter.accepter : k => v.id }
+}

--- a/terraform/aws/modules/composition/vpc-network/variables.tf
+++ b/terraform/aws/modules/composition/vpc-network/variables.tf
@@ -388,14 +388,14 @@ variable "lambda_subnet_tags" {
 variable "custom_subnet_groups" {
   description = "Map of custom subnet groups with their configurations"
   type = map(object({
-    cidr_block        = string
-    availability_zone = string
-    tier              = string
-    type              = string
+    cidr_block         = string
+    availability_zone  = string
+    tier               = string
+    type               = string
     create_route_table = optional(bool, true)
-    create_igw_route  = optional(bool, false)
-    create_nat_route  = optional(bool, false)
-    tags              = optional(map(string), {})
+    create_igw_route   = optional(bool, false)
+    create_nat_route   = optional(bool, false)
+    tags               = optional(map(string), {})
   }))
   default = {}
 }
@@ -444,6 +444,42 @@ variable "vpc_endpoint_security_group_ids" {
 
 variable "vpc_endpoint_private_dns_enabled" {
   description = "Whether to enable private DNS for VPC endpoints"
+  type        = bool
+  default     = true
+}
+
+###################
+# VPC Peering Configuration
+# Supports: cross-account, cross-region peering
+# For cross-account: accepter must run separate terraform to accept peering request
+###################
+variable "vpc_peering_connections" {
+  description = "Map of VPC peering connection configurations (supports cross-account and cross-region)"
+  type = map(object({
+    peer_vpc_id   = string
+    peer_vpc_cidr = string
+    peer_region   = optional(string)
+    peer_owner_id = optional(string)
+    route_tables  = optional(list(string), ["all"])
+    auto_accept   = optional(bool, false)
+    tags          = optional(map(string), {})
+  }))
+  default = {}
+}
+
+variable "vpc_peering_accepter_connections" {
+  description = "Map of VPC peering connection IDs to accept (for cross-account peering - run in accepter account)"
+  type = map(object({
+    peering_connection_id = string
+    route_tables          = optional(list(string), ["all"])
+    peer_vpc_cidr         = string
+    tags                  = optional(map(string), {})
+  }))
+  default = {}
+}
+
+variable "enable_vpc_peering_routes" {
+  description = "Whether to create routes for VPC peering connections"
   type        = bool
   default     = true
 }

--- a/terraform/aws/modules/composition/vpc-network/variables.tf
+++ b/terraform/aws/modules/composition/vpc-network/variables.tf
@@ -457,7 +457,7 @@ variable "vpc_peering_connections" {
   description = "Map of VPC peering connection configurations (supports cross-account and cross-region)"
   type = map(object({
     peer_vpc_id   = string
-    peer_vpc_cidr = string
+    peer_vpc_cidr = list(string)
     peer_region   = optional(string)
     peer_owner_id = optional(string)
     route_tables  = optional(list(string), ["all"])
@@ -472,7 +472,7 @@ variable "vpc_peering_accepter_connections" {
   type = map(object({
     peering_connection_id = string
     route_tables          = optional(list(string), ["all"])
-    peer_vpc_cidr         = string
+    peer_vpc_cidr         = list(string)
     tags                  = optional(map(string), {})
   }))
   default = {}

--- a/terraform/aws/modules/composition/vpc-network/vpc-peering.tf
+++ b/terraform/aws/modules/composition/vpc-network/vpc-peering.tf
@@ -55,12 +55,14 @@ locals {
           contains(peer_config.route_tables, "eks-workers") ? local.eks_workers_route_table_ids : [],
           [for rt in peer_config.route_tables : rt if !contains(["all", "public", "private-nat", "private-isolated", "database", "eks-workers"], rt)]
         )
-        ) : {
-        key            = "${peer_name}-${rt_id}"
-        peer_cidr      = peer_config.peer_vpc_cidr
-        peering_id     = aws_vpc_peering_connection.requester[peer_name].id
-        route_table_id = rt_id
-      }
+        ) : [
+        for cidr in peer_config.peer_vpc_cidr : {
+          key            = "${peer_name}-${rt_id}-${replace(cidr, "/", "-")}"
+          peer_cidr      = cidr
+          peering_id     = aws_vpc_peering_connection.requester[peer_name].id
+          route_table_id = rt_id
+        }
+      ]
     ]
   ]) : []
 
@@ -76,12 +78,14 @@ locals {
           contains(peer_config.route_tables, "eks-workers") ? local.eks_workers_route_table_ids : [],
           [for rt in peer_config.route_tables : rt if !contains(["all", "public", "private-nat", "private-isolated", "database", "eks-workers"], rt)]
         )
-        ) : {
-        key            = "${peer_name}-${rt_id}"
-        peer_cidr      = peer_config.peer_vpc_cidr
-        peering_id     = peer_config.peering_connection_id
-        route_table_id = rt_id
-      }
+        ) : [
+        for cidr in peer_config.peer_vpc_cidr : {
+          key            = "${peer_name}-${rt_id}-${replace(cidr, "/", "-")}"
+          peer_cidr      = cidr
+          peering_id     = peer_config.peering_connection_id
+          route_table_id = rt_id
+        }
+      ]
     ]
   ]) : []
 }

--- a/terraform/aws/modules/composition/vpc-network/vpc-peering.tf
+++ b/terraform/aws/modules/composition/vpc-network/vpc-peering.tf
@@ -1,0 +1,143 @@
+locals {
+  all_route_table_ids = compact([
+    module.common_internet_rt.route_table_id,
+    module.common_internet_s3_rt.route_table_id,
+    module.common_local_route_rt.route_table_id,
+    module.common_local_s3_rt.route_table_id,
+    module.db_route_table.route_table_id,
+    module.redis_route_table.route_table_id,
+    module.database_route_table.route_table_id,
+    module.locker_server_s3_rt.route_table_id,
+    module.eks_worker_rt.route_table_id,
+    var.enable_nat_gateway ? module.common_local_nat_s3_rt[0].route_table_id : "",
+    var.enable_nat_gateway && length(var.availability_zones) > 0 ? module.proxy_peering_nat_a_rt[0].route_table_id : "",
+    var.enable_nat_gateway && length(var.availability_zones) > 1 ? module.proxy_peering_nat_b_rt[0].route_table_id : "",
+    var.enable_nat_gateway && length(var.availability_zones) > 2 ? module.proxy_peering_nat_c_rt[0].route_table_id : "",
+  ])
+
+  public_route_table_ids = compact([
+    module.common_internet_rt.route_table_id,
+    module.common_internet_s3_rt.route_table_id,
+  ])
+
+  private_nat_route_table_ids = compact([
+    var.enable_nat_gateway ? module.common_local_nat_s3_rt[0].route_table_id : "",
+    var.enable_nat_gateway && length(var.availability_zones) > 0 ? module.proxy_peering_nat_a_rt[0].route_table_id : "",
+    var.enable_nat_gateway && length(var.availability_zones) > 1 ? module.proxy_peering_nat_b_rt[0].route_table_id : "",
+    var.enable_nat_gateway && length(var.availability_zones) > 2 ? module.proxy_peering_nat_c_rt[0].route_table_id : "",
+  ])
+
+  private_isolated_route_table_ids = compact([
+    module.common_local_route_rt.route_table_id,
+    module.common_local_s3_rt.route_table_id,
+  ])
+
+  database_route_table_ids = compact([
+    module.db_route_table.route_table_id,
+    module.redis_route_table.route_table_id,
+    module.database_route_table.route_table_id,
+    module.locker_server_s3_rt.route_table_id,
+  ])
+
+  eks_workers_route_table_ids = compact([
+    module.eks_worker_rt.route_table_id,
+  ])
+
+  peering_route_expanded = var.enable_vpc_peering_routes ? flatten([
+    for peer_name, peer_config in var.vpc_peering_connections : [
+      for rt_id in(
+        contains(peer_config.route_tables, "all") ? local.all_route_table_ids :
+        concat(
+          contains(peer_config.route_tables, "public") ? local.public_route_table_ids : [],
+          contains(peer_config.route_tables, "private-nat") ? local.private_nat_route_table_ids : [],
+          contains(peer_config.route_tables, "private-isolated") ? local.private_isolated_route_table_ids : [],
+          contains(peer_config.route_tables, "database") ? local.database_route_table_ids : [],
+          contains(peer_config.route_tables, "eks-workers") ? local.eks_workers_route_table_ids : [],
+          [for rt in peer_config.route_tables : rt if !contains(["all", "public", "private-nat", "private-isolated", "database", "eks-workers"], rt)]
+        )
+        ) : {
+        key            = "${peer_name}-${rt_id}"
+        peer_cidr      = peer_config.peer_vpc_cidr
+        peering_id     = aws_vpc_peering_connection.requester[peer_name].id
+        route_table_id = rt_id
+      }
+    ]
+  ]) : []
+
+  accepter_peering_route_expanded = var.enable_vpc_peering_routes ? flatten([
+    for peer_name, peer_config in var.vpc_peering_accepter_connections : [
+      for rt_id in(
+        contains(peer_config.route_tables, "all") ? local.all_route_table_ids :
+        concat(
+          contains(peer_config.route_tables, "public") ? local.public_route_table_ids : [],
+          contains(peer_config.route_tables, "private-nat") ? local.private_nat_route_table_ids : [],
+          contains(peer_config.route_tables, "private-isolated") ? local.private_isolated_route_table_ids : [],
+          contains(peer_config.route_tables, "database") ? local.database_route_table_ids : [],
+          contains(peer_config.route_tables, "eks-workers") ? local.eks_workers_route_table_ids : [],
+          [for rt in peer_config.route_tables : rt if !contains(["all", "public", "private-nat", "private-isolated", "database", "eks-workers"], rt)]
+        )
+        ) : {
+        key            = "${peer_name}-${rt_id}"
+        peer_cidr      = peer_config.peer_vpc_cidr
+        peering_id     = peer_config.peering_connection_id
+        route_table_id = rt_id
+      }
+    ]
+  ]) : []
+}
+
+resource "aws_vpc_peering_connection" "requester" {
+  for_each = var.vpc_peering_connections
+
+  vpc_id        = module.vpc.vpc_id
+  peer_vpc_id   = each.value.peer_vpc_id
+  peer_region   = each.value.peer_region
+  peer_owner_id = each.value.peer_owner_id
+
+  auto_accept = each.value.auto_accept && each.value.peer_region == null && each.value.peer_owner_id == null
+
+  tags = merge(
+    var.tags,
+    each.value.tags,
+    {
+      Name = "${var.vpc_name}-peering-${each.key}"
+      Side = "requester"
+    }
+  )
+}
+
+resource "aws_vpc_peering_connection_accepter" "accepter" {
+  for_each = var.vpc_peering_accepter_connections
+
+  vpc_peering_connection_id = each.value.peering_connection_id
+  auto_accept               = true
+
+  tags = merge(
+    var.tags,
+    each.value.tags,
+    {
+      Name = "${var.vpc_name}-peering-accepter-${each.key}"
+      Side = "accepter"
+    }
+  )
+}
+
+resource "aws_route" "peering_routes" {
+  for_each = {
+    for item in local.peering_route_expanded : item.key => item
+  }
+
+  route_table_id            = each.value.route_table_id
+  destination_cidr_block    = each.value.peer_cidr
+  vpc_peering_connection_id = each.value.peering_id
+}
+
+resource "aws_route" "accepter_peering_routes" {
+  for_each = {
+    for item in local.accepter_peering_route_expanded : item.key => item
+  }
+
+  route_table_id            = each.value.route_table_id
+  destination_cidr_block    = each.value.peer_cidr
+  vpc_peering_connection_id = each.value.peering_id
+}


### PR DESCRIPTION
This pull request introduces comprehensive support for VPC peering—including cross-account and cross-region scenarios—across the Terraform VPC network composition module and its live usage in the `dev/eu-central-1` environment. The changes add variables, resources, and outputs to configure, create, accept, and manage VPC peering connections and their associated routes, making peering setup more flexible and automatable.

**VPC Peering Support and Configuration:**

* Added variables to both the composition module (`vpc-network`) and the live environment to support configuration of VPC peering connections (`vpc_peering_connections`), accepter connections (`vpc_peering_accepter_connections`), and a toggle for peering routes (`enable_vpc_peering_routes`). These support cross-account and cross-region scenarios. [[1]](diffhunk://#diff-72582aaabbbc10efda0d98d04d0890f841bb0a5eee095cb8dcfed8e3b1bb5b4dR451-R486) [[2]](diffhunk://#diff-d9c6e38843a34f90f99291f19218f32961963563a2ee4a35b80b2bbbf90a4d1fR281-R311) [[3]](diffhunk://#diff-6373ddb4bf276c3302c49501f82b74d16ca1d080aa383388f3047010bfc252e6R177-R210)
* Updated the live environment's `main.tf` to pass the new peering variables to the `vpc_network` module.

**Resource Creation and Routing Logic:**

* Added a new `vpc-peering.tf` file to the composition module, which:
  * Defines resources for creating VPC peering connections (`aws_vpc_peering_connection`), accepting them (`aws_vpc_peering_connection_accepter`), and managing associated routes (`aws_route`).
  * Implements logic to flexibly select route tables for peering routes based on configuration, supporting both predefined and custom route table groups.

**Outputs for Peering Connections:**

* Added outputs to both the module and live environment to expose IDs and statuses of created and accepted VPC peering connections, enabling downstream modules or users to reference these resources. [[1]](diffhunk://#diff-1ed747c2f4891b5a603df1601204bdf6489d3a7384f70802a30ac5ab94f304e8R323-R337) [[2]](diffhunk://#diff-241a6668a0a2286fa545db468a3822da8fc9188af4c33078483123f25c2fe28cR75-R84)


```
Files Modified/Created
Composition Module (modules/composition/vpc-network/)
1. variables.tf - Added:
   - vpc_peering_connections - Map for requester-side peering configurations
   - vpc_peering_accepter_connections - Map for accepter-side peering (cross-account)
   - enable_vpc_peering_routes - Toggle for route creation
2. vpc-peering.tf (new) - Created:
   - aws_vpc_peering_connection.requester - Creates peering requests
   - aws_vpc_peering_connection_accepter.accepter - Accepts incoming peering
   - aws_route.peering_routes - Routes to peer CIDRs in selected route tables
   - aws_route.accepter_peering_routes - Routes for accepter side
3. outputs.tf - Added:
   - vpc_peering_connection_ids
   - vpc_peering_connection_accept_status
   - vpc_peering_accepter_ids
Live Layer (live/dev/eu-central-1/vpc-network/)
1. variables.tf - Added peering variables
2. main.tf - Wired variables to module
3. outputs.tf - Added peering outputs
4. terraform.tfvars - Added example configuration
Usage Example
Requester side (your VPC):
vpc_peering_connections = {
  peer-to-prod = {
    peer_vpc_id   = "vpc-abc12345"
    peer_vpc_cidr = "10.1.0.0/16"
    peer_region   = "us-east-1"              # Cross-region
    peer_owner_id = "123456789012"           # Cross-account
    route_tables  = ["private-nat", "eks-workers"]  # Selective route tables
  }
}
Accepter side (peer VPC - run in their account):
vpc_peering_accepter_connections = {
  accept-from-dev = {
    peering_connection_id = "pcx-abc12345"
    peer_vpc_cidr         = "10.0.0.0/16"
    route_tables          = ["all"]
  }
}
Route Table Options
- "all" - All route tables
- "public" - External incoming, management subnets
- "private-nat" - Subnets with NAT gateway access
- "private-isolated" - Fully isolated subnets
- "database" - Database, locker, ElastiCache subnets
- "eks-workers" - EKS worker subnets
- Or specific route table IDs
```