### PR TITLE
feat(decision-engine): add SES IAM policy with role assumption support

### DIFF
--- a/terraform/aws/modules/application-resources/decision-engine/locals.tf
+++ b/terraform/aws/modules/application-resources/decision-engine/locals.tf
@@ -46,4 +46,8 @@ locals {
 
   # S3 bucket feature
   s3_bucket_create = try(var.s3_bucket.enabled, false)
+
+  # SES feature
+  ses_enabled  = try(var.ses.enabled, false)
+  ses_role_arn = local.ses_enabled ? try(var.ses.role_arn, null) : null
 }

--- a/terraform/aws/modules/application-resources/decision-engine/main.tf
+++ b/terraform/aws/modules/application-resources/decision-engine/main.tf
@@ -75,3 +75,61 @@ resource "aws_iam_role_policy" "inline" {
   role   = aws_iam_role.this.name
   policy = each.value
 }
+
+# =========================================================================
+# IAM - SES POLICY
+# =========================================================================
+resource "aws_iam_policy" "ses_policy" {
+  count = local.ses_enabled ? 1 : 0
+
+  name = "${local.name_prefix}-ses-policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat(
+      # SES role assumption
+      local.ses_role_arn != null ? [
+        {
+          Sid    = "AllowSESRoleAssume"
+          Effect = "Allow"
+          Action = [
+            "sts:AssumeRole"
+          ]
+          Resource = local.ses_role_arn
+        },
+        {
+          Sid    = "AllowSESTokenOperations"
+          Effect = "Allow"
+          Action = [
+            "sts:GetSessionToken",
+            "sts:GetServiceBearerToken"
+          ]
+          Resource = local.ses_role_arn
+        }
+      ] : [],
+      # SES API operations
+      [
+        {
+          Sid    = "AllowSESOperations"
+          Effect = "Allow"
+          Action = [
+            "ses:ListTemplates",
+            "ses:SendEmail",
+            "ses:SendTemplatedEmail",
+            "ses:SendRawEmail",
+            "ses:ListVerifiedEmailAddresses"
+          ]
+          Resource = "*"
+        }
+      ]
+    )
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "ses_policy_attachment" {
+  count = local.ses_enabled ? 1 : 0
+
+  role       = aws_iam_role.this.name
+  policy_arn = aws_iam_policy.ses_policy[0].arn
+}

--- a/terraform/aws/modules/application-resources/decision-engine/variables.tf
+++ b/terraform/aws/modules/application-resources/decision-engine/variables.tf
@@ -140,3 +140,16 @@ variable "s3_bucket" {
   })
   default = {}
 }
+
+# =========================================================================
+# Feature: SES (Simple Email Service)
+# =========================================================================
+
+variable "ses" {
+  description = "SES configuration. Set to {} to disable SES policy. Only accepts existing SES role ARN (does NOT create SES resources)."
+  type = object({
+    enabled  = optional(bool, false)  # Set true to enable SES policy
+    role_arn = optional(string, null) # Existing SES role ARN to assume
+  })
+  default = {}
+}


### PR DESCRIPTION
This pull request introduces support for integrating AWS Simple Email Service (SES) into the `decision-engine` Terraform module. The changes add new configuration options for enabling SES-related IAM policies and associating an existing SES role ARN. The implementation ensures that SES permissions are only created and attached when explicitly enabled.

**SES Feature Integration:**

* Added a new `ses` variable in `variables.tf` to allow configuration of SES integration, including an `enabled` flag and an optional `role_arn` for an existing SES role.
* Updated `locals.tf` to compute local variables `ses_enabled` and `ses_role_arn` based on the new `ses` variable.

**IAM Policy and Role Attachments:**

* Added a conditional `aws_iam_policy` resource (`ses_policy`) in `main.tf` that grants permissions for SES operations and, if provided, to assume the specified SES role.
* Attached the SES policy to the module's IAM role only when SES integration is enabled.