### PR TITLE
fix: add lambda subnets to custom NACL association

### DIFF
--- a/terraform/aws/modules/composition/vpc-network/network-acls.tf
+++ b/terraform/aws/modules/composition/vpc-network/network-acls.tf
@@ -7,8 +7,8 @@ module "main_nacl" {
   source = "../../base/network-acl"
   count  = var.create_nacl ? 1 : 0
 
-  vpc_id     = module.vpc.vpc_id
-  nacl_name  = "${var.vpc_name}-nacl"
+  vpc_id    = module.vpc.vpc_id
+  nacl_name = "${var.vpc_name}-nacl"
   subnet_ids = concat(
     module.external_incoming_subnets[*].subnet_id,
     module.management_subnets[*].subnet_id,
@@ -17,6 +17,7 @@ module "main_nacl" {
     module.incoming_envoy_subnets[*].subnet_id,
     module.outgoing_proxy_subnets[*].subnet_id,
     module.utils_subnets[*].subnet_id,
+    module.lambda_subnets[*].subnet_id,
     module.locker_server_subnets[*].subnet_id,
     module.data_stack_subnets[*].subnet_id,
     module.database_subnets[*].subnet_id,


### PR DESCRIPTION
PR Description:
## Problem
Lambda subnets were not included in the `main_nacl` module's `subnet_ids`
in `network-acls.tf`. All other subnet types (external_incoming,
management, eks_workers, eks_control_plane, incoming_envoy,
outgoing_proxy, utils, locker_server, data_stack, database,
locker_database, elasticache) are listed, but `lambda_subnets` was
missed.
Since the VPC module sets `manage_default_network_acl = true` with no
rules (deny-all by default), any subnet not associated with the custom
NACL falls back to the default NACL which blocks all traffic.
## Impact
Lambda subnets end up with a deny-all NACL, which blocks all cross-subnet
traffic. This prevents:
- RDS Proxy ENIs in lambda subnets from connecting to Aurora (target
  health shows UNREACHABLE / "Timeout connecting to the database")
- Lambda functions from reaching any resource in other subnets (RDS,
  VPC endpoints, etc.) via cross-subnet routing
## Fix
Add `module.lambda_subnets[*].subnet_id` to the `subnet_ids` list in
the `main_nacl` module, matching the pattern used by all other subnet
types.
