### PR TITLE
feat: Add EKS and EKS Auth VPC interface endpoints to vpc-network module

### DIFF
--- a/terraform/aws/live/dev/eu-central-1/vpc-network/main.tf
+++ b/terraform/aws/live/dev/eu-central-1/vpc-network/main.tf
@@ -90,7 +90,9 @@ module "vpc_network" {
     "ssmmessages",
     "sts",
     "ec2messages",
-    "kms"
+    "kms",
+    "eks",
+    "eks_auth"
   ] : []
 
   create_vpc_endpoint_security_group = true

--- a/terraform/aws/modules/composition/vpc-network/vpc-endpoints.tf
+++ b/terraform/aws/modules/composition/vpc-network/vpc-endpoints.tf
@@ -113,6 +113,14 @@ locals {
       service_name = "com.amazonaws.${var.region}.sts"
       type         = "Interface"
     }
+    eks = {
+      service_name = "com.amazonaws.${var.region}.eks"
+      type         = "Interface"
+    }
+    eks_auth = {
+      service_name = "com.amazonaws.${var.region}.eks-auth"
+      type         = "Interface"
+    }
     autoscaling = {
       service_name = "com.amazonaws.${var.region}.autoscaling"
       type         = "Interface"
@@ -175,7 +183,7 @@ module "interface_vpc_endpoints" {
   service_name      = each.value.service_name
   vpc_endpoint_type = each.value.type
 
-  subnet_ids         = module.eks_workers_subnets[*].subnet_id
+  subnet_ids = module.eks_workers_subnets[*].subnet_id
   security_group_ids = compact(concat(
     var.create_vpc_endpoint_security_group ? [module.vpc_endpoint_sg[0].sg_id] : [],
     var.vpc_endpoint_security_group_ids


### PR DESCRIPTION
Summary
- Add eks (com.amazonaws.{region}.eks) and eks_auth (com.amazonaws.{region}.eks-auth) interface endpoints to the vpc-network composition module's endpoint catalogue
- Enable both endpoints in the dev eu-central-1 live deployment
Why
EKS API calls from within the VPC (aws eks describe-cluster, SDK calls, etc.) currently traverse the NAT gateway. The eks VPC endpoint keeps this traffic on the AWS private network, reducing NAT data processing costs and eliminating internet exposure for EKS management plane traffic — relevant for PCI DSS compliance.
The eks_auth endpoint is required for EKS Pod Identity (AssumeRoleForPodIdentity) in private clusters. While the current setup uses IRSA (already served by the existing sts endpoint), adding eks_auth now enables a future migration to Pod Identity without additional infrastructure changes.
Changes
- modules/composition/vpc-network/vpc-endpoints.tf — Added eks and eks_auth entries to the interface_endpoints local map
- live/dev/eu-central-1/vpc-network/main.tf — Added "eks" and "eks_auth" to the interface_vpc_endpoints list
Notes
- The eks VPC endpoint serves the EKS management API only — it does not provide Kubernetes API server access (kubectl), which is handled by the cluster's own private endpoint (cluster_endpoint_private_access = true)
- No changes to the EKS composition module are required — cluster_endpoint_private_access and the VPC endpoint are independent
- Existing VPC endpoint security group (HTTPS/443 from VPC CIDR) covers both new endpoints