### PR TITLE
fix: disable EC2 detailed monitoring on Kafka, ClickHouse, Cassandra,…

### DIFF
--- a/terraform/aws/modules/composition/cassandra/main.tf
+++ b/terraform/aws/modules/composition/cassandra/main.tf
@@ -305,7 +305,7 @@ resource "aws_instance" "cassandra" {
 
   iam_instance_profile = aws_iam_instance_profile.cassandra.name
   user_data            = base64encode(local.user_data_config)
-  monitoring           = true
+  monitoring           = false
 
   # Additional EBS volume for Cassandra data
   ebs_block_device {

--- a/terraform/aws/modules/composition/clickhouse/main.tf
+++ b/terraform/aws/modules/composition/clickhouse/main.tf
@@ -309,7 +309,7 @@ resource "aws_instance" "keeper" {
 
   iam_instance_profile = aws_iam_instance_profile.clickhouse.name
   user_data_base64     = base64encode(local.keeper_user_data)
-  monitoring           = true
+  monitoring           = false
 
   root_block_device {
     volume_size           = var.keeper_root_volume_size
@@ -497,7 +497,7 @@ resource "aws_instance" "server" {
 
   iam_instance_profile = aws_iam_instance_profile.clickhouse.name
   user_data_base64     = base64encode(local.server_user_data)
-  monitoring           = true
+  monitoring           = false
 
   root_block_device {
     volume_size           = var.server_root_volume_size

--- a/terraform/aws/modules/composition/jump-host/main.tf
+++ b/terraform/aws/modules/composition/jump-host/main.tf
@@ -264,7 +264,7 @@ module "jump_instance" {
   create_security_group = false
 
   associate_public_ip_address = false
-  monitoring                  = true
+  monitoring                  = false
   user_data_base64 = base64encode(templatefile("${path.module}/templates/userdata.sh", {
     environment       = var.environment
     cloudwatch_region = data.aws_region.current.id

--- a/terraform/aws/modules/composition/kafka/main.tf
+++ b/terraform/aws/modules/composition/kafka/main.tf
@@ -323,7 +323,7 @@ resource "aws_instance" "broker" {
 
   iam_instance_profile = aws_iam_instance_profile.kafka.name
   user_data_base64     = base64encode(local.broker_user_data)
-  monitoring           = true
+  monitoring           = false
 
   root_block_device {
     volume_size           = var.broker_root_volume_size
@@ -380,7 +380,7 @@ resource "aws_instance" "controller" {
 
   iam_instance_profile = aws_iam_instance_profile.kafka.name
   user_data_base64     = base64encode(local.controller_user_data)
-  monitoring           = true
+  monitoring           = false
 
   root_block_device {
     volume_size           = var.controller_root_volume_size

--- a/terraform/aws/modules/composition/locker/main.tf
+++ b/terraform/aws/modules/composition/locker/main.tf
@@ -279,7 +279,7 @@ module "locker_instance" {
   ami                         = var.ami_id
   instance_type               = var.instance_type
   key_name                    = local.key_name
-  monitoring                  = true
+  monitoring                  = false
   user_data                   = var.user_data
   subnet_id                   = local.locker_subnet_ids[count.index % length(local.locker_subnet_ids)]
   vpc_security_group_ids      = [local.locker_security_group_id]


### PR DESCRIPTION
Addresses findings from the InfraScan cost analysis report:
https://infrascan.soldevelo.com/report/hyperswitch-suite-254c5531-0923-48c0-9252-1780283139df

**Changes:**
- **EC2 Detailed Monitoring** - Set `monitoring = false` on 7 instances across 5 modules (`kafka`, `clickhouse`, `cassandra`, `locker`, `jump-host`). Detailed 1-minute CloudWatch metrics cost around $2-3/month per instance; standard 5-minute monitoring remains active. Combined saving: around $14-21/month.

**Not addressed (require maintainer review):**
- **Expensive NAT Gateway** - NAT gateway in `modules/base/subnet`. Likely needed for private subnet egress; removal is an architectural decision.
- **Load Balancer for Single Instance** (5 findings) - ALBs and NLBs across `nlb`, `alb`, `load-balancer`, `clickhouse`, and `locker` modules. Each serves an active service; fixed cost around $15-25/month each.
- **API Gateway REST Instead of HTTP API** - REST API in `modules/base/api-gateway`. Migrating to HTTP API requires code changes to callers.
- **Missing Cost and Usage Report / Missing AWS Budget** (26 findings each) - Organisation-level governance, not addressable at the module level.

Related: #264