### PR TITLE
feat(envoy-proxy): add ALB access logging support with S3 bucket policy

### DIFF
--- a/terraform/aws/modules/composition/envoy-proxy/data.tf
+++ b/terraform/aws/modules/composition/envoy-proxy/data.tf
@@ -6,6 +6,8 @@ data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
 
+data "aws_elb_service_account" "current" {}
+
 # =========================================================================
 # Blue-Green Deployment Data Sources
 # =========================================================================

--- a/terraform/aws/modules/composition/envoy-proxy/locals.tf
+++ b/terraform/aws/modules/composition/envoy-proxy/locals.tf
@@ -1,4 +1,8 @@
 locals {
+  # ALB access logs configuration
+  alb_access_logs_enabled = var.create_lb && var.enable_alb_access_logs
+  alb_access_logs_prefix  = var.alb_access_logs_prefix != null ? var.alb_access_logs_prefix : "AWSLogs/${data.aws_caller_identity.current.account_id}"
+
   # Naming convention
   name_prefix = "${var.environment}-${var.project_name}-envoy"
 

--- a/terraform/aws/modules/composition/envoy-proxy/main.tf
+++ b/terraform/aws/modules/composition/envoy-proxy/main.tf
@@ -71,9 +71,40 @@ module "logs_bucket" {
     }
   }
 
-  # Note: Lifecycle rules removed - manage log retention manually if needed
+  # Allow ELB service to deliver access logs to this bucket
+  attach_elb_log_delivery_policy = local.alb_access_logs_enabled
 
   tags = local.common_tags
+}
+
+resource "aws_s3_bucket_policy" "alb_access_logs_existing_bucket" {
+  count = !var.create_logs_bucket && local.alb_access_logs_enabled ? 1 : 0
+
+  bucket = var.logs_bucket_name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowALBWrite"
+        Effect    = "Allow"
+        Principal = {
+          AWS = data.aws_elb_service_account.current.arn
+        }
+        Action   = "s3:PutObject"
+        Resource = "arn:aws:s3:::${var.logs_bucket_name}/${local.alb_access_logs_prefix}/*"
+      },
+      {
+        Sid       = "AllowALBReadACL"
+        Effect    = "Allow"
+        Principal = {
+          Service = "elasticloadbalancing.amazonaws.com"
+        }
+        Action   = "s3:GetBucketAcl"
+        Resource = "arn:aws:s3:::${var.logs_bucket_name}"
+      }
+    ]
+  })
 }
 
 # =========================================================================
@@ -347,6 +378,13 @@ module "alb" {
   enable_deletion_protection       = var.environment == "prod" ? true : false
   enable_cross_zone_load_balancing = true
   enable_http2                     = true
+
+
+  access_logs = local.alb_access_logs_enabled ? {
+    enabled = true
+    bucket  = local.logs_bucket_name
+    prefix  = local.alb_access_logs_prefix
+  } : {}
 
   # We'll create target groups and listeners separately for more control
   create_security_group = false

--- a/terraform/aws/modules/composition/envoy-proxy/outputs.tf
+++ b/terraform/aws/modules/composition/envoy-proxy/outputs.tf
@@ -136,3 +136,18 @@ output "config_version" {
   description = "Current configuration version hash"
   value       = substr(md5(local.envoy_config_content), 0, 8)
 }
+
+output "alb_access_logs_enabled" {
+  description = "Whether ALB access logs are enabled (true only if create_lb = true and enable_alb_access_logs = true)"
+  value       = local.alb_access_logs_enabled
+}
+
+output "alb_access_logs_bucket" {
+  description = "S3 bucket name where ALB access logs are delivered (null if access logs disabled)"
+  value       = local.alb_access_logs_enabled ? local.logs_bucket_name : null
+}
+
+output "alb_access_logs_prefix" {
+  description = "S3 key prefix for ALB access logs (null if access logs disabled)"
+  value       = local.alb_access_logs_enabled ? local.alb_access_logs_prefix : null
+}

--- a/terraform/aws/modules/composition/envoy-proxy/variables.tf
+++ b/terraform/aws/modules/composition/envoy-proxy/variables.tf
@@ -712,6 +712,22 @@ variable "scaling_policies" {
   }
 }
 
+# =========================================================================
+# ALB Access Logs Configuration
+# =========================================================================
+
+variable "enable_alb_access_logs" {
+  description = "Enable ALB access logs and push them to the S3 logs bucket. Requires create_lb = true and create_logs_bucket = true (or an existing logs bucket with the appropriate policy). If create_lb = false, this setting has no effect."
+  type        = bool
+  default     = true
+}
+
+variable "alb_access_logs_prefix" {
+  description = "S3 key prefix for ALB access logs. Defaults to the AWS standard prefix pattern 'AWSLogs/{account_id}'"
+  type        = string
+  default     = null
+}
+
 variable "tags" {
   description = "Common tags to apply to all resources"
   type        = map(string)


### PR DESCRIPTION
Enable ALB access logs to be pushed to the envoy logs S3 bucket with proper ELB service permissions. Uses the S3 bucket module built-in attach_elb_log_delivery_policy for created buckets and data.aws_elb_service_account for existing buckets, avoiding stale hardcoded ELB account IDs.

- Add enable_alb_access_logs variable (default true, no-op if create_lb=false)
- Add alb_access_logs_prefix variable for custom S3 key prefix
- Add data.aws_elb_service_account for dynamic ELB account resolution
- Add access_logs block to ALB module conditionally
- Add S3 bucket policy for existing bucket scenario
- Add outputs: alb_access_logs_enabled, alb_access_logs_bucket, alb_access_logs_prefix