### PR TITLE
fix(loki): replace unsupported s3-bucket module event_notification with aws_s3_bucket_notification resource

### DIFF
--- a/terraform/aws/modules/application-resources/loki/README.md
+++ b/terraform/aws/modules/application-resources/loki/README.md
@@ -27,6 +27,7 @@
 | [aws_iam_role_policy_attachment.aws_managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.customer_managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.s3_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_s3_bucket_notification.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.eks_ingress_from_loki](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |

--- a/terraform/aws/modules/application-resources/loki/main.tf
+++ b/terraform/aws/modules/application-resources/loki/main.tf
@@ -134,11 +134,31 @@ module "s3_bucket" {
 
   lifecycle_rule = try(var.s3.lifecycle_rules, [])
 
-  event_notification = try(var.s3.event_notifications, [])
-
   tags = local.common_tags
 
   force_destroy = try(var.s3.force_destroy, false)
+}
+
+# =========================================================================
+# S3 BUCKET NOTIFICATIONS
+# =========================================================================
+resource "aws_s3_bucket_notification" "this" {
+  count = local.s3_create && length(try(var.s3.event_notifications, [])) > 0 ? 1 : 0
+
+  bucket = module.s3_bucket[0].s3_bucket_id
+
+  dynamic "queue" {
+    for_each = try(var.s3.event_notifications, [])
+    content {
+      id            = queue.value.id
+      queue_arn     = queue.value.queue_arn
+      events        = queue.value.events
+      filter_prefix = try(queue.value.filter_prefix, null)
+      filter_suffix = try(queue.value.filter_suffix, null)
+    }
+  }
+
+  depends_on = [module.s3_bucket]
 }
 
 # =========================================================================


### PR DESCRIPTION
This pull request updates how S3 bucket event notifications are managed in the `loki` Terraform module. Instead of passing event notifications directly to the `s3_bucket` module, a new dedicated `aws_s3_bucket_notification` resource is introduced to handle S3 event notifications more flexibly and explicitly.

**S3 Event Notification Handling:**

* Added a new `aws_s3_bucket_notification` resource to manage event notifications separately from the main S3 bucket resource, allowing for more granular configuration and improved maintainability.
* The new resource dynamically creates notifications for each entry in `var.s3.event_notifications`, supporting queue targets and optional filters.
* Removed the direct passing of `event_notification` to the `s3_bucket` module, centralizing notification logic in the new resource.