### PR TITLE
chore: add support for additional inline policy to hyperswitch-app

### DIFF
--- a/terraform/aws/modules/application-resources/hyperswitch/locals.tf
+++ b/terraform/aws/modules/application-resources/hyperswitch/locals.tf
@@ -47,6 +47,9 @@ locals {
   lambda_enabled      = var.lambda != {} && try(var.lambda.enabled, false)
   lambda_function_arns = local.lambda_enabled ? try(var.lambda.function_arns, []) : []
 
+  # Additional IAM Policies feature
+  additional_iam_policies_enabled = length(var.additional_iam_policies) > 0
+
   # =========================================================================
   # OIDC Configuration
   # =========================================================================

--- a/terraform/aws/modules/application-resources/hyperswitch/main.tf
+++ b/terraform/aws/modules/application-resources/hyperswitch/main.tf
@@ -329,3 +329,22 @@ resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
   role       = aws_iam_role.iam_role.name
   policy_arn = aws_iam_policy.lambda_policy[0].arn
 }
+
+# =========================================================================
+# IAM - ADDITIONAL POLICIES
+# =========================================================================
+resource "aws_iam_policy" "additional" {
+  for_each = var.additional_iam_policies
+
+  name   = "${local.name_prefix}-${each.key}"
+  policy = each.value.policy
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "additional" {
+  for_each = var.additional_iam_policies
+
+  role       = aws_iam_role.iam_role.name
+  policy_arn = aws_iam_policy.additional[each.key].arn
+}

--- a/terraform/aws/modules/application-resources/hyperswitch/outputs.tf
+++ b/terraform/aws/modules/application-resources/hyperswitch/outputs.tf
@@ -159,3 +159,11 @@ output "lambda_function_arns" {
   description = "List of Lambda function ARNs configured for access"
   value       = local.lambda_function_arns
 }
+
+# =========================================================================
+# ADDITIONAL IAM POLICIES OUTPUTS
+# =========================================================================
+output "additional_iam_policies_arns" {
+  description = "Map of additional IAM policy ARNs (key = policy name suffix, value = ARN)"
+  value       = { for k, v in aws_iam_policy.additional : k => v.arn }
+}

--- a/terraform/aws/modules/application-resources/hyperswitch/variables.tf
+++ b/terraform/aws/modules/application-resources/hyperswitch/variables.tf
@@ -190,3 +190,18 @@ variable "assume_role" {
   })
   default = {}
 }
+
+# =========================================================================
+# Feature: Additional IAM Policies
+# =========================================================================
+# Map of additional IAM policies to create and attach to the IAM role.
+# Each entry creates an aws_iam_policy and attaches it to the role.
+# Use this for cross-region or cross-account access not covered by built-in features.
+
+variable "additional_iam_policies" {
+  description = "Map of additional IAM policies to create and attach to the IAM role. Each key is used as a policy name suffix. Value is an object with a `policy` field containing the IAM policy document as JSON string."
+  type = map(object({
+    policy = string # IAM policy document as JSON string
+  }))
+  default = {}
+}


### PR DESCRIPTION
This pull request introduces support for attaching additional custom IAM policies to the Hyperswitch module's IAM role. Users can now specify a map of extra IAM policies to be created and attached, which is useful for scenarios like cross-region or cross-account access. The changes include new variables, resources, and outputs to manage and expose these additional policies.

**Additional IAM Policies Feature:**

* Added a new variable `additional_iam_policies` in `variables.tf` to allow users to define extra IAM policies as a map, where each entry specifies the policy document and is attached to the IAM role.
* Updated `locals.tf` to include a flag `additional_iam_policies_enabled` that checks if any additional IAM policies are defined.
* Added resource blocks in `main.tf` to create and attach each additional IAM policy to the IAM role, iterating over the user-supplied map.

**Outputs:**

* Added a new output `additional_iam_policies_arns` in `outputs.tf` to export the ARNs of all additional IAM policies created.