### PR TITLE
feat(s3): add S3 bucket configuration and outputs for decision engine

### DIFF
--- a/terraform/aws/modules/application-resources/decision-engine/locals.tf
+++ b/terraform/aws/modules/application-resources/decision-engine/locals.tf
@@ -43,4 +43,7 @@ locals {
 
   # Inline policies feature
   inline_policies_enabled = length(var.inline_policies) > 0
+
+  # S3 bucket feature
+  s3_bucket_create = try(var.s3_bucket.enabled, false)
 }

--- a/terraform/aws/modules/application-resources/decision-engine/outputs.tf
+++ b/terraform/aws/modules/application-resources/decision-engine/outputs.tf
@@ -56,3 +56,31 @@ output "inline_policies_enabled" {
   description = "Whether inline policies feature is enabled"
   value       = local.inline_policies_enabled
 }
+
+# =========================================================================
+# S3 BUCKET OUTPUTS
+# =========================================================================
+output "s3_bucket_id" {
+  description = "The ID (name) of the S3 bucket"
+  value       = local.s3_bucket_create && length(module.s3_bucket) > 0 ? module.s3_bucket[0].s3_bucket_id : null
+}
+
+output "s3_bucket_name" {
+  description = "The name of the S3 bucket"
+  value       = local.s3_bucket_create && length(module.s3_bucket) > 0 ? module.s3_bucket[0].s3_bucket_id : null
+}
+
+output "s3_bucket_arn" {
+  description = "The ARN of the S3 bucket"
+  value       = local.s3_bucket_create && length(module.s3_bucket) > 0 ? module.s3_bucket[0].s3_bucket_arn : null
+}
+
+output "s3_bucket_domain_name" {
+  description = "The domain name of the S3 bucket"
+  value       = local.s3_bucket_create && length(module.s3_bucket) > 0 ? module.s3_bucket[0].s3_bucket_bucket_domain_name : null
+}
+
+output "s3_bucket_regional_domain_name" {
+  description = "The regional domain name of the S3 bucket"
+  value       = local.s3_bucket_create && length(module.s3_bucket) > 0 ? module.s3_bucket[0].s3_bucket_bucket_regional_domain_name : null
+}

--- a/terraform/aws/modules/application-resources/decision-engine/s3.tf
+++ b/terraform/aws/modules/application-resources/decision-engine/s3.tf
@@ -1,0 +1,67 @@
+# =========================================================================
+# S3 BUCKET - Decision Engine Storage
+# =========================================================================
+
+locals {
+  s3_bucket_name = try(var.s3_bucket.bucket_name, null) != null ? var.s3_bucket.bucket_name : "${local.name_prefix}-storage"
+}
+
+module "s3_bucket" {
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "~> 5.0"
+
+  count = local.s3_bucket_create ? 1 : 0
+
+  bucket        = local.s3_bucket_name
+  force_destroy = try(var.s3_bucket.force_destroy, false)
+
+  # Versioning
+  versioning = {
+    enabled = try(var.s3_bucket.versioning_enabled, true)
+  }
+
+  # Security best practices - Block all public access
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  # Server-side encryption with S3-managed keys
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "AES256"
+      }
+      bucket_key_enabled = true
+    }
+  }
+
+  # Lifecycle rules
+  lifecycle_rule = try(length(var.s3_bucket.lifecycle_rules) > 0, false) ? [
+    for rule in var.s3_bucket.lifecycle_rules : {
+      id     = rule.id
+      status = rule.enabled ? "Enabled" : "Disabled"
+
+      filter = {
+        prefix = try(rule.prefix, "")
+      }
+
+      expiration = rule.expiration_days != null ? {
+        days = rule.expiration_days
+      } : {}
+
+      noncurrent_version_expiration = rule.noncurrent_version_expiration != null ? {
+        noncurrent_days = rule.noncurrent_version_expiration
+      } : {}
+
+      transition = [
+        for t in try(rule.transition, []) : {
+          days          = t.days
+          storage_class = t.storage_class
+        }
+      ]
+    }
+  ] : []
+
+  tags = local.common_tags
+}

--- a/terraform/aws/modules/application-resources/decision-engine/variables.tf
+++ b/terraform/aws/modules/application-resources/decision-engine/variables.tf
@@ -114,3 +114,29 @@ variable "inline_policies" {
   type        = map(string)
   default     = {}
 }
+
+# =========================================================================
+# S3 Bucket Configuration
+# =========================================================================
+
+variable "s3_bucket" {
+  description = "Configuration for the Decision Engine S3 bucket"
+  type = object({
+    enabled                       = optional(bool, true)
+    bucket_name                   = optional(string, null)
+    force_destroy                 = optional(bool, false)
+    versioning_enabled            = optional(bool, true)
+    lifecycle_rules               = optional(list(object({
+      id                            = string
+      enabled                       = bool
+      prefix                        = optional(string, "")
+      expiration_days               = optional(number, null)
+      noncurrent_version_expiration = optional(number, null)
+      transition                    = optional(list(object({
+        days          = number
+        storage_class = string
+      })), [])
+    })), [])
+  })
+  default = {}
+}


### PR DESCRIPTION
This pull request introduces support for configuring an S3 bucket as part of the `decision-engine` Terraform module. It adds a new variable for S3 bucket configuration, implements the S3 bucket resource using a community module, and exposes key outputs for use by other modules or environments. These changes enable teams to optionally provision and manage an S3 bucket with best practices and lifecycle management.

**S3 Bucket Feature Implementation:**

* Added a new `s3_bucket` variable to allow configuration of an S3 bucket, including options for name, versioning, force destroy, and lifecycle rules. (`terraform/aws/modules/application-resources/decision-engine/variables.tf`)
* Introduced logic in `locals.tf` to determine if the S3 bucket should be created based on the new variable. (`terraform/aws/modules/application-resources/decision-engine/locals.tf`)
* Added a new `s3.tf` file that provisions the S3 bucket using the `terraform-aws-modules/s3-bucket/aws` module, applying security best practices and supporting lifecycle rules. (`terraform/aws/modules/application-resources/decision-engine/s3.tf`)

**Outputs for S3 Bucket:**

* Exposed new outputs for the S3 bucket’s ID, name, ARN, domain name, and regional domain name, making them available for use by other modules or outputs. (`terraform/aws/modules/application-resources/decision-engine/outputs.tf`)