### PR TITLE
chore(terraform-custom-SC-support): add custom storage class support (EFS) in the eks-kubernetes-resources terraform module

### DIFF
--- a/terraform/aws/modules/composition/eks-kubernetes-resources/main.tf
+++ b/terraform/aws/modules/composition/eks-kubernetes-resources/main.tf
@@ -280,6 +280,26 @@ resource "kubernetes_storage_class_v1" "ebs_gp3" {
   depends_on = [terraform_data.cluster_ready]
 }
 
+# -----------------------------------------------------------------------------
+# Custom Storage Classes (e.g. EFS)
+# -----------------------------------------------------------------------------
+resource "kubernetes_storage_class_v1" "custom" {
+  for_each = var.custom_storage_classes
+
+  metadata {
+    name        = each.key
+    annotations = each.value.annotations
+  }
+
+  storage_provisioner    = each.value.storage_provisioner
+  volume_binding_mode    = each.value.volume_binding_mode
+  reclaim_policy         = each.value.reclaim_policy
+  allow_volume_expansion = each.value.allow_volume_expansion
+  parameters             = each.value.parameters
+
+  depends_on = [terraform_data.cluster_ready]
+}
+
 # =============================================================================
 # Cluster Autoscaler ECR Resources (Optional)
 # =============================================================================

--- a/terraform/aws/modules/composition/eks-kubernetes-resources/outputs.tf
+++ b/terraform/aws/modules/composition/eks-kubernetes-resources/outputs.tf
@@ -23,6 +23,11 @@ output "default_storage_class_name" {
   value       = var.create_default_storage_class ? var.default_storage_class_name : null
 }
 
+output "custom_storage_class_names" {
+  description = "Names of the custom storage classes created"
+  value       = keys(var.custom_storage_classes)
+}
+
 # -----------------------------------------------------------------------------
 # Cluster Autoscaler Outputs
 # -----------------------------------------------------------------------------

--- a/terraform/aws/modules/composition/eks-kubernetes-resources/variables.tf
+++ b/terraform/aws/modules/composition/eks-kubernetes-resources/variables.tf
@@ -88,9 +88,18 @@ variable "default_storage_class_name" {
   default     = "ebs-gp3"
 }
 
-# -----------------------------------------------------------------------------
-# Cluster Autoscaler Configuration
-# -----------------------------------------------------------------------------
+variable "custom_storage_classes" {
+  description = "Map of additional custom storage classes to create"
+  type = map(object({
+    storage_provisioner    = string
+    volume_binding_mode    = optional(string, "Immediate")
+    reclaim_policy         = optional(string, "Retain")
+    allow_volume_expansion = optional(bool, false)
+    parameters             = optional(map(string), {})
+    annotations            = optional(map(string), {})
+  }))
+  default = {}
+}
 variable "enable_cluster_autoscaler" {
   description = "Whether to deploy Cluster Autoscaler Kubernetes resources"
   type        = bool


### PR DESCRIPTION
The module only supports the single EBS storage class. 
Need to add a custom_storage_classes variable and resource to the module.
