### PR TITLE
fix: added s3 bucket access policy for decision-engine

### DIFF
--- a/terraform/aws/modules/application-resources/decision-engine/README.md
+++ b/terraform/aws/modules/application-resources/decision-engine/README.md
@@ -22,11 +22,13 @@
 
 | Name | Type |
 |------|------|
+| [aws_iam_policy.s3_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ses_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.inline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy_attachment.aws_managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.customer_managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.s3_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ses_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_eks_cluster.eks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
@@ -75,4 +77,5 @@
 | <a name="output_s3_bucket_id"></a> [s3\_bucket\_id](#output\_s3\_bucket\_id) | The ID (name) of the S3 bucket |
 | <a name="output_s3_bucket_name"></a> [s3\_bucket\_name](#output\_s3\_bucket\_name) | The name of the S3 bucket |
 | <a name="output_s3_bucket_regional_domain_name"></a> [s3\_bucket\_regional\_domain\_name](#output\_s3\_bucket\_regional\_domain\_name) | The regional domain name of the S3 bucket |
+| <a name="output_s3_policy_arn"></a> [s3\_policy\_arn](#output\_s3\_policy\_arn) | ARN of the S3 IAM policy attached to the Decision Engine role (if S3 bucket is enabled) |
 <!-- END_TF_DOCS -->

--- a/terraform/aws/modules/application-resources/decision-engine/main.tf
+++ b/terraform/aws/modules/application-resources/decision-engine/main.tf
@@ -77,6 +77,45 @@ resource "aws_iam_role_policy" "inline" {
 }
 
 # =========================================================================
+# IAM - S3 POLICY
+# =========================================================================
+resource "aws_iam_policy" "s3_policy" {
+  count = local.s3_bucket_create ? 1 : 0
+
+  name = "${local.name_prefix}-s3-policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowS3BucketAccess"
+        Effect = "Allow"
+        Action = [
+          "s3:PutObject",
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:GetObjectVersion",
+          "s3:DeleteObject",
+          "s3:GetBucketLocation"
+        ]
+        Resource = [
+          module.s3_bucket[0].s3_bucket_arn,
+          "${module.s3_bucket[0].s3_bucket_arn}/*"
+        ]
+      }
+    ]
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "s3_policy_attachment" {
+  count = local.s3_bucket_create ? 1 : 0
+
+  role       = aws_iam_role.this.name
+  policy_arn = aws_iam_policy.s3_policy[0].arn
+}
+
+# =========================================================================
 # IAM - SES POLICY
 # =========================================================================
 resource "aws_iam_policy" "ses_policy" {

--- a/terraform/aws/modules/application-resources/decision-engine/outputs.tf
+++ b/terraform/aws/modules/application-resources/decision-engine/outputs.tf
@@ -58,6 +58,14 @@ output "inline_policies_enabled" {
 }
 
 # =========================================================================
+# S3 IAM POLICY OUTPUTS
+# =========================================================================
+output "s3_policy_arn" {
+  description = "ARN of the S3 IAM policy attached to the Decision Engine role (if S3 bucket is enabled)"
+  value       = local.s3_bucket_create ? aws_iam_policy.s3_policy[0].arn : null
+}
+
+# =========================================================================
 # S3 BUCKET OUTPUTS
 # =========================================================================
 output "s3_bucket_id" {


### PR DESCRIPTION
This pull request introduces new IAM policies and outputs to support S3 bucket access for the Decision Engine. The main changes add an S3-specific IAM policy, attach it to the application role when an S3 bucket is created, and expose the policy ARN as an output.

**S3 IAM Policy Management:**

* Added a new `aws_iam_policy` resource (`s3_policy`) that grants necessary S3 permissions (such as `s3:PutObject`, `s3:GetObject`, etc.) on the managed S3 bucket and its objects, conditionally created if `local.s3_bucket_create` is true.
* Attached the S3 policy to the application IAM role using a new `aws_iam_role_policy_attachment` resource, also conditionally created.

**Outputs:**

* Added a new output variable `s3_policy_arn` to expose the ARN of the S3 IAM policy, or `null` if the S3 bucket is not enabled.