### PR TITLE
fix(clickhouse): prevent data volume loss on instance replacement by EBS decoupling + fix shard config

### DIFF
--- a/terraform/aws/modules/composition/clickhouse/locals.tf
+++ b/terraform/aws/modules/composition/clickhouse/locals.tf
@@ -25,8 +25,7 @@ locals {
   # Build server IP list from ENI private IPs
   server_ips = [for i in range(var.server_count) : aws_network_interface.server[i].private_ip]
 
-  # Build shard configuration - one shard with all servers
-  shard_config = [local.server_ips]
+  shard_config = local.server_ips
 
   # Default IAM inline policy (Kafka-like permissions)
   default_inline_policies = {

--- a/terraform/aws/modules/composition/clickhouse/main.tf
+++ b/terraform/aws/modules/composition/clickhouse/main.tf
@@ -303,9 +303,8 @@ resource "aws_instance" "keeper" {
   instance_type = var.keeper_instance_type
   key_name      = local.key_name
 
-  network_interface {
+  primary_network_interface {
     network_interface_id = aws_network_interface.keeper[count.index].id
-    device_index         = 0
   }
 
   iam_instance_profile = aws_iam_instance_profile.clickhouse.name
@@ -530,9 +529,8 @@ resource "aws_instance" "server" {
   instance_type = var.server_instance_type
   key_name      = local.key_name
 
-  network_interface {
+  primary_network_interface {
     network_interface_id = aws_network_interface.server[count.index].id
-    device_index         = 0
   }
 
   iam_instance_profile = aws_iam_instance_profile.clickhouse.name

--- a/terraform/aws/modules/composition/clickhouse/main.tf
+++ b/terraform/aws/modules/composition/clickhouse/main.tf
@@ -319,22 +319,6 @@ resource "aws_instance" "keeper" {
     delete_on_termination = true
   }
 
-  ebs_block_device {
-    device_name           = var.keeper_data_device_name
-    volume_size           = var.keeper_data_volume_size
-    volume_type           = var.keeper_data_volume_type
-    encrypted             = true
-    delete_on_termination = false
-  }
-
-  ebs_block_device {
-    device_name           = var.keeper_data2_device_name
-    volume_size           = var.keeper_data2_volume_size
-    volume_type           = var.keeper_data2_volume_type
-    encrypted             = true
-    delete_on_termination = false
-  }
-
   metadata_options {
     http_endpoint               = "enabled"
     http_tokens                 = var.metadata_http_tokens
@@ -356,6 +340,66 @@ resource "aws_instance" "keeper" {
     aws_security_group_rule.keeper_vpc_endpoint_egress,
     aws_security_group_rule.vpc_endpoint_keeper_ingress
   ]
+}
+
+# =========================================================================
+# STORAGE - EBS VOLUMES (KEEPERS)
+# =========================================================================
+
+resource "aws_ebs_volume" "keeper_data" {
+  count = var.keeper_count
+
+  availability_zone = aws_instance.keeper[count.index].availability_zone
+  size              = var.keeper_data_volume_size
+  type              = var.keeper_data_volume_type
+  encrypted         = true
+
+  tags = merge(local.common_tags, {
+    Name       = "Clickhouse-Keeper-${count.index}-data"
+    cluster    = "clickhouse-keeper"
+    Persistent = "true"
+  })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_ebs_volume" "keeper_data2" {
+  count = var.keeper_count
+
+  availability_zone = aws_instance.keeper[count.index].availability_zone
+  size              = var.keeper_data2_volume_size
+  type              = var.keeper_data2_volume_type
+  encrypted         = true
+
+  tags = merge(local.common_tags, {
+    Name       = "Clickhouse-Keeper-${count.index}-data2"
+    cluster    = "clickhouse-keeper"
+    Persistent = "true"
+  })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_volume_attachment" "keeper_data" {
+  count = var.keeper_count
+
+  device_name  = var.keeper_data_device_name
+  volume_id    = aws_ebs_volume.keeper_data[count.index].id
+  instance_id  = aws_instance.keeper[count.index].id
+  force_detach = true
+}
+
+resource "aws_volume_attachment" "keeper_data2" {
+  count = var.keeper_count
+
+  device_name  = var.keeper_data2_device_name
+  volume_id    = aws_ebs_volume.keeper_data2[count.index].id
+  instance_id  = aws_instance.keeper[count.index].id
+  force_detach = true
 }
 
 # =========================================================================
@@ -502,22 +546,6 @@ resource "aws_instance" "server" {
     delete_on_termination = true
   }
 
-  ebs_block_device {
-    device_name           = var.server_data_device_name
-    volume_size           = var.server_data_volume_size
-    volume_type           = var.server_data_volume_type
-    encrypted             = true
-    delete_on_termination = false
-  }
-
-  ebs_block_device {
-    device_name           = var.server_data2_device_name
-    volume_size           = var.server_data2_volume_size
-    volume_type           = var.server_data2_volume_type
-    encrypted             = true
-    delete_on_termination = false
-  }
-
   metadata_options {
     http_endpoint               = "enabled"
     http_tokens                 = var.metadata_http_tokens
@@ -540,6 +568,66 @@ resource "aws_instance" "server" {
     aws_security_group_rule.vpc_endpoint_server_ingress,
     time_sleep.wait_for_keeper
   ]
+}
+
+# =========================================================================
+# STORAGE - EBS VOLUMES (SERVERS)
+# =========================================================================
+
+resource "aws_ebs_volume" "server_data" {
+  count = var.server_count
+
+  availability_zone = aws_instance.server[count.index].availability_zone
+  size              = var.server_data_volume_size
+  type              = var.server_data_volume_type
+  encrypted         = true
+
+  tags = merge(local.common_tags, {
+    Name       = "Clickhouse-Server-${count.index}-data"
+    cluster    = "clickhouse-server"
+    Persistent = "true"
+  })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_ebs_volume" "server_data2" {
+  count = var.server_count
+
+  availability_zone = aws_instance.server[count.index].availability_zone
+  size              = var.server_data2_volume_size
+  type              = var.server_data2_volume_type
+  encrypted         = true
+
+  tags = merge(local.common_tags, {
+    Name       = "Clickhouse-Server-${count.index}-data2"
+    cluster    = "clickhouse-server"
+    Persistent = "true"
+  })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_volume_attachment" "server_data" {
+  count = var.server_count
+
+  device_name  = var.server_data_device_name
+  volume_id    = aws_ebs_volume.server_data[count.index].id
+  instance_id  = aws_instance.server[count.index].id
+  force_detach = true
+}
+
+resource "aws_volume_attachment" "server_data2" {
+  count = var.server_count
+
+  device_name  = var.server_data2_device_name
+  volume_id    = aws_ebs_volume.server_data2[count.index].id
+  instance_id  = aws_instance.server[count.index].id
+  force_detach = true
 }
 
 # =========================================================================


### PR DESCRIPTION
This removes the extra array wrapping that caused the userdata JSON to have 3-level nesting (shard: [ [["ip"]] ]) instead of the 2-level nesting the AMI parser expects (shard: [ ["ip"] ]). After this fix, a terragrunt apply will produce correct userdata JSON, the AMI will parse it successfully, and config.d/ files (including network_conf.xml with the listen_host override) will be generated on boot.