### PR TITLE
feat(chaos-engineering): add stress test lambda functions for Aurora, ElastiCache, FIS, and Lambda layer module

### DIFF
--- a/terraform/aws/modules/composition/aurora-fault-injection/README.md
+++ b/terraform/aws/modules/composition/aurora-fault-injection/README.md
@@ -53,3 +53,125 @@ module "aurora_fault_injection" {
 - `create_secret` / `secret_name` — use module-managed or existing Secrets Manager secret
 
 See `variables.tf` for the full input list and `outputs.tf` for emitted ARNs and experiment IDs.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.4 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | >= 2.4 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.fault_injection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_group.stress_test](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_iam_role.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.secrets_and_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.lambda_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.lambda_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_kms_alias.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
+| [aws_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_lambda_function.fault_injection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_function.stress_test](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_secretsmanager_secret.db_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.db_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_security_group.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.db_ingress_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [archive_file.fault_injection_code](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [archive_file.stress_test_code](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_secretsmanager_secret.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_conn_batch_size"></a> [conn\_batch\_size](#input\_conn\_batch\_size) | Connections per thread per batch in connection exhaustion test | `number` | `30` | no |
+| <a name="input_conn_hold_seconds"></a> [conn\_hold\_seconds](#input\_conn\_hold\_seconds) | Seconds to hold connections before closing in connection exhaustion test | `number` | `5` | no |
+| <a name="input_conn_phase_threads"></a> [conn\_phase\_threads](#input\_conn\_phase\_threads) | Comma-separated cumulative thread counts per connection exhaustion phase (e.g. 20,40,56) | `string` | `"20,40,56"` | no |
+| <a name="input_conn_ramp_seconds"></a> [conn\_ramp\_seconds](#input\_conn\_ramp\_seconds) | Seconds over which each worker spreads its connection openings to avoid a steep spike | `number` | `60` | no |
+| <a name="input_cpu_phase_baseline_pct"></a> [cpu\_phase\_baseline\_pct](#input\_cpu\_phase\_baseline\_pct) | Estimated CPU percentage consumed by the TPC-B workload alone. When cpu\_phase\_targets is set, the boost is computed as target - baseline. | `number` | `87` | no |
+| <a name="input_cpu_phase_duty"></a> [cpu\_phase\_duty](#input\_cpu\_phase\_duty) | Comma-separated duty cycles per CPU stress phase (e.g. 0.6,0.8,1.0) | `string` | `"0.6,0.8,1.0"` | no |
+| <a name="input_cpu_phase_extra_threads"></a> [cpu\_phase\_extra\_threads](#input\_cpu\_phase\_extra\_threads) | Comma-separated extra pure-CPU worker threads per phase, added on top of TPC-B and target-boost workers (e.g. 0,1,3). | `string` | `"0,0,0"` | no |
+| <a name="input_cpu_phase_pure_cpu"></a> [cpu\_phase\_pure\_cpu](#input\_cpu\_phase\_pure\_cpu) | Comma-separated booleans per CPU stress phase. When true, the phase uses a read-only generate\_series CPU-burn query instead of TPC-B writes (e.g. false,false,true) | `string` | `"false,false,true"` | no |
+| <a name="input_cpu_phase_targets"></a> [cpu\_phase\_targets](#input\_cpu\_phase\_targets) | Comma-separated target CPU percentages per phase. When set, active connection count is used instead of threads/duty (e.g. 70,75,80). Formula: effective\_connections = target\_pct/100 * cpu\_vcpus. | `string` | `""` | no |
+| <a name="input_cpu_phase_threads"></a> [cpu\_phase\_threads](#input\_cpu\_phase\_threads) | Comma-separated thread count per CPU stress phase (e.g. 2,2,16) | `string` | `"2,2,16"` | no |
+| <a name="input_cpu_pure_cpu_queries_per_loop"></a> [cpu\_pure\_cpu\_queries\_per\_loop](#input\_cpu\_pure\_cpu\_queries\_per\_loop) | Number of pure-CPU queries to issue back-to-back before duty-cycle sleep. Higher values keep the CPU pipeline fuller. | `number` | `10` | no |
+| <a name="input_cpu_pure_cpu_series_count"></a> [cpu\_pure\_cpu\_series\_count](#input\_cpu\_pure\_cpu\_series\_count) | Number of rows for the pure-CPU generate\_series query in pure\_cpu phases. Smaller rows with more queries per loop keeps the DB pipeline full. | `number` | `1000000` | no |
+| <a name="input_cpu_vcpus"></a> [cpu\_vcpus](#input\_cpu\_vcpus) | Number of vCPUs on the Aurora instance. Used to compute active connection count when cpu\_phase\_targets is set. | `number` | `4` | no |
+| <a name="input_create_secret"></a> [create\_secret](#input\_create\_secret) | Create a new Secrets Manager secret. If false, looks up an existing secret by secret\_name. The existing secret must contain JSON with: username, password, host, port, dbname | `bool` | `true` | no |
+| <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Create a dedicated security group for Lambda. If false, provide lambda\_security\_group\_id (e.g., reuse jump host SG) | `bool` | `false` | no |
+| <a name="input_db_endpoint"></a> [db\_endpoint](#input\_db\_endpoint) | Aurora PostgreSQL writer endpoint (cluster endpoint) | `string` | n/a | yes |
+| <a name="input_db_name"></a> [db\_name](#input\_db\_name) | Database name | `string` | `"postgres"` | no |
+| <a name="input_db_password"></a> [db\_password](#input\_db\_password) | Master database password (will be stored in Secrets Manager, KMS-encrypted) | `string` | n/a | yes |
+| <a name="input_db_port"></a> [db\_port](#input\_db\_port) | Database port | `number` | `5432` | no |
+| <a name="input_db_security_group_id"></a> [db\_security\_group\_id](#input\_db\_security\_group\_id) | Database security group ID (required when create\_security\_group = true, to add ingress rule for port 5432) | `string` | `""` | no |
+| <a name="input_db_username"></a> [db\_username](#input\_db\_username) | Master database username | `string` | `"postgres"` | no |
+| <a name="input_enable_stress_tests"></a> [enable\_stress\_tests](#input\_enable\_stress\_tests) | Deploy stress test Lambda functions (cpu\_stress, memory\_stress, connection\_exhaustion) | `bool` | `false` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment short name for resource naming (e.g., sbx, prod) | `string` | n/a | yes |
+| <a name="input_kms_key_alias"></a> [kms\_key\_alias](#input\_kms\_key\_alias) | Alias for the KMS key used to encrypt Secrets Manager secret | `string` | `""` | no |
+| <a name="input_lambda_layers"></a> [lambda\_layers](#input\_lambda\_layers) | List of Lambda layer ARNs (e.g., existing psycopg2-python311 layer) | `list(string)` | `[]` | no |
+| <a name="input_lambda_memory_size"></a> [lambda\_memory\_size](#input\_lambda\_memory\_size) | Lambda memory size in MB | `number` | `256` | no |
+| <a name="input_lambda_runtime"></a> [lambda\_runtime](#input\_lambda\_runtime) | Lambda runtime (must match compatible\_runtimes of the psycopg2 layer) | `string` | `"python3.11"` | no |
+| <a name="input_lambda_security_group_id"></a> [lambda\_security\_group\_id](#input\_lambda\_security\_group\_id) | Existing security group ID for Lambda (required when create\_security\_group = false). E.g., jump host internal SG | `string` | `""` | no |
+| <a name="input_lambda_subnet_ids"></a> [lambda\_subnet\_ids](#input\_lambda\_subnet\_ids) | List of subnet IDs for Lambda VPC config (use lambda subnets, not DB subnets) | `list(string)` | n/a | yes |
+| <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | Lambda timeout in seconds | `number` | `30` | no |
+| <a name="input_log_retention_days"></a> [log\_retention\_days](#input\_log\_retention\_days) | CloudWatch log group retention in days | `number` | `14` | no |
+| <a name="input_mem_agg_rows_max"></a> [mem\_agg\_rows\_max](#input\_mem\_agg\_rows\_max) | Maximum array\_agg rows per worker. Raise to build larger in-memory arrays. | `number` | `20000000` | no |
+| <a name="input_mem_arrays_per_worker"></a> [mem\_arrays\_per\_worker](#input\_mem\_arrays\_per\_worker) | Number of large arrays each worker holds simultaneously. Higher values consume memory faster. | `number` | `3` | no |
+| <a name="input_mem_phase_agg_rows"></a> [mem\_phase\_agg\_rows](#input\_mem\_phase\_agg\_rows) | Comma-separated array\_agg row counts per memory stress phase (e.g. 5000000,10000000,20000000) | `string` | `"5000000,10000000,20000000"` | no |
+| <a name="input_mem_phase_durations"></a> [mem\_phase\_durations](#input\_mem\_phase\_durations) | Comma-separated memory stress phase durations in seconds. Defaults to PHASE\_DURATIONS if unset. | `string` | `""` | no |
+| <a name="input_mem_phase_idle"></a> [mem\_phase\_idle](#input\_mem\_phase\_idle) | Comma-separated cumulative idle connection counts per memory stress phase (e.g. 50,150,300) | `string` | `"50,150,300"` | no |
+| <a name="input_mem_phase_sort"></a> [mem\_phase\_sort](#input\_mem\_phase\_sort) | Comma-separated cumulative sort session counts per memory stress phase (e.g. 5,10,20) | `string` | `"5,10,20"` | no |
+| <a name="input_mem_phase_temp_mb"></a> [mem\_phase\_temp\_mb](#input\_mem\_phase\_temp\_mb) | Comma-separated temp\_buffers MB per memory stress phase (e.g. 256,512,1024) | `string` | `"256,512,1024"` | no |
+| <a name="input_mem_temp_rows_max"></a> [mem\_temp\_rows\_max](#input\_mem\_temp\_rows\_max) | Maximum rows per temp table worker. Larger temp tables consume more temp\_buffers memory. | `number` | `5000000` | no |
+| <a name="input_mem_work_mem_mb"></a> [mem\_work\_mem\_mb](#input\_mem\_work\_mem\_mb) | work\_mem in MB for each memory stress worker session. Higher values force more in-memory operations and pressure shared resources. | `number` | `512` | no |
+| <a name="input_phase_durations"></a> [phase\_durations](#input\_phase\_durations) | Comma-separated phase durations in seconds (e.g. 240,300,300 = 4min+5min+5min) | `string` | `"240,300,300"` | no |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name for resource naming and tagging | `string` | `""` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS region | `string` | n/a | yes |
+| <a name="input_secret_name"></a> [secret\_name](#input\_secret\_name) | Name of the Secrets Manager secret for DB credentials | `string` | `""` | no |
+| <a name="input_sort_connections"></a> [sort\_connections](#input\_sort\_connections) | Number of concurrent sort connections for memory stress test | `number` | `10` | no |
+| <a name="input_sort_rows"></a> [sort\_rows](#input\_sort\_rows) | Number of rows to generate and sort in each memory stress iteration | `number` | `10000000` | no |
+| <a name="input_sort_work_mem_mb"></a> [sort\_work\_mem\_mb](#input\_sort\_work\_mem\_mb) | work\_mem setting in MB for each sort connection in memory stress test | `number` | `512` | no |
+| <a name="input_stress_clients"></a> [stress\_clients](#input\_stress\_clients) | Default number of concurrent clients/connections for stress tests | `number` | `50` | no |
+| <a name="input_stress_duration"></a> [stress\_duration](#input\_stress\_duration) | Default stress test duration in seconds | `number` | `300` | no |
+| <a name="input_stress_lambda_memory_size"></a> [stress\_lambda\_memory\_size](#input\_stress\_lambda\_memory\_size) | Lambda memory size in MB for stress test functions | `number` | `512` | no |
+| <a name="input_stress_lambda_timeout"></a> [stress\_lambda\_timeout](#input\_stress\_lambda\_timeout) | Lambda timeout in seconds for stress test functions (max 900) | `number` | `900` | no |
+| <a name="input_stress_threads"></a> [stress\_threads](#input\_stress\_threads) | Default number of worker threads for stress tests | `number` | `4` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID where Lambda functions will be deployed | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_invoke_commands"></a> [invoke\_commands](#output\_invoke\_commands) | AWS CLI commands to invoke each fault injection Lambda function |
+| <a name="output_kms_key_alias"></a> [kms\_key\_alias](#output\_kms\_key\_alias) | Alias of the KMS key |
+| <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | ARN of the KMS key used for Secrets Manager encryption |
+| <a name="output_kms_key_id"></a> [kms\_key\_id](#output\_kms\_key\_id) | ID of the KMS key |
+| <a name="output_lambda_function_arns"></a> [lambda\_function\_arns](#output\_lambda\_function\_arns) | Map of fault type to Lambda function ARN |
+| <a name="output_lambda_function_names"></a> [lambda\_function\_names](#output\_lambda\_function\_names) | Map of fault type to Lambda function name |
+| <a name="output_lambda_iam_role_arn"></a> [lambda\_iam\_role\_arn](#output\_lambda\_iam\_role\_arn) | ARN of the Lambda IAM role |
+| <a name="output_lambda_layers"></a> [lambda\_layers](#output\_lambda\_layers) | Lambda layer ARNs used by the fault injection functions |
+| <a name="output_secret_arn"></a> [secret\_arn](#output\_secret\_arn) | ARN of the Secrets Manager secret containing DB credentials |
+| <a name="output_secret_name"></a> [secret\_name](#output\_secret\_name) | Name of the Secrets Manager secret |
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | Security group ID used by Lambda functions (created or reused) |
+| <a name="output_stress_test_function_arns"></a> [stress\_test\_function\_arns](#output\_stress\_test\_function\_arns) | Map of stress type to Lambda function ARN |
+| <a name="output_stress_test_function_names"></a> [stress\_test\_function\_names](#output\_stress\_test\_function\_names) | Map of stress type to Lambda function name |
+| <a name="output_stress_test_invoke_commands"></a> [stress\_test\_invoke\_commands](#output\_stress\_test\_invoke\_commands) | AWS CLI commands to invoke each stress test Lambda function |
+<!-- END_TF_DOCS -->

--- a/terraform/aws/modules/composition/aurora-fault-injection/README.md
+++ b/terraform/aws/modules/composition/aurora-fault-injection/README.md
@@ -1,0 +1,55 @@
+# Aurora Fault Injection & Stress Test Module
+
+Generic Terraform module that deploys Lambda-based fault injection and stress tests for Amazon Aurora PostgreSQL.
+
+## What it creates
+
+- KMS key + Secrets Manager secret for Aurora credentials
+- IAM role for Lambda with VPC, Secrets Manager, and KMS access
+- Optional Lambda security group (or reuse an existing one)
+- Six fault-injection Lambda functions (`crash_instance`, `crash_dispatcher`, `crash_node`, `replica_failure`, `disk_failure`, `disk_congestion`)
+- Optional stress-test Lambda functions (`cpu_stress`, `memory_stress`, `connection_exhaustion`, `cleanup`)
+
+## Usage
+
+```hcl
+module "aurora_fault_injection" {
+  source = "./terraform/aws/modules/composition/aurora-fault-injection"
+
+  region      = "us-east-1"
+  environment = "dev"
+
+  db_endpoint = "my-cluster.cluster-xyz.us-east-1.rds.amazonaws.com"
+  db_name     = "postgres"
+  db_username = "postgres"
+  db_password = sensitive("supersecret")
+
+  vpc_id                  = "vpc-12345678"
+  lambda_subnet_ids       = ["subnet-11111111", "subnet-22222222"]
+  lambda_security_group_id = "sg-jumphost"
+
+  enable_stress_tests = true
+
+  tags = {
+    Project = "my-project"
+  }
+}
+```
+
+## Required inputs
+
+- `region`
+- `environment`
+- `db_endpoint`
+- `db_password`
+- `vpc_id`
+- `lambda_subnet_ids`
+- `lambda_security_group_id` (if `create_security_group = false`)
+
+## Optional highlights
+
+- `enable_stress_tests` — deploy CPU/memory/connection stress Lambdas
+- `create_security_group` / `db_security_group_id` — control SG creation
+- `create_secret` / `secret_name` — use module-managed or existing Secrets Manager secret
+
+See `variables.tf` for the full input list and `outputs.tf` for emitted ARNs and experiment IDs.

--- a/terraform/aws/modules/composition/aurora-fault-injection/main.tf
+++ b/terraform/aws/modules/composition/aurora-fault-injection/main.tf
@@ -1,0 +1,394 @@
+# ============================================================================
+# Aurora Fault Injection & Stress Test Module - Main Resources
+# ============================================================================
+# Creates:
+#   1. KMS key for Secrets Manager encryption + Lambda password decrypt
+#   2. Secrets Manager secret storing DB credentials (user-provided or existing)
+#   3. IAM role for Lambda (VPC access, Secrets Manager, KMS, CloudWatch)
+#   4. Optional security group (or reuse existing, e.g., jump host SG)
+#   5. Six Lambda functions for Aurora fault injection queries (src/aurora_inject/)
+#   6. Three Lambda functions for Aurora stress testing (src/stress_test/)
+#   Uses existing psycopg2 Lambda layer (provided via var.lambda_layers)
+# ============================================================================
+
+locals {
+  common_tags = merge(var.tags, {
+    Environment = var.environment
+    Project     = var.project_name
+    ManagedBy   = "terraform-IaC"
+    Component   = "aurora-fault-injection"
+  })
+
+  kms_alias   = var.kms_key_alias != "" ? var.kms_key_alias : "alias/${var.environment}-aurora-fi-kms"
+  secret_name = var.secret_name != "" ? var.secret_name : "rds/${var.environment}-test-rds-master-credentials"
+
+  fault_types = {
+    crash_instance   = { handler = "crash_instance.lambda_handler", description = "Inject DB process crash (instance)" }
+    crash_dispatcher = { handler = "crash_dispatcher.lambda_handler", description = "Inject dispatcher crash (writes to cluster volume)" }
+    crash_node       = { handler = "crash_node.lambda_handler", description = "Inject both DB + dispatcher crash (node)" }
+    replica_failure  = { handler = "replica_failure.lambda_handler", description = "Inject replica failure (100% block, 30s)" }
+    disk_failure     = { handler = "disk_failure.lambda_handler", description = "Inject disk failure (50% storage, 20s)" }
+    disk_congestion  = { handler = "disk_congestion.lambda_handler", description = "Inject disk congestion (100% I/O, 60s, 30-100ms)" }
+  }
+
+  stress_types = var.enable_stress_tests ? {
+    cpu_stress            = { handler = "cpu_stress.lambda_handler", description = "CPU stress via TPC-B-like concurrent workload (ThreadPoolExecutor + psycopg2)" }
+    memory_stress         = { handler = "memory_stress.lambda_handler", description = "Memory stress via connection flooding + large sorts" }
+    connection_exhaustion = { handler = "connection_exhaustion.lambda_handler", description = "Connection pool exhaustion via rapid connect/disconnect" }
+    cleanup               = { handler = "cleanup.lambda_handler", description = "Drop pgbench tables created by cpu_stress (run after testing)" }
+  } : {}
+
+  effective_security_group_id = var.create_security_group ? aws_security_group.lambda[0].id : var.lambda_security_group_id
+}
+
+# ============================================================================
+# KMS Key for Secrets Manager Encryption + Lambda Password Decrypt
+# ============================================================================
+
+resource "aws_kms_key" "this" {
+  description             = "KMS key for Aurora fault injection Secrets Manager encryption (${var.environment})"
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "EnableIAMUserPermissions"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root" }
+        Action    = "kms:*"
+        Resource  = "*"
+      },
+      {
+        Sid       = "AllowLambdaDecrypt"
+        Effect    = "Allow"
+        Principal = { AWS = aws_iam_role.lambda.arn }
+        Action    = ["kms:Decrypt", "kms:DescribeKey"]
+        Resource  = "*"
+        Condition = {
+          StringEquals = {
+            "kms:ViaService" = "secretsmanager.${var.region}.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_kms_alias" "this" {
+  name          = local.kms_alias
+  target_key_id = aws_kms_key.this.key_id
+}
+
+data "aws_caller_identity" "current" {}
+
+# ============================================================================
+# Secrets Manager - DB Credentials
+# When create_secret = true: creates a new secret with KMS encryption
+# When create_secret = false: looks up an existing secret by name (user-created)
+# ============================================================================
+
+resource "aws_secretsmanager_secret" "db_credentials" {
+  count = var.create_secret ? 1 : 0
+
+  name                    = local.secret_name
+  description             = "Aurora PostgreSQL credentials for fault injection Lambda (${var.environment})"
+  kms_key_id              = aws_kms_key.this.key_id
+  recovery_window_in_days = 0
+
+  tags = local.common_tags
+}
+
+resource "aws_secretsmanager_secret_version" "db_credentials" {
+  count = var.create_secret ? 1 : 0
+
+  secret_id = aws_secretsmanager_secret.db_credentials[0].id
+
+  secret_string = jsonencode({
+    username = var.db_username
+    password = var.db_password
+    host     = var.db_endpoint
+    port     = var.db_port
+    dbname   = var.db_name
+  })
+}
+
+data "aws_secretsmanager_secret" "existing" {
+  count = var.create_secret ? 0 : 1
+  name  = local.secret_name
+}
+
+locals {
+  secret_arn = var.create_secret ? aws_secretsmanager_secret.db_credentials[0].arn : data.aws_secretsmanager_secret.existing[0].arn
+}
+
+# ============================================================================
+# IAM Role for Lambda Functions
+# ============================================================================
+
+resource "aws_iam_role" "lambda" {
+  name = "${var.environment}-aurora-fi-lambda-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_vpc" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+  role       = aws_iam_role.lambda.name
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_logs" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  role       = aws_iam_role.lambda.name
+}
+
+resource "aws_iam_role_policy" "secrets_and_kms" {
+  name = "secrets-kms-access"
+  role = aws_iam_role.lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "GetSecretValue"
+        Effect = "Allow"
+        Action = ["secretsmanager:GetSecretValue"]
+        Resource = [
+          local.secret_arn
+        ]
+      },
+      {
+        Sid    = "KMSDecryptSecret"
+        Effect = "Allow"
+        Action = ["kms:Decrypt", "kms:DescribeKey"]
+        Resource = [
+          aws_kms_key.this.arn
+        ]
+        Condition = {
+          StringEquals = {
+            "kms:ViaService" = "secretsmanager.${var.region}.amazonaws.com"
+          }
+        }
+      },
+      {
+        Sid    = "KMSDecryptPassword"
+        Effect = "Allow"
+        Action = ["kms:Decrypt"]
+        Resource = [
+          aws_kms_key.this.arn
+        ]
+      }
+    ]
+  })
+}
+
+# ============================================================================
+# Optional Security Group (create or reuse existing)
+# ============================================================================
+
+resource "aws_security_group" "lambda" {
+  count = var.create_security_group ? 1 : 0
+
+  name        = "${var.environment}-aurora-fi-lambda-sg"
+  description = "Security group for Aurora fault injection Lambda functions"
+  vpc_id      = var.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_security_group_rule" "db_ingress_lambda" {
+  count = var.create_security_group ? 1 : 0
+
+  type                     = "ingress"
+  from_port                = var.db_port
+  to_port                  = var.db_port
+  protocol                 = "tcp"
+  security_group_id        = var.db_security_group_id
+  source_security_group_id = aws_security_group.lambda[0].id
+}
+
+# ============================================================================
+# Lambda Source Code Zips
+# ============================================================================
+
+data "archive_file" "fault_injection_code" {
+  type        = "zip"
+  source_dir  = "${path.module}/src/aurora_inject"
+  output_path = "${path.module}/build/fault-injection-code.zip"
+}
+
+data "archive_file" "stress_test_code" {
+  type        = "zip"
+  source_dir  = "${path.module}/src/stress_test"
+  output_path = "${path.module}/build/stress-test-code.zip"
+}
+
+# ============================================================================
+# CloudWatch Log Groups
+# ============================================================================
+
+resource "aws_cloudwatch_log_group" "fault_injection" {
+  for_each          = local.fault_types
+  name              = "/aws/lambda/${var.environment}-aurora-fi-${each.key}"
+  retention_in_days = var.log_retention_days
+  tags              = local.common_tags
+}
+
+resource "aws_cloudwatch_log_group" "stress_test" {
+  for_each          = local.stress_types
+  name              = "/aws/lambda/${var.environment}-aurora-stress-${each.key}"
+  retention_in_days = var.log_retention_days
+  tags              = local.common_tags
+}
+
+# ============================================================================
+# Lambda Functions - Fault Injection (6 functions, src/aurora_inject/)
+# ============================================================================
+
+resource "aws_lambda_function" "fault_injection" {
+  for_each = local.fault_types
+
+  function_name = "${var.environment}-aurora-fi-${each.key}"
+  description   = each.value.description
+
+  role    = aws_iam_role.lambda.arn
+  runtime = var.lambda_runtime
+  handler = each.value.handler
+
+  filename         = data.archive_file.fault_injection_code.output_path
+  source_code_hash = data.archive_file.fault_injection_code.output_base64sha256
+
+  timeout     = var.lambda_timeout
+  memory_size = var.lambda_memory_size
+
+  layers = var.lambda_layers
+
+  environment {
+    variables = {
+      SECRET_ARN  = local.secret_arn
+      KMS_KEY_ARN = aws_kms_key.this.arn
+      DB_HOST     = var.db_endpoint
+      DB_PORT     = tostring(var.db_port)
+      DB_NAME     = var.db_name
+      DB_USER     = var.db_username
+      FAULT_TYPE  = each.key
+    }
+  }
+
+  vpc_config {
+    subnet_ids         = var.lambda_subnet_ids
+    security_group_ids = [local.effective_security_group_id]
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.lambda_vpc,
+    aws_iam_role_policy_attachment.lambda_logs,
+    aws_iam_role_policy.secrets_and_kms,
+    aws_cloudwatch_log_group.fault_injection,
+    aws_secretsmanager_secret_version.db_credentials,
+  ]
+
+  tags = merge(local.common_tags, {
+    FaultType = each.key
+  })
+}
+
+# ============================================================================
+# Lambda Functions - Stress Test (3 functions, src/stress_test/)
+# ============================================================================
+
+resource "aws_lambda_function" "stress_test" {
+  for_each = local.stress_types
+
+  function_name = "${var.environment}-aurora-stress-${each.key}"
+  description   = each.value.description
+
+  role    = aws_iam_role.lambda.arn
+  runtime = var.lambda_runtime
+  handler = each.value.handler
+
+  filename         = data.archive_file.stress_test_code.output_path
+  source_code_hash = data.archive_file.stress_test_code.output_base64sha256
+
+  timeout     = var.stress_lambda_timeout
+  memory_size = var.stress_lambda_memory_size
+
+  layers = var.lambda_layers
+
+  environment {
+    variables = {
+      SECRET_ARN                    = local.secret_arn
+      KMS_KEY_ARN                   = aws_kms_key.this.arn
+      DB_HOST                       = var.db_endpoint
+      DB_PORT                       = tostring(var.db_port)
+      DB_NAME                       = var.db_name
+      DB_USER                       = var.db_username
+      STRESS_TYPE                   = each.key
+      DURATION                      = tostring(var.stress_duration)
+      CLIENTS                       = tostring(var.stress_clients)
+      THREADS                       = tostring(var.stress_threads)
+      SORT_CONNECTIONS              = tostring(var.sort_connections)
+      SORT_WORK_MEM_MB              = tostring(var.sort_work_mem_mb)
+      SORT_ROWS                     = tostring(var.sort_rows)
+      PHASE_DURATIONS               = var.phase_durations
+      CPU_PHASE_THREADS             = var.cpu_phase_threads
+      CPU_PHASE_DUTY                = var.cpu_phase_duty
+      CPU_PHASE_PURE_CPU            = var.cpu_phase_pure_cpu
+      CPU_PHASE_TARGETS             = var.cpu_phase_targets
+      CPU_VCPUS                     = tostring(var.cpu_vcpus)
+      CPU_PHASE_BASELINE_PCT        = tostring(var.cpu_phase_baseline_pct)
+      CPU_PHASE_EXTRA_THREADS       = var.cpu_phase_extra_threads
+      CPU_PURE_CPU_SERIES_COUNT     = tostring(var.cpu_pure_cpu_series_count)
+      CPU_PURE_CPU_QUERIES_PER_LOOP = tostring(var.cpu_pure_cpu_queries_per_loop)
+      MEM_PHASE_IDLE                = var.mem_phase_idle
+      MEM_PHASE_SORT                = var.mem_phase_sort
+      MEM_PHASE_TEMP_MB             = var.mem_phase_temp_mb
+      MEM_PHASE_AGG_ROWS            = var.mem_phase_agg_rows
+      MEM_PHASE_DURATIONS           = var.mem_phase_durations
+      MEM_WORK_MEM_MB               = tostring(var.mem_work_mem_mb)
+      MEM_AGG_ROWS_MAX              = tostring(var.mem_agg_rows_max)
+      MEM_ARRAYS_PER_WORKER         = tostring(var.mem_arrays_per_worker)
+      MEM_TEMP_ROWS_MAX             = tostring(var.mem_temp_rows_max)
+      CONN_PHASE_THREADS            = var.conn_phase_threads
+      CONN_BATCH_SIZE               = tostring(var.conn_batch_size)
+      CONN_HOLD_SECONDS             = tostring(var.conn_hold_seconds)
+      CONN_RAMP_SECONDS             = tostring(var.conn_ramp_seconds)
+    }
+  }
+
+  vpc_config {
+    subnet_ids         = var.lambda_subnet_ids
+    security_group_ids = [local.effective_security_group_id]
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.lambda_vpc,
+    aws_iam_role_policy_attachment.lambda_logs,
+    aws_iam_role_policy.secrets_and_kms,
+    aws_cloudwatch_log_group.stress_test,
+    aws_secretsmanager_secret_version.db_credentials,
+  ]
+
+  tags = merge(local.common_tags, {
+    StressType = each.key
+  })
+}

--- a/terraform/aws/modules/composition/aurora-fault-injection/outputs.tf
+++ b/terraform/aws/modules/composition/aurora-fault-injection/outputs.tf
@@ -1,0 +1,85 @@
+# ============================================================================
+# Aurora Fault Injection Module - Outputs
+# ============================================================================
+
+output "lambda_function_arns" {
+  description = "Map of fault type to Lambda function ARN"
+  value = {
+    for k, v in aws_lambda_function.fault_injection : k => v.arn
+  }
+}
+
+output "lambda_function_names" {
+  description = "Map of fault type to Lambda function name"
+  value = {
+    for k, v in aws_lambda_function.fault_injection : k => v.function_name
+  }
+}
+
+output "kms_key_arn" {
+  description = "ARN of the KMS key used for Secrets Manager encryption"
+  value       = aws_kms_key.this.arn
+}
+
+output "kms_key_id" {
+  description = "ID of the KMS key"
+  value       = aws_kms_key.this.key_id
+}
+
+output "kms_key_alias" {
+  description = "Alias of the KMS key"
+  value       = aws_kms_alias.this.name
+}
+
+output "secret_arn" {
+  description = "ARN of the Secrets Manager secret containing DB credentials"
+  value       = local.secret_arn
+}
+
+output "secret_name" {
+  description = "Name of the Secrets Manager secret"
+  value       = var.create_secret ? aws_secretsmanager_secret.db_credentials[0].name : data.aws_secretsmanager_secret.existing[0].name
+}
+
+output "lambda_iam_role_arn" {
+  description = "ARN of the Lambda IAM role"
+  value       = aws_iam_role.lambda.arn
+}
+
+output "lambda_layers" {
+  description = "Lambda layer ARNs used by the fault injection functions"
+  value       = var.lambda_layers
+}
+
+output "security_group_id" {
+  description = "Security group ID used by Lambda functions (created or reused)"
+  value       = var.create_security_group ? aws_security_group.lambda[0].id : var.lambda_security_group_id
+}
+
+output "invoke_commands" {
+  description = "AWS CLI commands to invoke each fault injection Lambda function"
+  value = {
+    for k, v in aws_lambda_function.fault_injection : k => "aws lambda invoke --function-name ${v.function_name} --region ${var.region} --payload '{}' /tmp/${k}-output.json && cat /tmp/${k}-output.json"
+  }
+}
+
+output "stress_test_function_arns" {
+  description = "Map of stress type to Lambda function ARN"
+  value = {
+    for k, v in aws_lambda_function.stress_test : k => v.arn
+  }
+}
+
+output "stress_test_function_names" {
+  description = "Map of stress type to Lambda function name"
+  value = {
+    for k, v in aws_lambda_function.stress_test : k => v.function_name
+  }
+}
+
+output "stress_test_invoke_commands" {
+  description = "AWS CLI commands to invoke each stress test Lambda function"
+  value = {
+    for k, v in aws_lambda_function.stress_test : k => "aws lambda invoke --function-name ${v.function_name} --region ${var.region} --payload '{}' /tmp/${k}-output.json && cat /tmp/${k}-output.json"
+  }
+}

--- a/terraform/aws/modules/composition/aurora-fault-injection/src/aurora_inject/common.py
+++ b/terraform/aws/modules/composition/aurora-fault-injection/src/aurora_inject/common.py
@@ -1,0 +1,120 @@
+import json
+import os
+import base64
+import logging
+import boto3
+import psycopg2
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+_secret_client = boto3.client("secretsmanager")
+_kms_client = boto3.client("kms")
+_secret_cache = None
+
+CRASH_FAULT_TYPES = {"crash_instance", "crash_dispatcher", "crash_node"}
+
+
+def get_secret(secret_arn):
+    global _secret_cache
+    if _secret_cache:
+        return _secret_cache
+    try:
+        response = _secret_client.get_secret_value(SecretId=secret_arn)
+        _secret_cache = json.loads(response["SecretString"])
+        return _secret_cache
+    except ClientError as e:
+        raise Exception(f"Failed to retrieve secret: {e}") from e
+
+
+def decrypt_password(encrypted_b64, kms_key_arn):
+    try:
+        response = _kms_client.decrypt(
+            CiphertextBlob=base64.b64decode(encrypted_b64),
+            KeyId=kms_key_arn,
+        )
+        return response["Plaintext"].decode("utf-8")
+    except ClientError as e:
+        raise Exception(f"KMS decrypt failed: {e}") from e
+
+
+def get_connection(secret):
+    kms_key_arn = os.environ["KMS_KEY_ARN"]
+    encrypted_password = secret["password"]
+
+    password = decrypt_password(encrypted_password, kms_key_arn)
+
+    try:
+        conn = psycopg2.connect(
+            host=secret.get("host", os.environ.get("DB_HOST")),
+            port=int(secret.get("port", os.environ.get("DB_PORT", 5432))),
+            dbname=secret.get("dbname", os.environ.get("DB_NAME")),
+            user=secret.get("username", os.environ.get("DB_USER")),
+            password=password,
+            connect_timeout=10,
+        )
+        conn.autocommit = True
+        return conn
+    except psycopg2.OperationalError as e:
+        logger.error(f"DB connection failed: {e}")
+        raise
+    finally:
+        password = None
+
+
+def execute_injection(query, params=None):
+    secret_arn = os.environ["SECRET_ARN"]
+    fault_type = os.environ.get("FAULT_TYPE", "unknown")
+
+    logger.info(f"Executing fault injection: {fault_type}")
+    logger.info(f"Query: {query}")
+
+    secret = get_secret(secret_arn)
+    conn = get_connection(secret)
+
+    try:
+        cursor = conn.cursor()
+        try:
+            if params:
+                cursor.execute(query, params)
+            else:
+                cursor.execute(query)
+            result = cursor.fetchone()
+            cursor.close()
+            logger.info(f"Injection completed. Result: {result}")
+            return {
+                "statusCode": 200,
+                "body": json.dumps({
+                    "fault_type": fault_type,
+                    "query": query,
+                    "result": str(result) if result else "executed",
+                }),
+            }
+        except psycopg2.OperationalError as e:
+            if fault_type in CRASH_FAULT_TYPES:
+                logger.info(f"Expected connection drop for {fault_type}: {e}")
+                return {
+                    "statusCode": 200,
+                    "body": json.dumps({
+                        "fault_type": fault_type,
+                        "query": query,
+                        "result": "crash_injected",
+                        "note": "connection dropped as expected — instance crashed",
+                    }),
+                }
+            raise
+    except Exception as e:
+        logger.error(f"Injection failed: {e}")
+        return {
+            "statusCode": 500,
+            "body": json.dumps({
+                "fault_type": fault_type,
+                "error": str(e),
+            }),
+        }
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass

--- a/terraform/aws/modules/composition/aurora-fault-injection/src/aurora_inject/crash_dispatcher.py
+++ b/terraform/aws/modules/composition/aurora-fault-injection/src/aurora_inject/crash_dispatcher.py
@@ -1,0 +1,5 @@
+from common import execute_injection
+
+
+def lambda_handler(event, context):
+    return execute_injection("SELECT aurora_inject_crash('dispatcher');")

--- a/terraform/aws/modules/composition/aurora-fault-injection/src/aurora_inject/crash_instance.py
+++ b/terraform/aws/modules/composition/aurora-fault-injection/src/aurora_inject/crash_instance.py
@@ -1,0 +1,5 @@
+from common import execute_injection
+
+
+def lambda_handler(event, context):
+    return execute_injection("SELECT aurora_inject_crash('instance');")

--- a/terraform/aws/modules/composition/aurora-fault-injection/src/aurora_inject/crash_node.py
+++ b/terraform/aws/modules/composition/aurora-fault-injection/src/aurora_inject/crash_node.py
@@ -1,0 +1,5 @@
+from common import execute_injection
+
+
+def lambda_handler(event, context):
+    return execute_injection("SELECT aurora_inject_crash('node');")

--- a/terraform/aws/modules/composition/aurora-fault-injection/src/aurora_inject/disk_congestion.py
+++ b/terraform/aws/modules/composition/aurora-fault-injection/src/aurora_inject/disk_congestion.py
@@ -1,0 +1,7 @@
+from common import execute_injection
+
+
+def lambda_handler(event, context):
+    return execute_injection(
+        "SELECT aurora_inject_disk_congestion(100, 0, true, 60, 30.0, 100.0);"
+    )

--- a/terraform/aws/modules/composition/aurora-fault-injection/src/aurora_inject/disk_failure.py
+++ b/terraform/aws/modules/composition/aurora-fault-injection/src/aurora_inject/disk_failure.py
@@ -1,0 +1,7 @@
+from common import execute_injection
+
+
+def lambda_handler(event, context):
+    return execute_injection(
+        "SELECT aurora_inject_disk_failure(50, 0, false, 20);"
+    )

--- a/terraform/aws/modules/composition/aurora-fault-injection/src/aurora_inject/replica_failure.py
+++ b/terraform/aws/modules/composition/aurora-fault-injection/src/aurora_inject/replica_failure.py
@@ -1,0 +1,7 @@
+from common import execute_injection
+
+
+def lambda_handler(event, context):
+    return execute_injection(
+        "SELECT aurora_inject_replica_failure(100, 30);"
+    )

--- a/terraform/aws/modules/composition/aurora-fault-injection/src/stress_test/cleanup.py
+++ b/terraform/aws/modules/composition/aurora-fault-injection/src/stress_test/cleanup.py
@@ -1,0 +1,47 @@
+import json
+import logging
+from common import get_conn_params
+import psycopg2
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def lambda_handler(event, context):
+    conn_params = get_conn_params()
+    conn = psycopg2.connect(**conn_params)
+    conn.autocommit = True
+    cursor = conn.cursor()
+
+    dropped = []
+
+    tables = [
+        "pgbench_history",
+        "pgbench_tellers",
+        "pgbench_accounts",
+        "pgbench_branches",
+    ]
+
+    for table in tables:
+        try:
+            cursor.execute(f"SELECT count(*) FROM {table}")
+            count = cursor.fetchone()[0]
+            cursor.execute(f"DROP TABLE IF EXISTS {table} CASCADE")
+            dropped.append(f"{table} ({count} rows)")
+            logger.info(f"Dropped {table} with {count} rows")
+        except psycopg2.Error:
+            logger.info(f"{table} does not exist, skipping")
+
+    cursor.close()
+    conn.close()
+
+    logger.info(f"Cleanup complete: {len(dropped)} tables dropped")
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps({
+            "action": "cleanup",
+            "dropped_tables": dropped,
+            "message": "pgbench schema removed — DB is clean",
+        }),
+    }

--- a/terraform/aws/modules/composition/aurora-fault-injection/src/stress_test/common.py
+++ b/terraform/aws/modules/composition/aurora-fault-injection/src/stress_test/common.py
@@ -1,0 +1,183 @@
+import json
+import os
+import base64
+import logging
+import time
+import random
+import boto3
+import psycopg2
+from botocore.exceptions import ClientError
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+_secret_client = boto3.client("secretsmanager")
+_kms_client = boto3.client("kms")
+_secret_cache = None
+
+
+def get_secret(secret_arn):
+    global _secret_cache
+    if _secret_cache:
+        return _secret_cache
+    try:
+        response = _secret_client.get_secret_value(SecretId=secret_arn)
+        _secret_cache = json.loads(response["SecretString"])
+        return _secret_cache
+    except ClientError as e:
+        raise Exception(f"Failed to retrieve secret: {e}") from e
+
+
+def decrypt_password(encrypted_b64, kms_key_arn):
+    try:
+        response = _kms_client.decrypt(
+            CiphertextBlob=base64.b64decode(encrypted_b64),
+            KeyId=kms_key_arn,
+        )
+        return response["Plaintext"].decode("utf-8")
+    except ClientError as e:
+        raise Exception(f"KMS decrypt failed: {e}") from e
+
+
+def get_conn_params():
+    secret_arn = os.environ["SECRET_ARN"]
+    kms_key_arn = os.environ["KMS_KEY_ARN"]
+    secret = get_secret(secret_arn)
+    password = decrypt_password(secret["password"], kms_key_arn)
+    params = {
+        "host": os.environ.get("DB_HOST", secret.get("host")),
+        "port": int(os.environ.get("DB_PORT") or secret.get("port") or 5432),
+        "dbname": os.environ.get("DB_NAME", secret.get("dbname")),
+        "user": os.environ.get("DB_USER", secret.get("username")),
+        "password": password,
+    }
+    password = None
+    return params
+
+
+def ensure_pgbench_schema(conn_params, scale=10):
+    conn = psycopg2.connect(**conn_params)
+    conn.autocommit = True
+    cursor = conn.cursor()
+    try:
+        cursor.execute("SELECT 1 FROM pgbench_accounts LIMIT 1")
+        cursor.fetchone()
+        logger.info("pgbench schema already exists")
+        cursor.close()
+        conn.close()
+        return True
+    except psycopg2.Error:
+        logger.info(f"Creating pgbench schema with scale factor {scale} via SQL...")
+        cursor.close()
+        conn.close()
+        try:
+            _create_pgbench_tables(conn_params, scale)
+            logger.info("pgbench schema created")
+            return True
+        except Exception as e:
+            logger.warning(f"pgbench schema creation failed: {e}")
+            return False
+
+
+def _create_pgbench_tables(conn_params, scale):
+    conn = psycopg2.connect(**conn_params)
+    conn.autocommit = True
+    cursor = conn.cursor()
+
+    tellers = scale * 10
+    branches = scale
+    accounts = scale * 100000
+
+    cursor.execute("DROP TABLE IF EXISTS pgbench_history")
+    cursor.execute("DROP TABLE IF EXISTS pgbench_tellers")
+    cursor.execute("DROP TABLE IF EXISTS pgbench_accounts")
+    cursor.execute("DROP TABLE IF EXISTS pgbench_branches")
+
+    cursor.execute("""
+        CREATE TABLE pgbench_branches (
+            bid integer PRIMARY KEY,
+            bbalance integer,
+            filler char(88)
+        )
+    """)
+    cursor.execute("""
+        CREATE TABLE pgbench_tellers (
+            tid integer PRIMARY KEY,
+            bid integer,
+            tbalance integer,
+            filler char(84)
+        )
+    """)
+    cursor.execute("""
+        CREATE TABLE pgbench_accounts (
+            aid bigint PRIMARY KEY,
+            bid integer,
+            abalance integer,
+            filler char(84)
+        )
+    """)
+    cursor.execute("""
+        CREATE TABLE pgbench_history (
+            tid integer,
+            bid integer,
+            aid bigint,
+            delta integer,
+            mtime timestamp
+        )
+    """)
+
+    cursor.execute(
+        "INSERT INTO pgbench_branches (bid, bbalance, filler) "
+        "SELECT i, 0, repeat(' ', 88) FROM generate_series(1, %s) AS i",
+        (branches,)
+    )
+    cursor.execute(
+        "INSERT INTO pgbench_tellers (tid, bid, tbalance, filler) "
+        "SELECT i, ((i - 1) / 10) + 1, 0, repeat(' ', 84) FROM generate_series(1, %s) AS i",
+        (tellers,)
+    )
+    cursor.execute(
+        "INSERT INTO pgbench_accounts (aid, bid, abalance, filler) "
+        "SELECT i, ((i - 1) / 100000) + 1, 0, repeat(' ', 84) FROM generate_series(1, %s) AS i",
+        (accounts,)
+    )
+
+    cursor.execute("CREATE INDEX IF NOT EXISTS pgbench_accounts_bid_idx ON pgbench_accounts(bid)")
+    cursor.execute("CREATE INDEX IF NOT EXISTS pgbench_tellers_bid_idx ON pgbench_tellers(bid)")
+    cursor.execute("ANALYZE pgbench_branches")
+    cursor.execute("ANALYZE pgbench_tellers")
+    cursor.execute("ANALYZE pgbench_accounts")
+
+    cursor.close()
+    conn.close()
+
+
+def run_stress_with_workers(conn_params, worker_fn, num_clients, num_threads, duration):
+    start_time = time.time()
+    end_time = start_time + duration
+    total_transactions = 0
+    errors = []
+
+    with ThreadPoolExecutor(max_workers=num_threads) as executor:
+        futures = []
+        for _ in range(num_clients):
+            futures.append(executor.submit(worker_fn, conn_params, end_time))
+
+        for future in as_completed(futures):
+            try:
+                result = future.result()
+                total_transactions += result
+            except Exception as e:
+                errors.append(str(e))
+
+    elapsed = time.time() - start_time
+    tps = total_transactions / elapsed if elapsed > 0 else 0
+
+    return {
+        "total_transactions": total_transactions,
+        "elapsed_seconds": round(elapsed, 2),
+        "tps": round(tps, 2),
+        "errors": errors[:10],
+        "error_count": len(errors),
+    }

--- a/terraform/aws/modules/composition/aurora-fault-injection/src/stress_test/connection_exhaustion.py
+++ b/terraform/aws/modules/composition/aurora-fault-injection/src/stress_test/connection_exhaustion.py
@@ -1,0 +1,164 @@
+import os
+import time
+import logging
+import json
+import psycopg2
+import threading
+from common import get_conn_params
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def parse_csv(env_var, default, cast=int):
+    val = os.environ.get(env_var, default)
+    return [cast(x) for x in val.split(",")]
+
+
+def connect_hold_worker(conn_params, end_time, batch_size, hold_seconds, ramp_seconds, results, idx):
+    start_time = time.time()
+    connections_held = 0
+    transactions = 0
+    errors = 0
+    held_conns = []
+
+    # Spread connection openings across ramp_seconds to avoid a steep spike.
+    # After the ramp, connections are held until the global end time.
+    ramp_end = min(end_time, start_time + ramp_seconds)
+
+    for i in range(batch_size):
+        if time.time() >= end_time:
+            break
+
+        remaining_connections = batch_size - i
+        remaining_ramp_time = ramp_end - time.time()
+        if remaining_ramp_time > 0 and remaining_connections > 0 and i > 0:
+            time.sleep(remaining_ramp_time / remaining_connections)
+
+        try:
+            conn = psycopg2.connect(**conn_params)
+            conn.autocommit = True
+            cursor = conn.cursor()
+            cursor.execute("SELECT 1")
+            cursor.fetchone()
+            cursor.close()
+            held_conns.append(conn)
+            connections_held += 1
+            transactions += 1
+        except psycopg2.Error:
+            errors += 1
+
+    # Hold until the global end time. Sleep in small chunks so we remain
+    # responsive and can keep the Python GIL from blocking other threads.
+    while time.time() < end_time:
+        time.sleep(min(1.0, end_time - time.time()))
+
+    for conn in held_conns:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    results[idx] = {
+        "connections_held": connections_held,
+        "transactions": transactions,
+        "errors": errors,
+    }
+
+
+def lambda_handler(event, context):
+    durations = parse_csv("PHASE_DURATIONS", "240,300,300", int)
+    phase_threads = parse_csv("CONN_PHASE_THREADS", "20,40,56", int)
+    batch_size = int(os.environ.get("CONN_BATCH_SIZE", "30"))
+    hold_seconds = int(os.environ.get("CONN_HOLD_SECONDS", "5"))
+    ramp_seconds = int(os.environ.get("CONN_RAMP_SECONDS", "60"))
+    stress_type = os.environ.get("STRESS_TYPE", "connection_exhaustion")
+
+    total_duration = sum(durations)
+    logger.info(
+        f"Staged connection exhaustion: {len(durations)} phases, {total_duration}s total, "
+        f"batch={batch_size}, hold={hold_seconds}s, ramp={ramp_seconds}s"
+    )
+    for i, (d, t) in enumerate(zip(durations, phase_threads)):
+        peak = t * batch_size
+        logger.info(f"  Phase {i+1}: {d}s, {t} threads, peak concurrent ~{peak}")
+
+    conn_params = get_conn_params()
+
+    phase_starts = []
+    cumulative = 0
+    for d in durations:
+        phase_starts.append(cumulative)
+        cumulative += d
+
+    now = time.time()
+    total_end = now + total_duration
+
+    all_threads = []
+    all_results = []
+
+    for phase_i in range(len(durations)):
+        phase_start_abs = now + phase_starts[phase_i]
+        target_threads = phase_threads[phase_i]
+        prev_threads = phase_threads[phase_i - 1] if phase_i > 0 else 0
+        new_threads = target_threads - prev_threads
+
+        time.sleep(max(0, phase_start_abs - time.time()))
+        logger.info(
+            f"Phase {phase_i+1} starting: +{new_threads} threads "
+            f"(total {target_threads}, peak ~{target_threads * batch_size})"
+        )
+
+        results_slot = [None] * new_threads
+        all_results.append(results_slot)
+
+        for j in range(new_threads):
+            t = threading.Thread(
+                target=connect_hold_worker,
+                args=(conn_params, total_end, batch_size, hold_seconds, ramp_seconds, results_slot, j),
+            )
+            t.daemon = True
+            t.start()
+            all_threads.append(t)
+
+    logger.info(f"All phases launched. Waiting for {total_duration}s...")
+
+    for t in all_threads:
+        t.join(timeout=total_duration + 60)
+
+    total_held = 0
+    total_txns = 0
+    total_errors = 0
+    phase_results = []
+
+    for phase_i, results_slot in enumerate(all_results):
+        phase_held = sum(r["connections_held"] for r in results_slot if r) if results_slot else 0
+        phase_txns = sum(r["transactions"] for r in results_slot if r) if results_slot else 0
+        phase_errors = sum(r["errors"] for r in results_slot if r) if results_slot else 0
+        total_held += phase_held
+        total_txns += phase_txns
+        total_errors += phase_errors
+
+        new_threads = phase_threads[phase_i] - (phase_threads[phase_i - 1] if phase_i > 0 else 0)
+        phase_results.append({
+            "phase": phase_i + 1,
+            "new_threads": new_threads,
+            "total_threads": phase_threads[phase_i],
+            "peak_concurrent": phase_threads[phase_i] * batch_size,
+            "connections_held": phase_held,
+            "errors": phase_errors,
+        })
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps({
+            "stress_type": stress_type,
+            "total_connections_opened": total_held,
+            "total_connect_cycles": total_txns,
+            "total_errors": total_errors,
+            "elapsed_seconds": total_duration,
+            "batch_size": batch_size,
+            "hold_seconds": hold_seconds,
+            "phases": phase_results,
+        }),
+    }

--- a/terraform/aws/modules/composition/aurora-fault-injection/src/stress_test/cpu_stress.py
+++ b/terraform/aws/modules/composition/aurora-fault-injection/src/stress_test/cpu_stress.py
@@ -1,0 +1,437 @@
+import os
+import time
+import random
+import logging
+import json
+import threading
+import psycopg2
+from common import get_conn_params, ensure_pgbench_schema
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def parse_csv(env_var, default, cast=float):
+    val = os.environ.get(env_var, default)
+    return [cast(x.strip()) for x in val.split(",")]
+
+
+def _to_bool(raw):
+    return str(raw).strip().lower() in ("true", "1", "yes", "on")
+
+
+def _short_cpu_query(cursor, series_count):
+    """Fixed-cost CPU-bound query. Tune series_count so one execution takes
+    ~10-30 ms on the target instance."""
+    cursor.execute(
+        "SELECT count(*) FROM generate_series(1, %s) AS x WHERE md5(x::text) <> ''",
+        (series_count,),
+    )
+    cursor.fetchone()
+
+
+def controlled_full_worker(conn_params, phase_start, phase_end, series_count, results, idx):
+    """Always-active worker: consumes ~100% of one DB vCPU."""
+    time.sleep(max(0, phase_start - time.time()))
+    logger.info(f"Controlled worker {idx}: always active")
+
+    queries = 0
+    conn = None
+    try:
+        conn = psycopg2.connect(**conn_params)
+        conn.autocommit = True
+        cursor = conn.cursor()
+        while time.time() < phase_end:
+            _short_cpu_query(cursor, series_count)
+            queries += 1
+        cursor.close()
+    except Exception as e:
+        logger.error(f"Controlled full worker {idx} error: {e}")
+        results[idx] = {"queries": queries, "error": str(e)}
+        return
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    results[idx] = {"queries": queries}
+
+
+def controlled_duty_worker(conn_params, phase_start, phase_end, series_count, duty, results, idx):
+    """Fractional worker: runs queries for on_seconds, then sleeps for off_seconds.
+
+    This is connection-level duty cycling, NOT query-level. The query is short
+    (~10-30 ms) so the ON/OFF windows are honored.
+    """
+    time.sleep(max(0, phase_start - time.time()))
+    logger.info(f"Controlled worker {idx}: fractional duty {duty*100:.0f}%")
+
+    on_seconds = 2.0
+    off_seconds = on_seconds * (1.0 / duty - 1.0) if duty > 0 else 0.0
+
+    queries = 0
+    conn = None
+    try:
+        conn = psycopg2.connect(**conn_params)
+        conn.autocommit = True
+        cursor = conn.cursor()
+        while time.time() < phase_end:
+            on_deadline = time.time() + on_seconds
+            while time.time() < on_deadline and time.time() < phase_end:
+                _short_cpu_query(cursor, series_count)
+                queries += 1
+            if time.time() >= phase_end:
+                break
+            remaining = phase_end - time.time()
+            if off_seconds > 0 and remaining > 0:
+                time.sleep(min(off_seconds, remaining))
+        cursor.close()
+    except Exception as e:
+        logger.error(f"Controlled duty worker {idx} error: {e}")
+        results[idx] = {"queries": queries, "error": str(e)}
+        return
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    results[idx] = {"queries": queries}
+
+
+def tpcb_staged_worker(conn_params, phase_num, phase_start, phase_end, duty_cycle, results, idx):
+    time.sleep(max(0, phase_start - time.time()))
+    logger.info(f"Phase {phase_num} worker {idx}: now active at {duty_cycle*100:.0f}% duty")
+
+    conn = None
+    transactions = 0
+    try:
+        conn = psycopg2.connect(**conn_params)
+        conn.autocommit = False
+        cursor = conn.cursor()
+
+        while time.time() < phase_end:
+            aid = random.randint(1, 100000)
+            bid = random.randint(1, 10)
+            tid = random.randint(1, 100)
+            delta = random.randint(1, 1000)
+
+            tx_start = time.time()
+            try:
+                cursor.execute(
+                    "UPDATE pgbench_accounts SET abalance = abalance + %s WHERE aid = %s",
+                    (delta, aid),
+                )
+                cursor.execute(
+                    "SELECT abalance FROM pgbench_accounts WHERE aid = %s", (aid,)
+                )
+                cursor.fetchone()
+                cursor.execute(
+                    "UPDATE pgbench_tellers SET tbalance = tbalance + %s WHERE tid = %s",
+                    (delta, tid),
+                )
+                cursor.execute(
+                    "UPDATE pgbench_branches SET bbalance = bbalance + %s WHERE bid = %s",
+                    (delta, bid),
+                )
+                cursor.execute(
+                    "INSERT INTO pgbench_history (tid, bid, aid, delta, mtime) VALUES (%s, %s, %s, %s, CURRENT_TIMESTAMP)",
+                    (tid, bid, aid, delta),
+                )
+                conn.commit()
+                transactions += 1
+            except psycopg2.Error:
+                conn.rollback()
+                raise
+
+            tx_elapsed = time.time() - tx_start
+            if duty_cycle < 1.0 and tx_elapsed > 0:
+                sleep_time = tx_elapsed * (1.0 / duty_cycle - 1.0)
+                time.sleep(sleep_time)
+
+        cursor.close()
+    except Exception as e:
+        logger.error(f"Worker {idx} error: {e}")
+        results[idx] = {"transactions": transactions, "error": str(e)}
+        return
+    else:
+        results[idx] = {"transactions": transactions}
+
+    if conn:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+def generate_series_staged_worker(conn_params, phase_num, phase_start, phase_end, duty_cycle, results, idx):
+    time.sleep(max(0, phase_start - time.time()))
+    logger.info(f"Phase {phase_num} worker {idx}: now active at {duty_cycle*100:.0f}% duty")
+
+    conn = None
+    txns = 0
+    try:
+        conn = psycopg2.connect(**conn_params)
+        conn.autocommit = True
+        cursor = conn.cursor()
+
+        while time.time() < phase_end:
+            q_start = time.time()
+            cursor.execute("""
+                SELECT count(*) FROM generate_series(1, 1000000) AS x
+                WHERE (x::float8 * x::float8 + sqrt(x::float8))::bigint % 13 = 0
+            """)
+            cursor.fetchone()
+            txns += 1
+
+            q_elapsed = time.time() - q_start
+            if duty_cycle < 1.0 and q_elapsed > 0:
+                sleep_time = q_elapsed * (1.0 / duty_cycle - 1.0)
+                time.sleep(sleep_time)
+
+        cursor.close()
+    except Exception as e:
+        logger.error(f"Worker {idx} error: {e}")
+        results[idx] = {"transactions": txns, "error": str(e)}
+        return
+    else:
+        results[idx] = {"transactions": txns}
+
+    if conn:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+def pure_cpu_staged_worker(conn_params, phase_num, phase_start, phase_end, duty_cycle, series_count, queries_per_loop, results, idx):
+    time.sleep(max(0, phase_start - time.time()))
+    logger.info(f"Phase {phase_num} worker {idx}: pure CPU burn active at {duty_cycle*100:.0f}% duty")
+
+    conn = None
+    queries = 0
+    try:
+        conn = psycopg2.connect(**conn_params)
+        conn.autocommit = True
+        cursor = conn.cursor()
+
+        while time.time() < phase_end:
+            loop_start = time.time()
+            for _ in range(queries_per_loop):
+                count_this_query = series_count + random.randint(-series_count // 10, series_count // 10)
+                count_this_query = max(100000, count_this_query)
+                cursor.execute(
+                    """
+                    SELECT count(*)
+                    FROM generate_series(1, %s) AS x
+                    WHERE md5(x::text) <> ''
+                    """,
+                    (count_this_query,),
+                )
+                cursor.fetchone()
+                queries += 1
+
+            loop_elapsed = time.time() - loop_start
+            if duty_cycle < 1.0 and loop_elapsed > 0:
+                sleep_time = loop_elapsed * (1.0 / duty_cycle - 1.0)
+                remaining = phase_end - time.time()
+                time.sleep(min(sleep_time, remaining))
+
+        cursor.close()
+    except Exception as e:
+        logger.error(f"Pure CPU worker {idx} error: {e}")
+        results[idx] = {"queries": queries, "error": str(e)}
+        return
+    else:
+        results[idx] = {"queries": queries}
+
+    if conn:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+def lambda_handler(event, context):
+    durations = parse_csv("PHASE_DURATIONS", "240,300,300", int)
+    phase_threads = parse_csv("CPU_PHASE_THREADS", "2,2,16", int)
+    phase_duty = parse_csv("CPU_PHASE_DUTY", "0.6,0.8,1.0", float)
+    phase_pure_cpu = [_to_bool(x) for x in parse_csv("CPU_PHASE_PURE_CPU", "false,false,true", str)]
+    pure_cpu_series_count = int(os.environ.get("CPU_PURE_CPU_SERIES_COUNT", "1000000"))
+    pure_cpu_queries_per_loop = int(os.environ.get("CPU_PURE_CPU_QUERIES_PER_LOOP", "10"))
+    stress_type = os.environ.get("STRESS_TYPE", "cpu_stress")
+
+    cpu_phase_targets_raw = os.environ.get("CPU_PHASE_TARGETS", "").strip()
+    phase_targets = []
+    if cpu_phase_targets_raw:
+        phase_targets = [
+            float(entry.strip()) if entry.strip() else None
+            for entry in cpu_phase_targets_raw.split(",")
+        ]
+    vcpus = int(os.environ.get("CPU_VCPUS", "4"))
+
+    baseline_pct = float(os.environ.get("CPU_PHASE_BASELINE_PCT", "87.0"))
+    phase_extra_threads = parse_csv("CPU_PHASE_EXTRA_THREADS", "0,0,0", int)
+
+    total_duration = sum(durations)
+    logger.info(f"Staged CPU stress: {len(durations)} phases, {total_duration}s total")
+    logger.info(f"TPC-B baseline estimate: {baseline_pct}%, vCPUs: {vcpus}")
+    for i, d in enumerate(durations):
+        target = phase_targets[i] if i < len(phase_targets) else None
+        t = phase_threads[i] if i < len(phase_threads) else 0
+        duty = phase_duty[i] if i < len(phase_duty) else 0.0
+        pure = phase_pure_cpu[i] if i < len(phase_pure_cpu) else False
+        extra_t = phase_extra_threads[i] if i < len(phase_extra_threads) else 0
+        if target is not None:
+            boost = max(0.0, target - baseline_pct)
+            eff = boost / 100.0 * vcpus
+            logger.info(f"  Phase {i+1}: {d}s, TPC-B {t} threads + boost {boost:.1f}% ({eff:.2f} conn) + {extra_t} extra pure-CPU threads")
+        else:
+            logger.info(f"  Phase {i+1}: {d}s, legacy {t} threads, {duty*100:.0f}% duty, pure_cpu={pure}, extra={extra_t}")
+
+    conn_params = get_conn_params()
+    schema_ready = ensure_pgbench_schema(conn_params, scale=10)
+
+    def choose_legacy_worker_fn(pure_cpu_flag):
+        if pure_cpu_flag:
+            return pure_cpu_staged_worker
+        return tpcb_staged_worker if schema_ready else generate_series_staged_worker
+
+    phase_starts = []
+    cumulative = 0
+    for d in durations:
+        phase_starts.append(cumulative)
+        cumulative += d
+
+    now = time.time()
+    all_threads = []
+    all_results = []
+
+    for phase_i in range(len(durations)):
+        phase_start_abs = now + phase_starts[phase_i]
+        phase_end_abs = now + phase_starts[phase_i] + durations[phase_i]
+        target_pct = phase_targets[phase_i] if phase_i < len(phase_targets) else None
+
+        num_threads = phase_threads[phase_i]
+        duty = phase_duty[phase_i]
+        pure_cpu = phase_pure_cpu[phase_i] if phase_i < len(phase_pure_cpu) else False
+        worker_fn = choose_legacy_worker_fn(pure_cpu)
+
+        extra_effective = 0.0
+        if target_pct is not None:
+            extra_pct = max(0.0, target_pct - baseline_pct)
+            extra_effective = extra_pct / 100.0 * vcpus
+
+        full_extra = int(extra_effective)
+        fractional_extra = extra_effective - full_extra
+        num_extra = full_extra + (1 if fractional_extra > 0.01 else 0)
+        extra_threads_this_phase = phase_extra_threads[phase_i] if phase_i < len(phase_extra_threads) else 0
+        total_workers = num_threads + num_extra + extra_threads_this_phase
+
+        results_slot = [None] * total_workers
+        all_results.append(results_slot)
+
+        for j in range(num_threads):
+            if pure_cpu:
+                t = threading.Thread(
+                    target=worker_fn,
+                    args=(conn_params, phase_i + 1, phase_start_abs, phase_end_abs, duty, pure_cpu_series_count, pure_cpu_queries_per_loop, results_slot, j),
+                )
+            else:
+                t = threading.Thread(
+                    target=worker_fn,
+                    args=(conn_params, phase_i + 1, phase_start_abs, phase_end_abs, duty, results_slot, j),
+                )
+            t.daemon = True
+            t.start()
+            all_threads.append(t)
+
+        for j in range(full_extra):
+            t = threading.Thread(
+                target=controlled_full_worker,
+                args=(conn_params, phase_start_abs, phase_end_abs, pure_cpu_series_count, results_slot, num_threads + j),
+            )
+            t.daemon = True
+            t.start()
+            all_threads.append(t)
+
+        if fractional_extra > 0.01:
+            t = threading.Thread(
+                target=controlled_duty_worker,
+                args=(conn_params, phase_start_abs, phase_end_abs, pure_cpu_series_count, fractional_extra, results_slot, num_threads + full_extra),
+            )
+            t.daemon = True
+            t.start()
+            all_threads.append(t)
+
+        for j in range(extra_threads_this_phase):
+            t = threading.Thread(
+                target=controlled_full_worker,
+                args=(conn_params, phase_start_abs, phase_end_abs, pure_cpu_series_count, results_slot, num_threads + num_extra + j),
+            )
+            t.daemon = True
+            t.start()
+            all_threads.append(t)
+
+        logger.info(
+            f"Phase {phase_i+1}: scheduled {num_threads} legacy + {num_extra} boost + {extra_threads_this_phase} extra workers, "
+            f"target={target_pct}%, baseline={baseline_pct}%, boost={extra_effective:.2f} effective"
+        )
+
+    total_duration = sum(durations)
+    for t in all_threads:
+        t.join(timeout=total_duration + 60)
+
+    total_ops = 0
+    errors = []
+    phase_results = []
+    for phase_i, results_slot in enumerate(all_results):
+        phase_ops = sum((r.get("transactions", 0) + r.get("queries", 0)) for r in results_slot if r) if results_slot else 0
+        phase_errors = [r["error"] for r in results_slot if r and "error" in r]
+        total_ops += phase_ops
+        errors.extend(phase_errors)
+        result = {
+            "phase": phase_i + 1,
+            "duration_s": durations[phase_i],
+            "operations": phase_ops,
+            "errors": len(phase_errors),
+        }
+        if phase_i < len(phase_targets) and phase_targets[phase_i] is not None:
+            result["mode"] = "tpcb_plus_boost" if not phase_pure_cpu[phase_i] else "legacy_plus_boost"
+            result["target_cpu_pct"] = phase_targets[phase_i]
+            result["baseline_cpu_pct"] = baseline_pct
+            result["threads"] = phase_threads[phase_i]
+            result["duty_cycle"] = phase_duty[phase_i]
+            result["pure_cpu_legacy"] = phase_pure_cpu[phase_i] if phase_i < len(phase_pure_cpu) else False
+            result["boost_effective_connections"] = max(0.0, (phase_targets[phase_i] - baseline_pct) / 100.0 * vcpus)
+            result["extra_pure_cpu_threads"] = phase_extra_threads[phase_i] if phase_i < len(phase_extra_threads) else 0
+        else:
+            result["mode"] = "tpcb_like" if not phase_pure_cpu[phase_i] else "pure_cpu_legacy"
+            result["threads"] = phase_threads[phase_i]
+            result["duty_cycle"] = phase_duty[phase_i]
+            result["pure_cpu"] = phase_pure_cpu[phase_i] if phase_i < len(phase_pure_cpu) else False
+            result["extra_pure_cpu_threads"] = phase_extra_threads[phase_i] if phase_i < len(phase_extra_threads) else 0
+        phase_results.append(result)
+
+    phase_modes = {
+        phase_results[i]["mode"]
+        for i in range(len(phase_results))
+    }
+    overall_mode = "mixed" if len(phase_modes) > 1 else (next(iter(phase_modes)) if phase_modes else "unknown")
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps({
+            "stress_type": stress_type,
+            "mode": overall_mode,
+            "total_operations": total_ops,
+            "pure_cpu_series_count": pure_cpu_series_count,
+            "elapsed_seconds": total_duration,
+            "phases": phase_results,
+            "error_count": len(errors),
+            "errors": errors[:10],
+        }),
+    }

--- a/terraform/aws/modules/composition/aurora-fault-injection/src/stress_test/memory_stress.py
+++ b/terraform/aws/modules/composition/aurora-fault-injection/src/stress_test/memory_stress.py
@@ -1,0 +1,271 @@
+import os
+import time
+import logging
+import json
+import psycopg2
+import threading
+from common import get_conn_params
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def parse_csv(env_var, default, cast=int):
+    val = os.environ.get(env_var, default)
+    return [cast(x) for x in val.split(",")]
+
+
+def hold_temp_buffers_worker(conn_params, temp_buffers_mb, work_mem_mb, temp_rows, hold_duration, results, idx):
+    conn = None
+    try:
+        conn = psycopg2.connect(**conn_params)
+        conn.autocommit = True
+        cursor = conn.cursor()
+
+        cursor.execute("SET max_parallel_workers_per_gather = 0")
+        cursor.execute(f"SET temp_buffers = '{temp_buffers_mb}MB'")
+        cursor.execute(f"SET work_mem = '{work_mem_mb}MB'")
+
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS memory_stress_pin (
+                id serial PRIMARY KEY,
+                worker integer,
+                tstamp timestamp default now()
+            )
+        """)
+        cursor.execute("INSERT INTO memory_stress_pin (worker) VALUES (%s)", (idx,))
+
+        cursor.execute(f"""
+            CREATE TEMP TABLE mem_hog_{idx} AS
+            SELECT generate_series(1, {temp_rows}) AS n, repeat('x', 80) AS payload
+        """)
+        cursor.execute(f"SELECT pg_size_pretty(pg_total_relation_size('mem_hog_{idx}'))")
+        size = cursor.fetchone()[0]
+
+        results[idx] = {"status": "holding", "temp_size": size, "temp_buffers_mb": temp_buffers_mb}
+        logger.info(f"Worker {idx}: temp table created ({size}), holding for {hold_duration}s")
+
+        cursor.execute(f"SELECT pg_sleep({hold_duration})")
+
+        cursor.execute(f"DROP TABLE IF EXISTS mem_hog_{idx}")
+        cursor.close()
+    except Exception as e:
+        logger.error(f"Temp buffer worker {idx} error: {e}")
+        results[idx] = {"status": "error", "error": str(e)}
+    finally:
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
+def array_agg_worker(conn_params, agg_rows, arrays_per_worker, work_mem_mb, hold_duration, results, idx):
+    conn = None
+    try:
+        conn = psycopg2.connect(**conn_params)
+        conn.autocommit = True
+        cursor = conn.cursor()
+
+        cursor.execute("SET max_parallel_workers_per_gather = 0")
+        cursor.execute(f"SET work_mem = '{work_mem_mb}MB'")
+
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS memory_stress_pin (
+                id serial PRIMARY KEY,
+                worker integer,
+                tstamp timestamp default now()
+            )
+        """)
+        cursor.execute("INSERT INTO memory_stress_pin (worker) VALUES (%s)", (idx,))
+
+        logger.info(f"Worker {idx}: building {arrays_per_worker} arrays of {agg_rows} elements each...")
+        array_vars = ", ".join(f"big_arr_{i} text[]" for i in range(arrays_per_worker))
+        array_builds = "\n".join(
+            f"SELECT array_agg(md5(random()::text)) INTO big_arr_{i} FROM generate_series(1, {agg_rows});"
+            for i in range(arrays_per_worker)
+        )
+        cursor.execute(f"""
+            DO $$
+            DECLARE
+                {array_vars}
+            BEGIN
+                {array_builds}
+                RAISE NOTICE 'Worker {idx} done: {arrays_per_worker} arrays held, sleeping...';
+                PERFORM pg_sleep({hold_duration});
+            END $$;
+        """)
+        results[idx] = {"status": "complete", "agg_rows": agg_rows, "arrays_per_worker": arrays_per_worker}
+        cursor.close()
+    except Exception as e:
+        logger.error(f"Array agg worker {idx} error: {e}")
+        results[idx] = {"status": "error", "error": str(e)}
+    finally:
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
+def lambda_handler(event, context):
+    durations_raw = os.environ.get("MEM_PHASE_DURATIONS", os.environ.get("PHASE_DURATIONS", "240,300,300"))
+    durations = [int(x.strip()) for x in durations_raw.split(",")]
+    phase_idle = parse_csv("MEM_PHASE_IDLE", "50,150,300", int)
+    phase_sort = parse_csv("MEM_PHASE_SORT", "5,10,20", int)
+    phase_temp_mb = parse_csv("MEM_PHASE_TEMP_MB", "256,512,1024", int)
+    phase_agg_rows = parse_csv("MEM_PHASE_AGG_ROWS", "5000000,10000000,20000000", int)
+    work_mem_mb = int(os.environ.get("MEM_WORK_MEM_MB", "512"))
+    agg_rows_max = int(os.environ.get("MEM_AGG_ROWS_MAX", "20000000"))
+    arrays_per_worker = int(os.environ.get("MEM_ARRAYS_PER_WORKER", "3"))
+    temp_rows_max = int(os.environ.get("MEM_TEMP_ROWS_MAX", "5000000"))
+    stress_type = os.environ.get("STRESS_TYPE", "memory_stress")
+
+    total_duration = sum(durations)
+    logger.info(f"Staged memory stress: {len(durations)} phases, {total_duration}s total")
+    logger.info(f"work_mem={work_mem_mb}MB, agg_rows_max={agg_rows_max}, arrays_per_worker={arrays_per_worker}, temp_rows_max={temp_rows_max}")
+    for i in range(len(durations)):
+        logger.info(
+            f"  Phase {i+1}: {durations[i]}s, "
+            f"idle={phase_idle[i]}, sort={phase_sort[i]}, "
+            f"temp={phase_temp_mb[i]}MB, agg_rows={phase_agg_rows[i]}, arrays={arrays_per_worker}"
+        )
+
+    conn_params = get_conn_params()
+
+    all_idle_conns = []
+    all_threads = []
+    all_results = []
+
+    phase_starts = []
+    cumulative = 0
+    for d in durations:
+        phase_starts.append(cumulative)
+        cumulative += d
+
+    now = time.time()
+    prev_idle = 0
+    prev_sort = 0
+
+    for phase_i in range(len(durations)):
+        phase_start_abs = now + phase_starts[phase_i]
+        remaining_hold = total_duration - phase_starts[phase_i]
+
+        target_idle = phase_idle[phase_i]
+        target_sort = phase_sort[phase_i]
+        new_idle = target_idle - prev_idle
+        new_sort = target_sort - prev_sort
+
+        time.sleep(max(0, phase_start_abs - time.time()))
+        logger.info(
+            f"Phase {phase_i+1} starting: +{new_idle} idle conns (total {target_idle}), "
+            f"+{new_sort} sort sessions (total {target_sort})"
+        )
+
+        for _ in range(new_idle):
+            try:
+                conn = psycopg2.connect(**conn_params)
+                all_idle_conns.append(conn)
+            except psycopg2.Error as e:
+                logger.warning(f"Idle conn failed: {e}")
+
+        results_slot = [None] * (new_sort * 2)
+        all_results.append(results_slot)
+
+        for j in range(new_sort):
+            temp_mb = phase_temp_mb[phase_i]
+            temp_rows = min(phase_agg_rows[phase_i], temp_rows_max)
+            t = threading.Thread(
+                target=hold_temp_buffers_worker,
+                args=(conn_params, temp_mb, work_mem_mb, temp_rows, remaining_hold, results_slot, j),
+            )
+            t.daemon = True
+            t.start()
+            all_threads.append(t)
+
+        for j in range(new_sort):
+            agg_rows = min(phase_agg_rows[phase_i], agg_rows_max)
+            t = threading.Thread(
+                target=array_agg_worker,
+                args=(conn_params, agg_rows, arrays_per_worker, work_mem_mb, remaining_hold, results_slot, new_sort + j),
+            )
+            t.daemon = True
+            t.start()
+            all_threads.append(t)
+
+        logger.info(f"Phase {phase_i+1}: started {new_sort} temp_buffer + {new_sort} array_agg workers")
+        prev_idle = target_idle
+        prev_sort = target_sort
+
+    logger.info(f"All phases launched. Waiting for {total_duration}s total duration...")
+
+    for t in all_threads:
+        t.join(timeout=total_duration + 60)
+
+    for conn in all_idle_conns:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    total_temp_ok = 0
+    total_temp_err = 0
+    total_agg_ok = 0
+    total_agg_err = 0
+    phase_results = []
+
+    for phase_i, results_slot in enumerate(all_results):
+        sort_count = phase_sort[phase_i] - (phase_sort[phase_i - 1] if phase_i > 0 else 0)
+        temp_ok = sum(
+            1 for r in results_slot[:sort_count]
+            if r and r.get("status") in ("holding", "complete")
+        )
+        temp_err = sum(
+            1 for r in results_slot[:sort_count]
+            if r and r.get("status") == "error"
+        )
+        agg_ok = sum(
+            1 for r in results_slot[sort_count:]
+            if r and r.get("status") in ("holding", "complete")
+        )
+        agg_err = sum(
+            1 for r in results_slot[sort_count:]
+            if r and r.get("status") == "error"
+        )
+        total_temp_ok += temp_ok
+        total_temp_err += temp_err
+        total_agg_ok += agg_ok
+        total_agg_err += agg_err
+        phase_results.append({
+            "phase": phase_i + 1,
+            "idle_conns_total": phase_idle[phase_i],
+            "sort_sessions_total": phase_sort[phase_i],
+            "temp_buffer_ok": temp_ok,
+            "temp_buffer_err": temp_err,
+            "array_agg_ok": agg_ok,
+            "array_agg_err": agg_err,
+        })
+
+    temp_mem_gb = round(
+        sum(total_temp_ok * mb for mb in phase_temp_mb) / 1024, 1
+    )
+    agg_mem_gb = round(
+        sum(total_agg_ok * rows * 40 for rows in phase_agg_rows) / (1024 ** 3), 1
+    )
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps({
+            "stress_type": stress_type,
+            "idle_connections_held": len(all_idle_conns),
+            "temp_buffer_sessions_ok": total_temp_ok,
+            "temp_buffer_errors": total_temp_err,
+            "array_agg_sessions_ok": total_agg_ok,
+            "array_agg_errors": total_agg_err,
+            "temp_memory_gb": temp_mem_gb,
+            "array_agg_memory_gb": agg_mem_gb,
+            "total_potential_memory_gb": round(temp_mem_gb + agg_mem_gb, 1),
+            "elapsed_seconds": total_duration,
+            "phases": phase_results,
+        }),
+    }

--- a/terraform/aws/modules/composition/aurora-fault-injection/variables.tf
+++ b/terraform/aws/modules/composition/aurora-fault-injection/variables.tf
@@ -1,0 +1,354 @@
+# ============================================================================
+# Aurora Fault Injection Module - Variables
+# ============================================================================
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment short name for resource naming (e.g., sbx, prod)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for resource naming and tagging"
+  type        = string
+  default     = ""
+}
+
+# ============================================================================
+# Database Connection
+# ============================================================================
+
+variable "db_endpoint" {
+  description = "Aurora PostgreSQL writer endpoint (cluster endpoint)"
+  type        = string
+}
+
+variable "db_port" {
+  description = "Database port"
+  type        = number
+  default     = 5432
+}
+
+variable "db_name" {
+  description = "Database name"
+  type        = string
+  default     = "postgres"
+}
+
+variable "db_username" {
+  description = "Master database username"
+  type        = string
+  default     = "postgres"
+}
+
+variable "db_password" {
+  description = "Master database password (will be stored in Secrets Manager, KMS-encrypted)"
+  type        = string
+  sensitive   = true
+}
+
+# ============================================================================
+# VPC Configuration
+# ============================================================================
+
+variable "vpc_id" {
+  description = "VPC ID where Lambda functions will be deployed"
+  type        = string
+}
+
+variable "lambda_subnet_ids" {
+  description = "List of subnet IDs for Lambda VPC config (use lambda subnets, not DB subnets)"
+  type        = list(string)
+}
+
+# ============================================================================
+# Security Group
+# ============================================================================
+
+variable "create_security_group" {
+  description = "Create a dedicated security group for Lambda. If false, provide lambda_security_group_id (e.g., reuse jump host SG)"
+  type        = bool
+  default     = false
+}
+
+variable "lambda_security_group_id" {
+  description = "Existing security group ID for Lambda (required when create_security_group = false). E.g., jump host internal SG"
+  type        = string
+  default     = ""
+}
+
+variable "db_security_group_id" {
+  description = "Database security group ID (required when create_security_group = true, to add ingress rule for port 5432)"
+  type        = string
+  default     = ""
+}
+
+# ============================================================================
+# KMS Key
+# ============================================================================
+
+variable "kms_key_alias" {
+  description = "Alias for the KMS key used to encrypt Secrets Manager secret"
+  type        = string
+  default     = ""
+}
+
+# ============================================================================
+# Secrets Manager
+# ============================================================================
+
+variable "secret_name" {
+  description = "Name of the Secrets Manager secret for DB credentials"
+  type        = string
+  default     = ""
+}
+
+variable "create_secret" {
+  description = "Create a new Secrets Manager secret. If false, looks up an existing secret by secret_name. The existing secret must contain JSON with: username, password, host, port, dbname"
+  type        = bool
+  default     = true
+}
+
+# ============================================================================
+# Lambda Configuration
+# ============================================================================
+
+variable "lambda_runtime" {
+  description = "Lambda runtime (must match compatible_runtimes of the psycopg2 layer)"
+  type        = string
+  default     = "python3.11"
+}
+
+variable "lambda_layers" {
+  description = "List of Lambda layer ARNs (e.g., existing psycopg2-python311 layer)"
+  type        = list(string)
+  default     = []
+}
+
+variable "lambda_timeout" {
+  description = "Lambda timeout in seconds"
+  type        = number
+  default     = 30
+}
+
+variable "lambda_memory_size" {
+  description = "Lambda memory size in MB"
+  type        = number
+  default     = 256
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch log group retention in days"
+  type        = number
+  default     = 14
+}
+
+# ============================================================================
+# Tags
+# ============================================================================
+
+variable "tags" {
+  description = "Additional tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+# ============================================================================
+# Stress Test Configuration
+# ============================================================================
+
+variable "enable_stress_tests" {
+  description = "Deploy stress test Lambda functions (cpu_stress, memory_stress, connection_exhaustion)"
+  type        = bool
+  default     = false
+}
+
+variable "stress_lambda_timeout" {
+  description = "Lambda timeout in seconds for stress test functions (max 900)"
+  type        = number
+  default     = 900
+}
+
+variable "stress_lambda_memory_size" {
+  description = "Lambda memory size in MB for stress test functions"
+  type        = number
+  default     = 512
+}
+
+variable "stress_duration" {
+  description = "Default stress test duration in seconds"
+  type        = number
+  default     = 300
+}
+
+variable "stress_clients" {
+  description = "Default number of concurrent clients/connections for stress tests"
+  type        = number
+  default     = 50
+}
+
+variable "stress_threads" {
+  description = "Default number of worker threads for stress tests"
+  type        = number
+  default     = 4
+}
+
+variable "sort_connections" {
+  description = "Number of concurrent sort connections for memory stress test"
+  type        = number
+  default     = 10
+}
+
+variable "sort_work_mem_mb" {
+  description = "work_mem setting in MB for each sort connection in memory stress test"
+  type        = number
+  default     = 512
+}
+
+variable "sort_rows" {
+  description = "Number of rows to generate and sort in each memory stress iteration"
+  type        = number
+  default     = 10000000
+}
+
+variable "phase_durations" {
+  description = "Comma-separated phase durations in seconds (e.g. 240,300,300 = 4min+5min+5min)"
+  type        = string
+  default     = "240,300,300"
+}
+
+variable "cpu_phase_threads" {
+  description = "Comma-separated thread count per CPU stress phase (e.g. 2,2,16)"
+  type        = string
+  default     = "2,2,16"
+}
+
+variable "cpu_phase_duty" {
+  description = "Comma-separated duty cycles per CPU stress phase (e.g. 0.6,0.8,1.0)"
+  type        = string
+  default     = "0.6,0.8,1.0"
+}
+
+variable "cpu_phase_pure_cpu" {
+  description = "Comma-separated booleans per CPU stress phase. When true, the phase uses a read-only generate_series CPU-burn query instead of TPC-B writes (e.g. false,false,true)"
+  type        = string
+  default     = "false,false,true"
+}
+
+variable "cpu_phase_targets" {
+  description = "Comma-separated target CPU percentages per phase. When set, active connection count is used instead of threads/duty (e.g. 70,75,80). Formula: effective_connections = target_pct/100 * cpu_vcpus."
+  type        = string
+  default     = ""
+}
+
+variable "cpu_vcpus" {
+  description = "Number of vCPUs on the Aurora instance. Used to compute active connection count when cpu_phase_targets is set."
+  type        = number
+  default     = 4
+}
+
+variable "cpu_phase_baseline_pct" {
+  description = "Estimated CPU percentage consumed by the TPC-B workload alone. When cpu_phase_targets is set, the boost is computed as target - baseline."
+  type        = number
+  default     = 87.0
+}
+
+variable "cpu_phase_extra_threads" {
+  description = "Comma-separated extra pure-CPU worker threads per phase, added on top of TPC-B and target-boost workers (e.g. 0,1,3)."
+  type        = string
+  default     = "0,0,0"
+}
+
+variable "cpu_pure_cpu_series_count" {
+  description = "Number of rows for the pure-CPU generate_series query in pure_cpu phases. Smaller rows with more queries per loop keeps the DB pipeline full."
+  type        = number
+  default     = 1000000
+}
+
+variable "cpu_pure_cpu_queries_per_loop" {
+  description = "Number of pure-CPU queries to issue back-to-back before duty-cycle sleep. Higher values keep the CPU pipeline fuller."
+  type        = number
+  default     = 10
+}
+
+variable "mem_phase_idle" {
+  description = "Comma-separated cumulative idle connection counts per memory stress phase (e.g. 50,150,300)"
+  type        = string
+  default     = "50,150,300"
+}
+
+variable "mem_phase_sort" {
+  description = "Comma-separated cumulative sort session counts per memory stress phase (e.g. 5,10,20)"
+  type        = string
+  default     = "5,10,20"
+}
+
+variable "mem_phase_temp_mb" {
+  description = "Comma-separated temp_buffers MB per memory stress phase (e.g. 256,512,1024)"
+  type        = string
+  default     = "256,512,1024"
+}
+
+variable "mem_phase_agg_rows" {
+  description = "Comma-separated array_agg row counts per memory stress phase (e.g. 5000000,10000000,20000000)"
+  type        = string
+  default     = "5000000,10000000,20000000"
+}
+
+variable "mem_phase_durations" {
+  description = "Comma-separated memory stress phase durations in seconds. Defaults to PHASE_DURATIONS if unset."
+  type        = string
+  default     = ""
+}
+
+variable "mem_work_mem_mb" {
+  description = "work_mem in MB for each memory stress worker session. Higher values force more in-memory operations and pressure shared resources."
+  type        = number
+  default     = 512
+}
+
+variable "mem_agg_rows_max" {
+  description = "Maximum array_agg rows per worker. Raise to build larger in-memory arrays."
+  type        = number
+  default     = 20000000
+}
+
+variable "mem_arrays_per_worker" {
+  description = "Number of large arrays each worker holds simultaneously. Higher values consume memory faster."
+  type        = number
+  default     = 3
+}
+
+variable "mem_temp_rows_max" {
+  description = "Maximum rows per temp table worker. Larger temp tables consume more temp_buffers memory."
+  type        = number
+  default     = 5000000
+}
+
+variable "conn_phase_threads" {
+  description = "Comma-separated cumulative thread counts per connection exhaustion phase (e.g. 20,40,56)"
+  type        = string
+  default     = "20,40,56"
+}
+
+variable "conn_batch_size" {
+  description = "Connections per thread per batch in connection exhaustion test"
+  type        = number
+  default     = 30
+}
+
+variable "conn_hold_seconds" {
+  description = "Seconds to hold connections before closing in connection exhaustion test"
+  type        = number
+  default     = 5
+}
+
+variable "conn_ramp_seconds" {
+  description = "Seconds over which each worker spreads its connection openings to avoid a steep spike"
+  type        = number
+  default     = 60
+}

--- a/terraform/aws/modules/composition/aurora-fault-injection/versions.tf
+++ b/terraform/aws/modules/composition/aurora-fault-injection/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">= 2.4"
+    }
+  }
+}

--- a/terraform/aws/modules/composition/elasticache-stress-test/README.md
+++ b/terraform/aws/modules/composition/elasticache-stress-test/README.md
@@ -59,3 +59,115 @@ module "elasticache_stress_test" {
 - `workload_emit_cloudwatch_metrics` — emit custom CloudWatch metrics per phase
 
 See `variables.tf` for the full input list and `outputs.tf` for emitted function names and ARNs.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.4 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | >= 2.4 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.stress_test](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_iam_role.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.cloudwatch_metrics](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.elasticache_failover](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.lambda_invoke_worker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.lambda_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.lambda_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_lambda_function.stress_test](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_security_group.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.redis_ingress_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [archive_file.stress_test_code](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_connection_batch_size"></a> [connection\_batch\_size](#input\_connection\_batch\_size) | Number of raw TCP sockets opened per batch per worker in connection exhaustion test | `number` | `100` | no |
+| <a name="input_connection_rapid_churn"></a> [connection\_rapid\_churn](#input\_connection\_rapid\_churn) | If true, after reaching connection\_target\_total workers churn (open/handshake/close) while holding the pool | `bool` | `false` | no |
+| <a name="input_connection_target"></a> [connection\_target](#input\_connection\_target) | Target number of concurrent connections for connection exhaustion test (legacy; prefer connection\_target\_total) | `number` | `1000` | no |
+| <a name="input_connection_target_total"></a> [connection\_target\_total](#input\_connection\_target\_total) | Total number of held connections across all workers before switching to churn mode | `number` | `850` | no |
+| <a name="input_connection_threads"></a> [connection\_threads](#input\_connection\_threads) | Number of worker threads for connection exhaustion test | `number` | `48` | no |
+| <a name="input_cpu_burn_iterations"></a> [cpu\_burn\_iterations](#input\_cpu\_burn\_iterations) | Number of Lua iterations in the CPU stress script (default 500k ≈ 20-50ms on cache.m6g.large) | `number` | `500000` | no |
+| <a name="input_cpu_mixed_mode"></a> [cpu\_mixed\_mode](#input\_cpu\_mixed\_mode) | If true, CPU stress mixes SET/GET/INCR with Lua burn. If false, runs pure Lua burn (higher EngineCPU). | `bool` | `false` | no |
+| <a name="input_cpu_phase_cycle_period_seconds"></a> [cpu\_phase\_cycle\_period\_seconds](#input\_cpu\_phase\_cycle\_period\_seconds) | Max random startup jitter in seconds for CPU stress workers (e.g. 2). Small jitter is enough when per-cycle jitter is also applied; large jitter distorts 1-minute CloudWatch averages. | `number` | `2` | no |
+| <a name="input_cpu_phase_durations"></a> [cpu\_phase\_durations](#input\_cpu\_phase\_durations) | Comma-separated phase durations in seconds for staged CPU stress (e.g. 60,300,300 = 1min warmup + 5min + 5min) | `string` | `"60,180,180"` | no |
+| <a name="input_cpu_phase_duty"></a> [cpu\_phase\_duty](#input\_cpu\_phase\_duty) | Comma-separated duty cycles per CPU stress phase (e.g. 0.97,0.98,1.0). Values <1.0 throttle the aggregate offered load so EngineCPU stays below 100%. | `string` | `"0.97,0.98,1.0"` | no |
+| <a name="input_cpu_phase_threads"></a> [cpu\_phase\_threads](#input\_cpu\_phase\_threads) | Comma-separated thread counts per CPU stress phase (e.g. 8,8,8). With the linear D/N duty model, 8 threads is usually enough for a smooth 90-97% EngineCPU plateau. | `string` | `"8,8,8"` | no |
+| <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Create a dedicated security group for Lambda. If false, provide lambda\_security\_group\_id (e.g., reuse jump host SG) | `bool` | `false` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment short name for resource naming (e.g., sbx, prod) | `string` | n/a | yes |
+| <a name="input_failover_poll_interval_seconds"></a> [failover\_poll\_interval\_seconds](#input\_failover\_poll\_interval\_seconds) | Polling interval in seconds between describe\_replication\_groups calls during failover recovery | `number` | `15` | no |
+| <a name="input_failover_timeout_seconds"></a> [failover\_timeout\_seconds](#input\_failover\_timeout\_seconds) | Maximum time in seconds to wait for the replication group to return to available after TestFailover | `number` | `600` | no |
+| <a name="input_key_prefix"></a> [key\_prefix](#input\_key\_prefix) | Prefix for all keys created by stress tests (used by cleanup function) | `string` | `"stress:test:"` | no |
+| <a name="input_lambda_layers"></a> [lambda\_layers](#input\_lambda\_layers) | List of Lambda layer ARNs (e.g., existing redis-py-python311 layer) | `list(string)` | `[]` | no |
+| <a name="input_lambda_memory_size"></a> [lambda\_memory\_size](#input\_lambda\_memory\_size) | Lambda memory size in MB for stress test functions | `number` | `512` | no |
+| <a name="input_lambda_runtime"></a> [lambda\_runtime](#input\_lambda\_runtime) | Lambda runtime (must match compatible\_runtimes of the redis-py layer) | `string` | `"python3.11"` | no |
+| <a name="input_lambda_security_group_id"></a> [lambda\_security\_group\_id](#input\_lambda\_security\_group\_id) | Existing security group ID for Lambda (required when create\_security\_group = false) | `string` | `""` | no |
+| <a name="input_lambda_subnet_ids"></a> [lambda\_subnet\_ids](#input\_lambda\_subnet\_ids) | List of subnet IDs for Lambda VPC config (use lambda subnets) | `list(string)` | n/a | yes |
+| <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | Lambda timeout in seconds for stress test functions (max 900) | `number` | `900` | no |
+| <a name="input_log_retention_days"></a> [log\_retention\_days](#input\_log\_retention\_days) | CloudWatch log group retention in days | `number` | `14` | no |
+| <a name="input_memory_cleanup_after_stress"></a> [memory\_cleanup\_after\_stress](#input\_memory\_cleanup\_after\_stress) | If true, memory\_stress automatically unlinks all stress keys before returning | `bool` | `true` | no |
+| <a name="input_memory_key_count"></a> [memory\_key\_count](#input\_memory\_key\_count) | Number of keys to write for memory stress test (legacy; prefer memory\_keys\_per\_worker) | `number` | `10000` | no |
+| <a name="input_memory_keys_per_worker"></a> [memory\_keys\_per\_worker](#input\_memory\_keys\_per\_worker) | Number of keys each memory stress worker writes before stopping | `number` | `5000` | no |
+| <a name="input_memory_phase_durations"></a> [memory\_phase\_durations](#input\_memory\_phase\_durations) | Comma-separated phase durations in seconds for staged memory stress (e.g. 240,240,240) | `string` | `"240,240,240"` | no |
+| <a name="input_memory_phase_target_percent"></a> [memory\_phase\_target\_percent](#input\_memory\_phase\_target\_percent) | Comma-separated target used\_memory percentages of maxmemory per memory stress phase (e.g. 60,85,100) | `string` | `"60,85,100"` | no |
+| <a name="input_memory_phase_workers"></a> [memory\_phase\_workers](#input\_memory\_phase\_workers) | Comma-separated writer counts per memory stress phase (e.g. 8,12,24) | `string` | `"8,12,24"` | no |
+| <a name="input_memory_pipeline_size"></a> [memory\_pipeline\_size](#input\_memory\_pipeline\_size) | Number of SET commands per pipeline batch in memory stress test | `number` | `5` | no |
+| <a name="input_memory_value_size_kb"></a> [memory\_value\_size\_kb](#input\_memory\_value\_size\_kb) | Size of each value in KB for memory stress test | `number` | `4096` | no |
+| <a name="input_memory_workers"></a> [memory\_workers](#input\_memory\_workers) | Number of per-worker threads (each with its own redis client) for memory stress test | `number` | `24` | no |
+| <a name="input_memory_write_ttl"></a> [memory\_write\_ttl](#input\_memory\_write\_ttl) | TTL in seconds for memory stress keys (0 = no TTL, keys persist until eviction or cleanup) | `number` | `0` | no |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name for resource naming and tagging | `string` | `""` | no |
+| <a name="input_redis_auth_token"></a> [redis\_auth\_token](#input\_redis\_auth\_token) | AUTH token for Redis (if enabled). Leave empty for no AUTH. | `string` | `""` | no |
+| <a name="input_redis_cluster_mode"></a> [redis\_cluster\_mode](#input\_redis\_cluster\_mode) | Whether Redis has cluster mode enabled. If true, uses redis.cluster.RedisCluster client connecting to configuration endpoint. If false, uses redis.Redis client connecting to primary endpoint. | `bool` | `true` | no |
+| <a name="input_redis_endpoint"></a> [redis\_endpoint](#input\_redis\_endpoint) | Elasticache Redis/Valkey endpoint (configuration endpoint for cluster mode, primary endpoint for standalone) | `string` | n/a | yes |
+| <a name="input_redis_node_group_id"></a> [redis\_node\_group\_id](#input\_redis\_node\_group\_id) | ElastiCache node group / shard ID for the failover Lambda (e.g., 0001) | `string` | `"0001"` | no |
+| <a name="input_redis_port"></a> [redis\_port](#input\_redis\_port) | Redis/Valkey port | `number` | `6379` | no |
+| <a name="input_redis_replication_group_id"></a> [redis\_replication\_group\_id](#input\_redis\_replication\_group\_id) | ElastiCache replication group ID for the failover Lambda (TestFailover API) | `string` | `""` | no |
+| <a name="input_redis_security_group_id"></a> [redis\_security\_group\_id](#input\_redis\_security\_group\_id) | Redis security group ID (required when create\_security\_group = true, to add ingress rule for port 6379) | `string` | `""` | no |
+| <a name="input_redis_use_tls"></a> [redis\_use\_tls](#input\_redis\_use\_tls) | Whether Redis has TLS enabled (transit\_encryption\_enabled) | `bool` | `false` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS region | `string` | n/a | yes |
+| <a name="input_stress_clients"></a> [stress\_clients](#input\_stress\_clients) | Default number of concurrent clients/connections for stress tests | `number` | `50` | no |
+| <a name="input_stress_duration"></a> [stress\_duration](#input\_stress\_duration) | Default stress test duration in seconds | `number` | `300` | no |
+| <a name="input_stress_threads"></a> [stress\_threads](#input\_stress\_threads) | Default number of worker threads for stress tests | `number` | `4` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID where Lambda functions will be deployed | `string` | n/a | yes |
+| <a name="input_workload_command_mix"></a> [workload\_command\_mix](#input\_workload\_command\_mix) | Command mix for mixed workload stress as command:weight pairs (e.g. get:60,set:20,hget:10,hset:5,incr:5). Weights are normalised by their total. | `string` | `"get:60,set:20,hget:10,hset:5,incr:5"` | no |
+| <a name="input_workload_emit_cloudwatch_metrics"></a> [workload\_emit\_cloudwatch\_metrics](#input\_workload\_emit\_cloudwatch\_metrics) | If true, mixed workload stress emits custom CloudWatch metrics (Operations, Errors, P50Latency, P99Latency) per phase | `bool` | `false` | no |
+| <a name="input_workload_key_count"></a> [workload\_key\_count](#input\_workload\_key\_count) | Upper bound for random key ID selection in mixed workload stress (keys are in [0, workload\_key\_count)) | `number` | `100000` | no |
+| <a name="input_workload_key_pattern"></a> [workload\_key\_pattern](#input\_workload\_key\_pattern) | Key pattern for mixed workload stress. Use {id} as placeholder for random integer in [0, workload\_key\_count) | `string` | `"stress:test:{id}"` | no |
+| <a name="input_workload_phase_cycle_period_seconds"></a> [workload\_phase\_cycle\_period\_seconds](#input\_workload\_phase\_cycle\_period\_seconds) | Max random startup jitter in seconds for mixed workload workers (desynchronises thread send schedules) | `number` | `2` | no |
+| <a name="input_workload_phase_durations"></a> [workload\_phase\_durations](#input\_workload\_phase\_durations) | Comma-separated phase durations in seconds for mixed workload stress (e.g. 60,180,180) | `string` | `"60,180,180"` | no |
+| <a name="input_workload_phase_ops_per_sec"></a> [workload\_phase\_ops\_per\_sec](#input\_workload\_phase\_ops\_per\_sec) | Comma-separated target total ops/sec per mixed workload phase (e.g. 20000,35000,45000) | `string` | `"20000,35000,45000"` | no |
+| <a name="input_workload_pipeline_size"></a> [workload\_pipeline\_size](#input\_workload\_pipeline\_size) | Number of commands per pipeline batch in mixed workload stress (1 = no pipelining) | `number` | `1` | no |
+| <a name="input_workload_threads"></a> [workload\_threads](#input\_workload\_threads) | Number of worker threads for mixed workload stress (each with its own Redis client). Dedicated knob so the generator can scale independently of other stress types. | `number` | `32` | no |
+| <a name="input_workload_value_size_bytes"></a> [workload\_value\_size\_bytes](#input\_workload\_value\_size\_bytes) | Size of random byte string values for SET/HSET commands in mixed workload stress | `number` | `256` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_invoke_commands"></a> [invoke\_commands](#output\_invoke\_commands) | AWS CLI commands to invoke each stress test Lambda function |
+| <a name="output_lambda_function_arns"></a> [lambda\_function\_arns](#output\_lambda\_function\_arns) | Map of stress type to Lambda function ARN |
+| <a name="output_lambda_function_names"></a> [lambda\_function\_names](#output\_lambda\_function\_names) | Map of stress type to Lambda function name |
+| <a name="output_lambda_iam_role_arn"></a> [lambda\_iam\_role\_arn](#output\_lambda\_iam\_role\_arn) | ARN of the Lambda IAM role |
+| <a name="output_lambda_layers"></a> [lambda\_layers](#output\_lambda\_layers) | Lambda layer ARNs used by the stress test functions |
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | Security group ID used by Lambda functions (created or reused) |
+<!-- END_TF_DOCS -->

--- a/terraform/aws/modules/composition/elasticache-stress-test/README.md
+++ b/terraform/aws/modules/composition/elasticache-stress-test/README.md
@@ -1,0 +1,61 @@
+# ElastiCache Redis/Valkey Stress Test Module
+
+Generic Terraform module that deploys Lambda-based stress tests for Amazon ElastiCache Redis or Valkey.
+
+## What it creates
+
+- IAM role for Lambda with VPC, CloudWatch, and optional ElastiCache failover access
+- Optional Lambda security group (or reuse an existing one)
+- `cpu_stress` — phased Lua CPU burn (or flat mode)
+- `mixed_workload` — open-loop mixed command workload (GET/SET/HGET/HSET/INCR) with latency percentile tracking
+- `memory_stress` — pipelined writes to fill `maxmemory` and trigger evictions
+- `connection_exhaustion` — raw TCP/RESP connection flooding
+- `connection_orchestrator` — fan-out orchestrator for massive connection counts
+- `failover` — triggers `TestFailover` on the replication group
+- `cleanup` — deletes stress keys by prefix
+
+## Usage
+
+```hcl
+module "elasticache_stress_test" {
+  source = "./terraform/aws/modules/composition/elasticache-stress-test"
+
+  region      = "us-east-1"
+  environment = "dev"
+
+  redis_endpoint    = "my-cluster.xxx.cache.amazonaws.com"
+  redis_port        = 6379
+  redis_cluster_mode = false
+
+  vpc_id                   = "vpc-12345678"
+  lambda_subnet_ids        = ["subnet-11111111", "subnet-22222222"]
+  lambda_security_group_id = "sg-jumphost"
+  redis_security_group_id  = "sg-elasticache"
+
+  redis_replication_group_id = "my-redis"
+  redis_node_group_id        = "0001"
+
+  tags = {
+    Project = "my-project"
+  }
+}
+```
+
+## Required inputs
+
+- `region`
+- `environment`
+- `redis_endpoint`
+- `vpc_id`
+- `lambda_subnet_ids`
+- `lambda_security_group_id` or `create_security_group = true` + `redis_security_group_id`
+
+## Optional highlights
+
+- `workload_*` variables — tune the open-loop mixed workload
+- `cpu_phase_*` variables — tune phased CPU stress
+- `memory_phase_*` variables — tune phased memory stress
+- `connection_target_total` / `connection_rapid_churn` — connection exhaustion behavior
+- `workload_emit_cloudwatch_metrics` — emit custom CloudWatch metrics per phase
+
+See `variables.tf` for the full input list and `outputs.tf` for emitted function names and ARNs.

--- a/terraform/aws/modules/composition/elasticache-stress-test/main.tf
+++ b/terraform/aws/modules/composition/elasticache-stress-test/main.tf
@@ -1,0 +1,254 @@
+locals {
+  common_tags = merge(var.tags, {
+    Environment = var.environment
+    Project     = var.project_name
+    ManagedBy   = "terraform-IaC"
+    Component   = "elasticache-stress-test"
+  })
+
+  lambda_common_environment = {
+    REDIS_HOST                          = var.redis_endpoint
+    REDIS_PORT                          = tostring(var.redis_port)
+    CLUSTER_MODE                        = tostring(var.redis_cluster_mode)
+    REDIS_AUTH_TOKEN                    = var.redis_auth_token
+    REDIS_USE_TLS                       = tostring(var.redis_use_tls)
+    DURATION                            = tostring(var.stress_duration)
+    STRESS_DURATION                     = tostring(var.stress_duration)
+    CLIENTS                             = tostring(var.stress_clients)
+    THREADS                             = tostring(var.stress_threads)
+    STRESS_THREADS                      = tostring(var.stress_threads)
+    CPU_BURN_ITERATIONS                 = tostring(var.cpu_burn_iterations)
+    CPU_MIXED_MODE                      = tostring(var.cpu_mixed_mode)
+    CPU_PHASE_DURATIONS                 = var.cpu_phase_durations
+    CPU_PHASE_THREADS                   = var.cpu_phase_threads
+    CPU_PHASE_DUTY                      = var.cpu_phase_duty
+    CPU_PHASE_CYCLE_PERIOD_SECONDS      = tostring(var.cpu_phase_cycle_period_seconds)
+    MEMORY_KEY_COUNT                    = tostring(var.memory_key_count)
+    MEMORY_VALUE_SIZE                   = tostring(var.memory_value_size_kb)
+    MEMORY_WORKERS                      = tostring(var.memory_workers)
+    MEMORY_KEYS_PER_WORKER              = tostring(var.memory_keys_per_worker)
+    MEMORY_PIPELINE_SIZE                = tostring(var.memory_pipeline_size)
+    MEMORY_WRITE_TTL                    = tostring(var.memory_write_ttl)
+    MEMORY_CLEANUP_AFTER_STRESS         = tostring(var.memory_cleanup_after_stress)
+    MEMORY_PHASE_DURATIONS              = var.memory_phase_durations
+    MEMORY_PHASE_TARGET_PERCENT         = var.memory_phase_target_percent
+    MEMORY_PHASE_WORKERS                = var.memory_phase_workers
+    CONNECTION_TARGET                   = tostring(var.connection_target)
+    CONNECTION_THREADS                  = tostring(var.connection_threads)
+    CONNECTION_BATCH_SIZE               = tostring(var.connection_batch_size)
+    CONNECTION_TARGET_TOTAL             = tostring(var.connection_target_total)
+    CONNECTION_RAPID_CHURN              = tostring(var.connection_rapid_churn)
+    KEY_PREFIX                          = var.key_prefix
+    ENVIRONMENT                         = var.environment
+    WORKLOAD_PHASE_DURATIONS            = var.workload_phase_durations
+    WORKLOAD_PHASE_OPS_PER_SEC          = var.workload_phase_ops_per_sec
+    WORKLOAD_COMMAND_MIX                = var.workload_command_mix
+    WORKLOAD_PIPELINE_SIZE              = tostring(var.workload_pipeline_size)
+    WORKLOAD_KEY_PATTERN                = var.workload_key_pattern
+    WORKLOAD_KEY_COUNT                  = tostring(var.workload_key_count)
+    WORKLOAD_VALUE_SIZE_BYTES           = tostring(var.workload_value_size_bytes)
+    WORKLOAD_EMIT_CLOUDWATCH_METRICS    = tostring(var.workload_emit_cloudwatch_metrics)
+    WORKLOAD_PHASE_CYCLE_PERIOD_SECONDS = tostring(var.workload_phase_cycle_period_seconds)
+    WORKLOAD_THREADS                    = tostring(var.workload_threads)
+  }
+
+  stress_types = {
+    cpu_stress            = { handler = "cpu_stress.lambda_handler", description = "CPU stress via concurrent SET/GET/INCR + Lua script CPU burn (ThreadPoolExecutor + redis-py)" }
+    mixed_workload        = { handler = "mixed_workload.lambda_handler", description = "Open-loop mixed Redis/Valkey command workload (GET/SET/HGET/HSET/INCR) with fixed arrival rate and latency percentile measurement" }
+    memory_stress         = { handler = "memory_stress.lambda_handler", description = "Memory stress via large value writes to fill maxmemory and trigger evictions" }
+    connection_exhaustion = { handler = "connection_exhaustion.lambda_handler", description = "Connection pool exhaustion via rapid connect/disconnect flooding" }
+    cleanup               = { handler = "cleanup.lambda_handler", description = "Delete all keys with stress test prefix (run after testing)" }
+    connection_orchestrator = {
+      handler     = "connection_orchestrator.lambda_handler"
+      description = "Orchestrate multiple connection_exhaustion Lambdas and centrally manage Redis maxclients"
+      timeout     = 900
+      memory_size = 512
+      environment = {
+        WORKER_FUNCTION_NAME             = "${var.environment}-elasticache-stress-connection_exhaustion"
+        WORKER_REGION                    = var.region
+        ORCHESTRATOR_WORKER_COUNT        = "84"
+        ORCHESTRATOR_DESIRED_TOTAL       = "70000"
+        ORCHESTRATOR_MAX_PER_WORKER      = "850"
+        ORCHESTRATOR_DURATION            = "600"
+        ORCHESTRATOR_WORKER_TARGET_TOTAL = "850"
+        ORCHESTRATOR_WORKER_THREADS      = "16"
+        ORCHESTRATOR_WORKER_BATCH_SIZE   = "10"
+        TARGET_PRIMARY_ONLY              = "false"
+      }
+    }
+    failover = {
+      handler                = "failover.lambda_handler"
+      description            = "Trigger Elasticache TestFailover on the Valkey replication group and poll until available"
+      timeout                = 900
+      memory_size            = 256
+      layers                 = []
+      include_vpc_config     = false
+      use_common_environment = false
+      environment = {
+        REDIS_REPLICATION_GROUP_ID = var.redis_replication_group_id
+        REDIS_NODE_GROUP_ID        = var.redis_node_group_id
+      }
+    }
+  }
+
+  effective_security_group_id = var.create_security_group ? aws_security_group.lambda[0].id : var.lambda_security_group_id
+
+  redis_replication_group_arn = "arn:aws:elasticache:${var.region}:${data.aws_caller_identity.current.account_id}:replicationgroup:${var.redis_replication_group_id}"
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_role" "lambda" {
+  name = "${var.environment}-elasticache-stress-lambda-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_vpc" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+  role       = aws_iam_role.lambda.name
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_logs" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  role       = aws_iam_role.lambda.name
+}
+
+resource "aws_iam_role_policy" "elasticache_failover" {
+  name = "${var.environment}-elasticache-failover"
+  role = aws_iam_role.lambda.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["elasticache:TestFailover", "elasticache:DescribeReplicationGroups"]
+      Resource = local.redis_replication_group_arn
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "lambda_invoke_worker" {
+  name = "${var.environment}-elasticache-invoke-worker"
+  role = aws_iam_role.lambda.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "lambda:InvokeFunction"
+      Resource = "arn:aws:lambda:${var.region}:${data.aws_caller_identity.current.account_id}:function:${var.environment}-elasticache-stress-connection_exhaustion"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "cloudwatch_metrics" {
+  name = "${var.environment}-elasticache-cloudwatch-metrics"
+  role = aws_iam_role.lambda.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "cloudwatch:PutMetricData"
+      Resource = "*"
+    }]
+  })
+}
+
+resource "aws_security_group" "lambda" {
+  count = var.create_security_group ? 1 : 0
+
+  name        = "${var.environment}-elasticache-stress-lambda-sg"
+  description = "Security group for Elasticache stress test Lambda functions"
+  vpc_id      = var.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_security_group_rule" "redis_ingress_lambda" {
+  count = var.create_security_group ? 1 : 0
+
+  type                     = "ingress"
+  from_port                = var.redis_port
+  to_port                  = var.redis_port
+  protocol                 = "tcp"
+  security_group_id        = var.redis_security_group_id
+  source_security_group_id = aws_security_group.lambda[0].id
+}
+
+data "archive_file" "stress_test_code" {
+  type        = "zip"
+  source_dir  = "${path.module}/src"
+  output_path = "${path.module}/build/stress-test-code.zip"
+}
+
+resource "aws_cloudwatch_log_group" "stress_test" {
+  for_each          = local.stress_types
+  name              = "/aws/lambda/${var.environment}-elasticache-stress-${each.key}"
+  retention_in_days = var.log_retention_days
+  tags              = local.common_tags
+}
+
+resource "aws_lambda_function" "stress_test" {
+  for_each = local.stress_types
+
+  function_name = "${var.environment}-elasticache-stress-${each.key}"
+  description   = each.value.description
+
+  role    = aws_iam_role.lambda.arn
+  runtime = var.lambda_runtime
+  handler = each.value.handler
+
+  filename         = data.archive_file.stress_test_code.output_path
+  source_code_hash = data.archive_file.stress_test_code.output_base64sha256
+
+  timeout     = lookup(each.value, "timeout", var.lambda_timeout)
+  memory_size = lookup(each.value, "memory_size", var.lambda_memory_size)
+
+  layers = lookup(each.value, "layers", var.lambda_layers)
+
+  environment {
+    variables = merge(
+      lookup(each.value, "use_common_environment", true) ? local.lambda_common_environment : {},
+      { STRESS_TYPE = each.key },
+      lookup(each.value, "environment", {})
+    )
+  }
+
+  dynamic "vpc_config" {
+    for_each = lookup(each.value, "include_vpc_config", true) ? [1] : []
+    content {
+      subnet_ids         = var.lambda_subnet_ids
+      security_group_ids = [local.effective_security_group_id]
+    }
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.lambda_vpc,
+    aws_iam_role_policy_attachment.lambda_logs,
+    aws_iam_role_policy.elasticache_failover,
+    aws_iam_role_policy.cloudwatch_metrics,
+    aws_cloudwatch_log_group.stress_test,
+  ]
+
+  tags = merge(local.common_tags, {
+    StressType = each.key
+  })
+}

--- a/terraform/aws/modules/composition/elasticache-stress-test/outputs.tf
+++ b/terraform/aws/modules/composition/elasticache-stress-test/outputs.tf
@@ -1,0 +1,35 @@
+output "lambda_function_arns" {
+  description = "Map of stress type to Lambda function ARN"
+  value = {
+    for k, v in aws_lambda_function.stress_test : k => v.arn
+  }
+}
+
+output "lambda_function_names" {
+  description = "Map of stress type to Lambda function name"
+  value = {
+    for k, v in aws_lambda_function.stress_test : k => v.function_name
+  }
+}
+
+output "lambda_iam_role_arn" {
+  description = "ARN of the Lambda IAM role"
+  value       = aws_iam_role.lambda.arn
+}
+
+output "lambda_layers" {
+  description = "Lambda layer ARNs used by the stress test functions"
+  value       = var.lambda_layers
+}
+
+output "security_group_id" {
+  description = "Security group ID used by Lambda functions (created or reused)"
+  value       = var.create_security_group ? aws_security_group.lambda[0].id : var.lambda_security_group_id
+}
+
+output "invoke_commands" {
+  description = "AWS CLI commands to invoke each stress test Lambda function"
+  value = {
+    for k, v in aws_lambda_function.stress_test : k => "aws lambda invoke --function-name ${v.function_name} --region ${var.region} --payload '{}' /tmp/${k}-output.json && cat /tmp/${k}-output.json"
+  }
+}

--- a/terraform/aws/modules/composition/elasticache-stress-test/src/cleanup.py
+++ b/terraform/aws/modules/composition/elasticache-stress-test/src/cleanup.py
@@ -1,0 +1,140 @@
+import os
+import json
+import logging
+
+import redis
+from redis.cluster import RedisCluster, ClusterNode
+from common import get_redis_client
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def _unlink_keys_safely(client, keys):
+    pipe = client.pipeline()
+    for key in keys:
+        pipe.unlink(key)
+    pipe.execute()
+
+
+def _is_cluster_enabled(client):
+    try:
+        info = client.info(section="cluster")
+        return info.get("cluster_enabled") == 1
+    except Exception:
+        return False
+
+
+def _cluster_client_from_env():
+    host = os.environ.get("REDIS_HOST", "")
+    port = int(os.environ.get("REDIS_PORT", "6379"))
+    auth_token = os.environ.get("REDIS_AUTH_TOKEN", "")
+    use_tls = os.environ.get("REDIS_USE_TLS", "false").lower() == "true"
+
+    kwargs = {
+        "decode_responses": True,
+        "socket_timeout": 30,
+        "socket_connect_timeout": 10,
+        "retry_on_timeout": True,
+        "skip_full_coverage_check": True,
+    }
+    if auth_token:
+        kwargs["password"] = auth_token
+    if use_tls:
+        kwargs["ssl"] = True
+
+    startup_node = ClusterNode(host=host, port=port)
+    return RedisCluster(startup_nodes=[startup_node], **kwargs)
+
+
+def _cleanup_with_cluster(cluster_client, key_prefix, batch_size, min_remaining_ms, context):
+    deleted = 0
+    keys_batch = []
+    for key in cluster_client.scan_iter(match=f"{key_prefix}*", count=batch_size):
+        keys_batch.append(key)
+        if len(keys_batch) >= batch_size:
+            _unlink_keys_safely(cluster_client, keys_batch)
+            deleted += len(keys_batch)
+            keys_batch = []
+            if context.get_remaining_time_in_millis() < min_remaining_ms:
+                logger.info("Stopping cleanup: nearing Lambda timeout")
+                return deleted
+    if keys_batch:
+        _unlink_keys_safely(cluster_client, keys_batch)
+        deleted += len(keys_batch)
+    return deleted
+
+
+def _cleanup_with_standalone(client, key_prefix, batch_size, min_remaining_ms, context):
+    deleted = 0
+    keys_batch = []
+    for key in client.scan_iter(match=f"{key_prefix}*", count=batch_size):
+        keys_batch.append(key)
+        if len(keys_batch) >= batch_size:
+            _unlink_keys_safely(client, keys_batch)
+            deleted += len(keys_batch)
+            keys_batch = []
+            if context.get_remaining_time_in_millis() < min_remaining_ms:
+                logger.info("Stopping cleanup: nearing Lambda timeout")
+                return deleted
+    if keys_batch:
+        _unlink_keys_safely(client, keys_batch)
+        deleted += len(keys_batch)
+    return deleted
+
+
+def lambda_handler(event, context):
+    key_prefix = os.environ.get("KEY_PREFIX", "stress:test:")
+    batch_size = 1000
+    min_remaining_ms = 30000
+
+    logger.info(f"Cleaning up all keys with prefix: {key_prefix}")
+
+    initial_client = None
+    cluster_client = None
+    deleted = 0
+
+    try:
+        initial_client = get_redis_client()
+        initial_client.ping()
+        cluster_enabled = _is_cluster_enabled(initial_client)
+
+        if cluster_enabled:
+            logger.info("Cluster mode detected; using RedisCluster for cleanup")
+            cluster_client = _cluster_client_from_env()
+            deleted = _cleanup_with_cluster(
+                cluster_client, key_prefix, batch_size, min_remaining_ms, context
+            )
+        else:
+            logger.info("Standalone mode detected")
+            deleted = _cleanup_with_standalone(
+                initial_client, key_prefix, batch_size, min_remaining_ms, context
+            )
+
+        logger.info(f"Unlinked {deleted} keys with prefix {key_prefix}")
+
+        return {
+            "statusCode": 200,
+            "body": json.dumps({
+                "status": "complete",
+                "keys_deleted": deleted,
+                "key_prefix": key_prefix,
+                "cluster_enabled": cluster_enabled,
+            }),
+        }
+    except Exception as e:
+        logger.error(f"Cleanup error: {e}", exc_info=True)
+        return {
+            "statusCode": 500,
+            "body": json.dumps({
+                "status": "error",
+                "error": str(e),
+            }),
+        }
+    finally:
+        for c in (initial_client, cluster_client):
+            if c is not None:
+                try:
+                    c.close()
+                except Exception:
+                    pass

--- a/terraform/aws/modules/composition/elasticache-stress-test/src/common.py
+++ b/terraform/aws/modules/composition/elasticache-stress-test/src/common.py
@@ -1,0 +1,151 @@
+import os
+import time
+import logging
+import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import redis
+from redis.cluster import RedisCluster, ClusterNode
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def _redis_kwargs(host, port, auth_token, use_tls, decode=False):
+    kwargs = {
+        "host": host,
+        "port": port,
+        "decode_responses": decode,
+        "socket_timeout": 30,
+        "socket_connect_timeout": 30,
+        "retry_on_timeout": True,
+    }
+    if auth_token:
+        kwargs["password"] = auth_token
+    if use_tls:
+        kwargs["ssl"] = True
+    return kwargs
+
+
+def discover_primary_host():
+    host = os.environ.get("REDIS_HOST", "")
+    port = int(os.environ.get("REDIS_PORT", "6379"))
+    auth_token = os.environ.get("REDIS_AUTH_TOKEN", "")
+    use_tls = os.environ.get("REDIS_USE_TLS", "false").lower() == "true"
+    target_primary = os.environ.get("TARGET_PRIMARY_ONLY", "true").lower() == "true"
+    if not target_primary:
+        return host
+    discovered = _discover_primary_node(host, port, auth_token, use_tls)
+    return discovered if discovered else host
+
+
+def _discover_primary_node(host, port, auth_token, use_tls):
+    probe = redis.Redis(**_redis_kwargs(host, port, auth_token, use_tls, decode=True))
+    try:
+        probe.ping()
+        try:
+            raw = probe.execute_command("CLUSTER", "NODES")
+            if isinstance(raw, bytes):
+                raw = raw.decode()
+            for line in raw.strip().splitlines():
+                parts = line.split()
+                if len(parts) < 8:
+                    continue
+                flags = parts[2].split(",")
+                if "master" not in flags:
+                    continue
+                addr = parts[1]
+                node_host = addr.rsplit("@", 1)[0].rsplit(":", 1)[0]
+                logger.info(f"Discovered primary node: {node_host} (flags={parts[2]})")
+                return node_host
+        except redis.ResponseError:
+            pass
+
+        info = probe.info(section="replication")
+        if info.get("role") == "master":
+            logger.info("Node is already primary (standalone mode)")
+            return None
+        master_host = info.get("master_host", "")
+        if master_host:
+            logger.info(f"Discovered primary via INFO replication: {master_host}")
+            return master_host
+    finally:
+        try:
+            probe.close()
+        except Exception:
+            pass
+    return None
+
+
+def get_redis_client():
+    host = os.environ.get("REDIS_HOST", "")
+    port = int(os.environ.get("REDIS_PORT", "6379"))
+    cluster_mode = os.environ.get("CLUSTER_MODE", "true").lower() == "true"
+    auth_token = os.environ.get("REDIS_AUTH_TOKEN", "")
+    use_tls = os.environ.get("REDIS_USE_TLS", "false").lower() == "true"
+    target_primary = os.environ.get("TARGET_PRIMARY_ONLY", "true").lower() == "true"
+
+    logger.info(
+        f"Creating Redis client: host={host}, port={port}, cluster_mode={cluster_mode}, "
+        f"use_tls={use_tls}, has_auth={bool(auth_token)}, target_primary_only={target_primary}"
+    )
+
+    if not cluster_mode and target_primary:
+        primary_host = _discover_primary_node(host, port, auth_token, use_tls)
+        if primary_host:
+            logger.info(f"Redirecting client to primary node: {primary_host}:{port}")
+            host = primary_host
+
+    try:
+        if cluster_mode:
+            startup_node = ClusterNode(host=host, port=port)
+            logger.info(f"Initializing RedisCluster with startup_node {host}:{port}")
+            client = RedisCluster(
+                startup_nodes=[startup_node],
+                **{k: v for k, v in _redis_kwargs(host, port, auth_token, use_tls).items()
+                   if k != "host" and k != "port"},
+            )
+            logger.info("RedisCluster initialized successfully")
+        else:
+            logger.info(f"Initializing standalone redis.Redis client to {host}:{port}")
+            client = redis.Redis(**_redis_kwargs(host, port, auth_token, use_tls))
+            logger.info("Standalone Redis client initialized successfully")
+    except Exception as e:
+        logger.error(
+            f"Failed to create Redis client: host={host}, port={port}, "
+            f"cluster_mode={cluster_mode}, error={e}",
+            exc_info=True,
+        )
+        raise
+
+    return client
+
+
+def run_stress_with_workers(worker_fn, num_clients, num_threads, duration):
+    start_time = time.time()
+    end_time = start_time + duration
+    total_operations = 0
+    errors = []
+
+    with ThreadPoolExecutor(max_workers=num_threads) as executor:
+        futures = []
+        for _ in range(num_clients):
+            futures.append(executor.submit(worker_fn, end_time))
+
+        for future in as_completed(futures):
+            try:
+                result = future.result()
+                total_operations += result
+            except Exception as e:
+                errors.append(str(e))
+
+    elapsed = time.time() - start_time
+    ops_per_sec = total_operations / elapsed if elapsed > 0 else 0
+
+    return {
+        "total_operations": total_operations,
+        "elapsed_seconds": round(elapsed, 2),
+        "ops_per_sec": round(ops_per_sec, 2),
+        "errors": errors[:10],
+        "error_count": len(errors),
+    }

--- a/terraform/aws/modules/composition/elasticache-stress-test/src/connection_exhaustion.py
+++ b/terraform/aws/modules/composition/elasticache-stress-test/src/connection_exhaustion.py
@@ -1,0 +1,228 @@
+import os
+import time
+import json
+import logging
+import socket
+import threading
+
+from common import get_redis_client, discover_primary_host
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+PING_REQ = b"*1\r\n$4\r\nPING\r\n"
+PONG = b"+PONG\r\n"
+
+
+def open_and_handshake(host, port, timeout=10):
+    """Open a raw TCP socket to Redis, send RESP PING, read +PONG.
+
+    Returns the open socket on success or None on failure. Using raw sockets
+    instead of redis-py clients minimises per-connection memory/CPU overhead so
+    thousands of connections can be held within a single Lambda invocation.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(timeout)
+    try:
+        sock.connect((host, port))
+        sock.sendall(PING_REQ)
+        resp = sock.recv(64)
+        if resp != PONG:
+            logger.warning(f"Unexpected PING response: {resp!r}")
+            sock.close()
+            return None
+        return sock
+    except Exception as e:
+        try:
+            sock.close()
+        except Exception:
+            pass
+        return None
+
+
+def connection_worker(idx, host, port, end_time, batch_size, target_total,
+                      rapid_churn, shared_state, results):
+    """Per-thread connection exhaustion worker.
+
+    Opens raw TCP/RESP sockets in batches until the global held-pool reaches
+    ``target_total``, then optionally churns (open/handshake/close repeatedly)
+    while still holding the pool, until ``end_time``.
+    """
+    held = []
+    opened = 0
+    errors = 0
+    churn_opened = 0
+    last_log = 0
+
+    try:
+        while time.time() < end_time:
+            with shared_state["lock"]:
+                total_held = shared_state["total_held"]
+
+            if total_held < target_total:
+                remaining = target_total - total_held
+                batch = min(batch_size, remaining)
+                for _ in range(batch):
+                    with shared_state["lock"]:
+                        if shared_state["total_held"] >= target_total:
+                            break
+                    sock = open_and_handshake(host, port)
+                    if sock is not None:
+                        held.append(sock)
+                        opened += 1
+                        with shared_state["lock"]:
+                            shared_state["total_held"] += 1
+                    else:
+                        errors += 1
+                if opened - last_log >= 250:
+                    with shared_state["lock"]:
+                        global_held = shared_state["total_held"]
+                    logger.info(
+                        f"Worker {idx}: opened {opened} "
+                        f"(total held={global_held})"
+                    )
+                    last_log = opened
+                time.sleep(0.05)
+            elif rapid_churn:
+                sock = open_and_handshake(host, port)
+                if sock is not None:
+                    churn_opened += 1
+                    try:
+                        sock.close()
+                    except Exception:
+                        pass
+                else:
+                    errors += 1
+                time.sleep(0.05)
+            else:
+                time.sleep(1.0)
+    except Exception as e:
+        logger.error(f"Worker {idx} error: {e}")
+        errors += 1
+    finally:
+        for s in held:
+            try:
+                s.close()
+            except Exception:
+                pass
+        with shared_state["lock"]:
+            shared_state["total_held"] -= len(held)
+        results[idx] = {
+            "connections_opened": opened,
+            "churn_opened": churn_opened,
+            "errors": errors,
+            "held_at_exit": len(held),
+        }
+
+
+def lambda_handler(event, context):
+    duration = int(event.get("duration", os.environ.get("DURATION", "300")))
+    threads = int(event.get("threads", os.environ.get("CONNECTION_THREADS", "48")))
+    batch_size = int(event.get("batch_size", os.environ.get("CONNECTION_BATCH_SIZE", "100")))
+    target_total = int(event.get("target_total", os.environ.get("CONNECTION_TARGET_TOTAL", "5000")))
+    rapid_churn = str(event.get("rapid_churn", os.environ.get("CONNECTION_RAPID_CHURN", "false"))).lower() == "true"
+    redis_host = discover_primary_host()
+    redis_port = int(os.environ.get("REDIS_PORT", "6379"))
+    stress_type = os.environ.get("STRESS_TYPE", "connection_exhaustion")
+
+    logger.info(
+        f"Connection exhaustion: threads={threads}, batch={batch_size}, "
+        f"target_total={target_total}, rapid_churn={rapid_churn}, "
+        f"duration={duration}s"
+    )
+
+    info_client = get_redis_client()
+    try:
+        info_client.ping()
+        info_before = info_client.info()
+        maxclients_before = info_before.get("maxclients", "?")
+        connected_before = info_before.get("connected_clients", "?")
+        logger.info(
+            f"Before: connected_clients={connected_before}, maxclients={maxclients_before}"
+        )
+    finally:
+        try:
+            info_client.close()
+        except Exception as e:
+            logger.warning(f"info_client close error: {e}")
+
+    shared_state = {"total_held": 0, "lock": threading.Lock()}
+    results = [None] * threads
+    thread_list = []
+    end_time = time.time() + duration
+
+    for i in range(threads):
+        t = threading.Thread(
+            target=connection_worker,
+            args=(
+                i, redis_host, redis_port, end_time, batch_size,
+                target_total, rapid_churn, shared_state, results,
+            ),
+        )
+        t.daemon = True
+        t.start()
+        thread_list.append(t)
+
+    for t in thread_list:
+        t.join(timeout=duration + 60)
+
+    total_opened = sum(r["connections_opened"] for r in results if r)
+    total_churn = sum(r["churn_opened"] for r in results if r)
+    total_errors = sum(r["errors"] for r in results if r)
+
+    info_client = None
+    connected_after = "?"
+    rejected = 0
+    maxclients_after = "?"
+    for attempt in range(1, 4):
+        try:
+            info_client = get_redis_client()
+            info_after = info_client.info()
+            connected_after = info_after.get("connected_clients", "?")
+            rejected = info_after.get("rejected_connections", 0)
+            maxclients_after = info_after.get("maxclients", "?")
+            logger.info(
+                f"After (attempt {attempt}/3): connected_clients={connected_after}, "
+                f"rejected_connections={rejected}, maxclients={maxclients_after}"
+            )
+            break
+        except Exception as e:
+            logger.warning(f"After INFO attempt {attempt}/3 failed: {e}")
+            if info_client is not None:
+                try:
+                    info_client.close()
+                except Exception:
+                    pass
+                info_client = None
+            if attempt < 3:
+                time.sleep(5)
+    if info_client is not None:
+        try:
+            info_client.close()
+        except Exception as e:
+            logger.warning(f"info_client close error: {e}")
+
+    logger.info(
+        f"Connection exhaustion complete: opened={total_opened}, "
+        f"churn={total_churn}, errors={total_errors}"
+    )
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps({
+            "stress_type": stress_type,
+            "threads": threads,
+            "batch_size": batch_size,
+            "target_total": target_total,
+            "rapid_churn": rapid_churn,
+            "total_connections_opened": total_opened,
+            "total_churn_opened": total_churn,
+            "total_errors": total_errors,
+            "connected_before": connected_before,
+            "connected_after": connected_after,
+            "rejected_connections": rejected,
+            "maxclients_before": maxclients_before,
+            "maxclients_after": maxclients_after,
+            "elapsed_seconds": duration,
+        }),
+    }

--- a/terraform/aws/modules/composition/elasticache-stress-test/src/connection_orchestrator.py
+++ b/terraform/aws/modules/composition/elasticache-stress-test/src/connection_orchestrator.py
@@ -1,0 +1,125 @@
+import os
+import json
+import time
+import logging
+import math
+import boto3
+
+from common import get_redis_client
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def _safe_close(client):
+    try:
+        client.close()
+    except Exception:
+        pass
+
+
+def _info_with_retry(attempts=3, backoff_seconds=5):
+    last_error = None
+    for attempt in range(1, attempts + 1):
+        client = None
+        try:
+            client = get_redis_client()
+            client.ping()
+            info = client.info()
+            connected = info.get("connected_clients", "?")
+            maxclients = info.get("maxclients", "?")
+            rejected = info.get("rejected_connections", 0)
+            logger.info(f"INFO attempt {attempt}/{attempts}: connected={connected}, maxclients={maxclients}, rejected={rejected}")
+            return connected, maxclients, rejected
+        except Exception as e:
+            last_error = e
+            logger.warning(f"INFO attempt {attempt}/{attempts} failed: {e}")
+            if attempt < attempts:
+                time.sleep(backoff_seconds)
+        finally:
+            if client is not None:
+                _safe_close(client)
+    logger.error(f"INFO failed after {attempts} attempts: {last_error}")
+    return "?", "?", 0
+
+
+def lambda_handler(event, context):
+    worker_function_name = os.environ.get("WORKER_FUNCTION_NAME", "")
+    worker_region = os.environ.get("WORKER_REGION", os.environ.get("AWS_REGION", "us-east-1"))
+
+    worker_count = int(event.get("worker_count", os.environ.get("ORCHESTRATOR_WORKER_COUNT", "84")))
+    desired_total = int(event.get("desired_total", os.environ.get("ORCHESTRATOR_DESIRED_TOTAL", "70000")))
+    max_per_worker = int(event.get("max_per_worker", os.environ.get("ORCHESTRATOR_MAX_PER_WORKER", "850")))
+    duration = int(event.get("duration", os.environ.get("ORCHESTRATOR_DURATION", "600")))
+    worker_threads = int(event.get("worker_threads", os.environ.get("ORCHESTRATOR_WORKER_THREADS", "16")))
+    worker_batch_size = int(event.get("worker_batch_size", os.environ.get("ORCHESTRATOR_WORKER_BATCH_SIZE", "10")))
+
+    worker_target_total = int(event.get("worker_target_total", math.ceil(desired_total / worker_count)))
+    if worker_target_total > max_per_worker:
+        capped = worker_target_total
+        worker_target_total = max_per_worker
+        effective_total = worker_target_total * worker_count
+        logger.warning(
+            f"Per-worker target {capped} exceeds safe fd limit {max_per_worker}; "
+            f"capping to {max_per_worker}. Effective plateau = {effective_total}"
+        )
+
+    effective_total = worker_target_total * worker_count
+    logger.info(
+        f"Connection orchestrator: workers={worker_count}, desired_total={desired_total}, "
+        f"worker_target_total={worker_target_total}, max_per_worker={max_per_worker}, "
+        f"effective_total={effective_total}, duration={duration}s"
+    )
+
+    lambda_client = boto3.client("lambda", region_name=worker_region)
+
+    connected_before, maxclients, _ = _info_with_retry()
+    logger.info(f"Before: connected_clients={connected_before}, maxclients={maxclients}")
+
+    payload = json.dumps({
+        "target_total": worker_target_total,
+        "threads": worker_threads,
+        "batch_size": worker_batch_size,
+        "duration": duration,
+        "rapid_churn": False,
+    })
+
+    invocation_results = []
+    for i in range(worker_count):
+        try:
+            resp = lambda_client.invoke(
+                FunctionName=worker_function_name,
+                InvocationType="Event",
+                Payload=payload,
+            )
+            invocation_results.append({"worker": i + 1, "status_code": resp.get("StatusCode")})
+            if (i + 1) % 10 == 0 or i + 1 == worker_count:
+                logger.info(f"Invoked {i + 1}/{worker_count} workers")
+        except Exception as e:
+            logger.error(f"Failed to invoke worker {i + 1}: {e}")
+            invocation_results.append({"worker": i + 1, "error": str(e)})
+
+    sleep_seconds = duration + 60
+    logger.info(f"Waiting {sleep_seconds}s for workers to hold connections")
+    time.sleep(sleep_seconds)
+
+    connected_after, _, rejected = _info_with_retry(attempts=5, backoff_seconds=10)
+    logger.info(f"After: connected_clients={connected_after}, rejected_connections={rejected}")
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps({
+            "orchestrator": True,
+            "worker_count": worker_count,
+            "desired_total": desired_total,
+            "worker_target_total": worker_target_total,
+            "effective_total": effective_total,
+            "max_per_worker": max_per_worker,
+            "worker_function_name": worker_function_name,
+            "maxclients": maxclients,
+            "connected_before": connected_before,
+            "connected_after": connected_after,
+            "rejected_connections": rejected,
+            "invocations": invocation_results,
+        }),
+    }

--- a/terraform/aws/modules/composition/elasticache-stress-test/src/cpu_stress.py
+++ b/terraform/aws/modules/composition/elasticache-stress-test/src/cpu_stress.py
@@ -1,0 +1,297 @@
+"""
+CPU stress Lambda for Redis/Valkey.
+
+Supports two modes:
+1. Legacy flat mode: one constant-intensity burn window controlled by STRESS_DURATION,
+   STRESS_THREADS, CPU_BURN_ITERATIONS and CPU_MIXED_MODE.
+2. Phased mode (default): a sequence of plateaus, each lasting a configurable duration
+   and using configurable thread count + duty cycle to produce ~60% / ~85% / ~100%
+   CPU load. Set CPU_PHASE_DURATIONS to an empty string to fall back to legacy mode.
+
+Phased environment variables mirror the aurora-fault-injection pattern:
+  CPU_PHASE_DURATIONS="240,240,240"
+  CPU_PHASE_THREADS="8,16,32"
+  CPU_PHASE_DUTY="0.6,0.85,1.0"
+  CPU_BURN_ITERATIONS="500000"
+  CPU_MIXED_MODE="false"
+"""
+
+import json
+import logging
+import os
+import random
+import threading
+import time
+import uuid
+
+from common import get_redis_client
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+_LUA_CPU_BURN = """
+local result = 0
+local n = tonumber(ARGV[1])
+for i = 1, n do
+    result = result + math.floor(math.sqrt(i) * 3.14159265358979 / 2.71828182845905)
+end
+return result
+"""
+
+
+def _parse_csv(env_var, default=None, cast=str):
+    raw = os.environ.get(env_var, default)
+    if raw is None:
+        return []
+    return [cast(item.strip()) for item in raw.split(",") if item.strip()]
+
+
+def _run_flat_burn(key_prefix, mixed_mode):
+    duration_seconds = int(os.environ.get("STRESS_DURATION", "300"))
+    worker_count = int(os.environ.get("STRESS_THREADS", "1"))
+    cpu_burn_iterations = int(os.environ.get("CPU_BURN_ITERATIONS", "500000"))
+    end_time = time.time() + duration_seconds
+    lock_key = f"{key_prefix}lock:cpu:{uuid.uuid4()}"
+    results = {}
+    threads = []
+
+    def worker(worker_id):
+        client = get_redis_client()
+        ops = 0
+        try:
+            while time.time() < end_time:
+                client.eval(_LUA_CPU_BURN, 0, cpu_burn_iterations)
+                if mixed_mode:
+                    client.set(f"{key_prefix}cpu:{worker_id}:{ops}", str(time.time()))
+                    client.get(f"{key_prefix}cpu:{worker_id}:{ops}")
+                    client.incr(f"{key_prefix}counter:{worker_id}")
+                ops += 1
+            results[worker_id] = {"operations": ops}
+        except Exception as exc:
+            logger.exception("Worker %s failed", worker_id)
+            results[worker_id] = {"error": str(exc)}
+        finally:
+            try:
+                client.delete(lock_key)
+                client.close()
+            except Exception:
+                pass
+
+    for i in range(worker_count):
+        t = threading.Thread(target=worker, args=(i,))
+        t.daemon = True
+        t.start()
+        threads.append(t)
+
+    for t in threads:
+        t.join(timeout=duration_seconds + 60)
+
+    return {
+        "statusCode": 200,
+        "mode": "flat",
+        "duration_seconds": duration_seconds,
+        "workers": worker_count,
+        "results": results,
+    }
+
+
+def _phase_worker(client_factory, worker_label, lua_script, phase_index, phase_start, phase_end, aggregate_duty, num_threads, jitter_max, mixed_mode, key_prefix, results, index_in_results):
+    client = None
+    cpu_burn_iterations = int(os.environ.get("CPU_BURN_ITERATIONS", "500000"))
+    try:
+        client = client_factory()
+    except Exception as exc:
+        logger.exception("[%s] failed to create Redis client", worker_label)
+        results[index_in_results] = {"worker": worker_label, "error": str(exc)}
+        return
+
+    if aggregate_duty >= 1.0 or num_threads <= 1:
+        personal_duty = aggregate_duty
+    else:
+        # Linear per-worker duty for a single-server queue. Redis/Valkey has
+        # one engine thread; the aggregate offered load is what matters. The
+        # Bernoulli-style formula oversubscribes the engine and causes 100%
+        # spikes when multiple workers happen to be active at once.
+        personal_duty = aggregate_duty / num_threads
+
+    ops = 0
+    try:
+        sleep_to_start = phase_start - time.time()
+        if sleep_to_start > 0:
+            time.sleep(sleep_to_start)
+
+        if jitter_max > 0:
+            time.sleep(random.uniform(0, jitter_max))
+
+        logger.info(
+            "[%s] phase %d aggregate duty %.2f, personal duty %.3f, %d threads",
+            worker_label, phase_index + 1, aggregate_duty, personal_duty, num_threads,
+        )
+
+        while time.time() < phase_end:
+            loop_start = time.time()
+            try:
+                client.eval(lua_script, 0, cpu_burn_iterations)
+                if mixed_mode:
+                    key = f"{key_prefix}cpu:{worker_label}:{ops}"
+                    client.set(key, str(time.time()))
+                    client.get(key)
+                    client.incr(f"{key_prefix}counter:{worker_label}")
+                ops += 1
+            except Exception as exc:
+                logger.warning("[%s] operation failed: %s", worker_label, exc)
+
+            if personal_duty < 1.0:
+                elapsed = time.time() - loop_start
+                if elapsed > 0:
+                    sleep_for = elapsed * ((1.0 / personal_duty) - 1.0)
+                    # Per-cycle jitter desynchronizes workers without the long
+                    # startup ramp that distorts CloudWatch 1-minute averages.
+                    sleep_for *= random.uniform(0.85, 1.15)
+                    remaining = phase_end - time.time()
+                    time.sleep(min(sleep_for, remaining))
+    except Exception as exc:
+        logger.exception("[%s] unhandled exception in phase %d", worker_label, phase_index + 1)
+        results[index_in_results] = {"worker": worker_label, "phase": phase_index + 1, "error": str(exc)}
+    finally:
+        if client is not None:
+            try:
+                client.close()
+            except Exception:
+                pass
+        results[index_in_results] = {"worker": worker_label, "phase": phase_index + 1, "operations": ops}
+
+
+def _ping_with_retry(client_factory, attempts=3, backoff_seconds=5):
+    last_error = None
+    for attempt in range(1, attempts + 1):
+        client = None
+        try:
+            client = client_factory()
+            client.ping()
+            client.close()
+            logger.info("Redis connectivity check passed on attempt %d", attempt)
+            return True
+        except Exception as exc:
+            last_error = exc
+            logger.warning("Redis connectivity check attempt %d failed: %s", attempt, exc)
+            if client is not None:
+                try:
+                    client.close()
+                except Exception:
+                    pass
+            if attempt < attempts:
+                time.sleep(backoff_seconds)
+    logger.error("Redis connectivity check failed after %d attempts: %s", attempts, last_error)
+    return False
+
+
+def _run_phased_burn(key_prefix, mixed_mode):
+    durations = _parse_csv("CPU_PHASE_DURATIONS", default="240,240,240", cast=int)
+    thread_counts = _parse_csv("CPU_PHASE_THREADS", default="8,16,32", cast=int)
+    duties = _parse_csv("CPU_PHASE_DUTY", default="0.6,0.85,1.0", cast=float)
+    jitter_max = int(os.environ.get("CPU_PHASE_CYCLE_PERIOD_SECONDS", "10"))
+
+    if not (len(durations) == len(thread_counts) == len(duties)):
+        raise ValueError("CPU_PHASE_DURATIONS, CPU_PHASE_THREADS and CPU_PHASE_DUTY must all have the same length")
+    if not durations:
+        raise ValueError("At least one phase is required when CPU_PHASE_DURATIONS is set")
+    if any(d <= 0 for d in durations):
+        raise ValueError("All CPU_PHASE_DURATIONS values must be positive integers")
+    if any(duty <= 0 or duty > 1.0 for duty in duties):
+        raise ValueError("All CPU_PHASE_DUTY values must be in (0, 1.0]")
+    if any(t <= 0 for t in thread_counts):
+        raise ValueError("All CPU_PHASE_THREADS values must be positive integers")
+    if jitter_max <= 0:
+        raise ValueError("CPU_PHASE_CYCLE_PERIOD_SECONDS must be a positive integer")
+
+    _ping_with_retry(get_redis_client)
+
+    total_duration = sum(durations)
+    start_ts = time.time()
+    results_by_phase = [None] * len(durations)
+    threads = []
+    cumulative_offset = 0.0
+
+    for phase_idx, phase_duration in enumerate(durations):
+        phase_start = start_ts + cumulative_offset
+        phase_end = phase_start + phase_duration
+        cumulative_offset += phase_duration
+
+        num_threads = thread_counts[phase_idx]
+        duty = duties[phase_idx]
+        phase_results = [None] * num_threads
+        results_by_phase[phase_idx] = {
+            "phase": phase_idx + 1,
+            "threads": num_threads,
+            "duty": duty,
+            "jitter_max_seconds": jitter_max,
+            "duration_seconds": phase_duration,
+            "scheduled_start": phase_start,
+            "scheduled_end": phase_end,
+            "workers": phase_results,
+        }
+
+        for worker_idx in range(num_threads):
+            worker_label = f"p{phase_idx + 1}-w{worker_idx}"
+            t = threading.Thread(
+                target=_phase_worker,
+                args=(
+                    get_redis_client,
+                    worker_label,
+                    _LUA_CPU_BURN,
+                    phase_idx,
+                    phase_start,
+                    phase_end,
+                    duty,
+                    num_threads,
+                    jitter_max,
+                    mixed_mode,
+                    key_prefix,
+                    phase_results,
+                    worker_idx,
+                ),
+            )
+            t.daemon = True
+            t.start()
+            threads.append(t)
+
+        logger.info(
+            "Scheduled phase %d: %d threads, %ss duration, %.0f%% duty, %ss jitter",
+            phase_idx + 1,
+            num_threads,
+            phase_duration,
+            duty * 100,
+            jitter_max,
+        )
+
+    deadline = start_ts + total_duration + 60
+    for t in threads:
+        remaining = max(0, deadline - time.time())
+        t.join(timeout=remaining)
+
+    return {
+        "statusCode": 200,
+        "mode": "phased",
+        "total_duration_seconds": total_duration,
+        "phases": results_by_phase,
+        "cpu_burn_iterations": int(os.environ.get("CPU_BURN_ITERATIONS", "500000")),
+        "cpu_phase_jitter_max_seconds": jitter_max,
+        "mixed_mode": mixed_mode,
+    }
+
+
+def lambda_handler(event, context):
+    _ = event
+    _ = context
+    key_prefix = os.environ.get("KEY_PREFIX", "stress:test:")
+    mixed_mode = os.environ.get("CPU_MIXED_MODE", "false").lower() == "true"
+
+    if os.environ.get("CPU_PHASE_DURATIONS", "").strip():
+        return _run_phased_burn(key_prefix, mixed_mode)
+
+    return _run_flat_burn(key_prefix, mixed_mode)
+
+
+if __name__ == "__main__":
+    print(json.dumps(lambda_handler({}, None)))

--- a/terraform/aws/modules/composition/elasticache-stress-test/src/failover.py
+++ b/terraform/aws/modules/composition/elasticache-stress-test/src/failover.py
@@ -1,0 +1,260 @@
+"""Elasticache Valkey failover stress test Lambda.
+
+Triggers an ``elasticache:TestFailover`` on the target replication group's
+node group and polls ``describe_replication_groups`` until the replication
+group returns to ``available``. This exercises shard-level primary/replica
+failover without needing a direct Redis connection (no redis-py layer).
+
+Pre-flight checks (any failure returns statusCode 400):
+  a. Replication group status must be ``available``.
+  b. Target node group must have at least 2 members (primary + replica).
+  c. Every replica in the node group must have ``ReplicaLag`` <= 30 seconds
+     (skipped when the metric is absent).
+  d. No node replacement/failover already in progress (status must be available).
+
+Environment variables:
+  REDIS_REPLICATION_GROUP_ID  - Replication group ID (default ``sbx-test-redis``)
+  REDIS_NODE_GROUP_ID         - Node group / shard ID (default ``0001``)
+  AWS_REGION                  - AWS region (auto-set by Lambda)
+"""
+
+import json
+import os
+import time
+import logging
+from typing import Any, Dict, List, Optional
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+POLL_INTERVAL_SECONDS = 15
+MAX_WAIT_SECONDS = 600
+MAX_REPLICA_LAG_SECONDS = 30
+
+
+def _get_config() -> Dict[str, str]:
+    """Read configuration from environment variables with sensible defaults."""
+    return {
+        "replication_group_id": os.environ.get("REDIS_REPLICATION_GROUP_ID", "sbx-test-redis"),
+        "node_group_id": os.environ.get("REDIS_NODE_GROUP_ID", "0001"),
+        "region": os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "")),
+    }
+
+
+def _get_elasticache_client(region: str):
+    """Build an Elasticache boto3 client for the given region."""
+    return boto3.client("elasticache", region_name=region)
+
+
+def _describe_replication_group(client, replication_group_id: str) -> Dict[str, Any]:
+    """Fetch the replication group description, returning the inner dict.
+
+    Raises ``RuntimeError`` if the replication group is not found.
+    """
+    response = client.describe_replication_groups(ReplicationGroupId=replication_group_id)
+    groups: List[Dict[str, Any]] = response.get("ReplicationGroups", [])
+    if not groups:
+        raise RuntimeError(f"Replication group '{replication_group_id}' not found")
+    return groups[0]
+
+
+def _find_node_group(replication_group: Dict[str, Any], node_group_id: str) -> Optional[Dict[str, Any]]:
+    """Return the node group dict matching ``node_group_id`` or ``None``."""
+    for ng in replication_group.get("NodeGroups", []):
+        if ng.get("NodeGroupId") == node_group_id:
+            return ng
+    return None
+
+
+def _preflight_checks(client, replication_group_id: str, node_group_id: str) -> Dict[str, Any]:
+    """Run all pre-flight checks and return the initial replication group state.
+
+    Raises ``RuntimeError`` on any check failure.
+    """
+    rg = _describe_replication_group(client, replication_group_id)
+    status: str = rg.get("Status", "unknown")
+
+    # Check (a) + (d): replication group must be available (no failover/replacement in progress)
+    if status != "available":
+        raise RuntimeError(
+            f"Replication group '{replication_group_id}' status is '{status}', "
+            f"expected 'available'. A failover or replacement may already be in progress."
+        )
+
+    node_group = _find_node_group(rg, node_group_id)
+    if node_group is None:
+        raise RuntimeError(
+            f"Node group '{node_group_id}' not found in replication group '{replication_group_id}'. "
+            f"Available node groups: {[ng.get('NodeGroupId') for ng in rg.get('NodeGroups', [])]}"
+        )
+
+    # Check (b): at least 2 members (primary + replica)
+    members: List[Dict[str, Any]] = node_group.get("NodeGroupMembers", [])
+    if len(members) < 2:
+        raise RuntimeError(
+            f"Node group '{node_group_id}' has only {len(members)} member(s); "
+            f"at least 2 (primary + replica) are required for failover."
+        )
+
+    # Check (c): every replica must have ReplicaLag <= 30s (skip if absent)
+    for member in members:
+        role = member.get("CurrentRole", "")
+        if role.lower() != "replica":
+            continue
+        lag = member.get("ReadReplicaLag") or member.get("ReplicaLag")
+        if lag is None:
+            logger.info(
+                f"Replica '{member.get('CacheClusterId', '?')}' has no ReplicaLag metric; skipping lag check."
+            )
+            continue
+        # lag can be a string like "0" or a number
+        try:
+            lag_seconds = float(lag)
+        except (TypeError, ValueError):
+            logger.warning(
+                f"Replica '{member.get('CacheClusterId', '?')}' has unparseable ReplicaLag '{lag}'; skipping."
+            )
+            continue
+        if lag_seconds > MAX_REPLICA_LAG_SECONDS:
+            raise RuntimeError(
+                f"Replica '{member.get('CacheClusterId', '?')}' ReplicaLag is {lag_seconds}s, "
+                f"exceeds maximum allowed {MAX_REPLICA_LAG_SECONDS}s."
+            )
+
+    logger.info(
+        f"Pre-flight checks passed: replication_group='{replication_group_id}' status='{status}', "
+        f"node_group='{node_group_id}' members={len(members)}"
+    )
+    return rg
+
+
+def _poll_until_available(client, replication_group_id: str, max_wait: int = MAX_WAIT_SECONDS,
+                          poll_interval: int = POLL_INTERVAL_SECONDS) -> str:
+    """Poll ``describe_replication_groups`` until status is ``available``.
+
+    Returns the final status string. Raises ``RuntimeError`` on timeout.
+    """
+    deadline = time.time() + max_wait
+    last_status = "unknown"
+    while time.time() < deadline:
+        rg = _describe_replication_group(client, replication_group_id)
+        last_status = rg.get("Status", "unknown")
+        logger.info(
+            f"Polling replication group '{replication_group_id}': status='{last_status}'"
+        )
+        if last_status == "available":
+            return last_status
+        time.sleep(poll_interval)
+    raise RuntimeError(
+        f"Replication group '{replication_group_id}' did not return to 'available' "
+        f"within {max_wait}s (last status: '{last_status}')."
+    )
+
+
+def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Trigger a TestFailover on the Valkey replication group and poll until available.
+
+    Args:
+        event: Lambda event payload (unused).
+        context: Lambda runtime context (unused).
+
+    Returns:
+        A dict with ``statusCode`` and a JSON ``body`` containing
+        ``replication_group_id``, ``node_group_id``, ``initial_status``,
+        ``final_status``, and ``failover_initiated``.
+    """
+    config = _get_config()
+    replication_group_id = config["replication_group_id"]
+    node_group_id = config["node_group_id"]
+    region = config["region"]
+
+    if not region:
+        return {
+            "statusCode": 400,
+            "body": json.dumps({
+                "error": "AWS_REGION environment variable is not set",
+            }),
+        }
+
+    logger.info(
+        f"Failover test: replication_group_id='{replication_group_id}', "
+        f"node_group_id='{node_group_id}', region='{region}'"
+    )
+
+    client = _get_elasticache_client(region)
+
+    try:
+        rg = _preflight_checks(client, replication_group_id, node_group_id)
+        initial_status = rg.get("Status", "unknown")
+
+        logger.info(
+            f"Initiating TestFailover on replication group '{replication_group_id}' "
+            f"node group '{node_group_id}'"
+        )
+        client.test_failover(
+            ReplicationGroupId=replication_group_id,
+            NodeGroupId=node_group_id,
+        )
+        logger.info("TestFailover initiated successfully")
+
+        final_status = _poll_until_available(
+            client, replication_group_id,
+            max_wait=MAX_WAIT_SECONDS,
+            poll_interval=POLL_INTERVAL_SECONDS,
+        )
+
+        logger.info(
+            f"Failover complete: replication_group='{replication_group_id}' "
+            f"initial_status='{initial_status}' final_status='{final_status}'"
+        )
+
+        return {
+            "statusCode": 200,
+            "body": json.dumps({
+                "replication_group_id": replication_group_id,
+                "node_group_id": node_group_id,
+                "initial_status": initial_status,
+                "final_status": final_status,
+                "failover_initiated": True,
+            }),
+        }
+
+    except ClientError as e:
+        error_code = e.response.get("Error", {}).get("Code", "Unknown")
+        error_msg = e.response.get("Error", {}).get("Message", str(e))
+        logger.error(f"ClientError [{error_code}]: {error_msg}")
+        return {
+            "statusCode": 500,
+            "body": json.dumps({
+                "replication_group_id": replication_group_id,
+                "node_group_id": node_group_id,
+                "error": error_msg,
+                "error_code": error_code,
+                "failover_initiated": False,
+            }),
+        }
+    except RuntimeError as e:
+        logger.error(f"Pre-flight or polling error: {e}")
+        return {
+            "statusCode": 400,
+            "body": json.dumps({
+                "replication_group_id": replication_group_id,
+                "node_group_id": node_group_id,
+                "error": str(e),
+                "failover_initiated": False,
+            }),
+        }
+    except Exception as e:
+        logger.error(f"Unexpected error: {e}", exc_info=True)
+        return {
+            "statusCode": 500,
+            "body": json.dumps({
+                "replication_group_id": replication_group_id,
+                "node_group_id": node_group_id,
+                "error": str(e),
+                "failover_initiated": False,
+            }),
+        }

--- a/terraform/aws/modules/composition/elasticache-stress-test/src/memory_stress.py
+++ b/terraform/aws/modules/composition/elasticache-stress-test/src/memory_stress.py
@@ -1,0 +1,521 @@
+"""
+Memory stress Lambda for Redis/Valkey.
+
+Two modes:
+1. Legacy flat mode fills a fixed number of keys per worker over STRESS_DURATION and
+   cleans up afterwards.
+2. Phased mode (default) ramps used_memory to configured percentages of maxmemory,
+   holds each level for a configured duration, then cleans up.
+
+Phased env vars mirror the aurora-fault-injection pattern:
+  MEMORY_PHASE_DURATIONS="240,240,240"
+  MEMORY_PHASE_TARGET_PERCENT="60,85,100"
+  MEMORY_PHASE_WORKERS="8,12,24"
+  MEMORY_VALUE_SIZE="512"
+  MEMORY_PIPELINE_SIZE="5"
+  MEMORY_WRITE_TTL="0"
+  MEMORY_CLEANUP_AFTER_STRESS="true"
+"""
+
+import json
+import logging
+import os
+import threading
+import time
+
+from redis.cluster import RedisCluster, ClusterNode
+from common import get_redis_client
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def _parse_csv(env_var, default=None, cast=str):
+    raw = os.environ.get(env_var, default)
+    if raw is None:
+        return []
+    return [cast(item.strip()) for item in raw.split(",") if item.strip()]
+
+
+def _is_cluster_enabled(client):
+    # If CLUSTER_MODE env var is explicitly "false", use a standalone client
+    # even when the server has cluster mode enabled.  This guarantees all
+    # traffic (writes, scans, cleanup) goes to the configured endpoint only
+    # (the primary), never discovering or connecting to the replica.
+    env_cluster_mode = os.environ.get("CLUSTER_MODE", "").lower()
+    if env_cluster_mode == "false":
+        return False
+    try:
+        return client.info(section="cluster").get("cluster_enabled") == 1
+    except Exception:
+        return False
+
+
+def _cluster_client_from_env():
+    host = os.environ.get("REDIS_HOST", "")
+    port = int(os.environ.get("REDIS_PORT", "6379"))
+    auth_token = os.environ.get("REDIS_AUTH_TOKEN", "")
+    use_tls = os.environ.get("REDIS_USE_TLS", "false").lower() == "true"
+
+    kwargs = {
+        "decode_responses": True,
+        "socket_timeout": 30,
+        "socket_connect_timeout": 10,
+        "retry_on_timeout": True,
+        "skip_full_coverage_check": True,
+    }
+    if auth_token:
+        kwargs["password"] = auth_token
+    if use_tls:
+        kwargs["ssl"] = True
+
+    return RedisCluster(startup_nodes=[ClusterNode(host=host, port=port)], **kwargs)
+
+
+def _make_worker_client(use_cluster):
+    if use_cluster:
+        return _cluster_client_from_env()
+    return get_redis_client()
+
+
+def memory_worker(idx, key_prefix, keys_to_write, value_size_bytes, pipeline_size, write_ttl, use_cluster, results):
+    worker_key_prefix = f"{key_prefix}{{:worker{idx}:}}mem:"
+    payload = b"x" * value_size_bytes
+    written = 0
+    errors = 0
+    error_samples = []
+
+    try:
+        client = _make_worker_client(use_cluster)
+    except Exception as e:
+        logger.error(f"Worker {idx} failed to create redis client: {e}")
+        results[idx] = {
+            "status": "error",
+            "error": str(e),
+            "keys_written": 0,
+            "errors": 1,
+        }
+        return
+
+    try:
+        i = 0
+        while i < keys_to_write:
+            batch = min(pipeline_size, keys_to_write - i)
+            try:
+                pipe = client.pipeline()
+                for j in range(batch):
+                    key = f"{worker_key_prefix}{i + j}"
+                    if write_ttl > 0:
+                        pipe.set(key, payload, ex=write_ttl)
+                    else:
+                        pipe.set(key, payload)
+                result = pipe.execute()
+                if isinstance(result, list):
+                    batch_errors = sum(1 for r in result if isinstance(r, Exception))
+                    batch_ok = len(result) - batch_errors
+                    written += batch_ok
+                    if batch_errors > 0:
+                        errors += batch_errors
+                        for r in result:
+                            if isinstance(r, Exception) and len(error_samples) < 3:
+                                error_samples.append(str(r))
+                else:
+                    written += batch
+            except Exception as e:
+                errors += 1
+                if len(error_samples) < 3:
+                    error_samples.append(str(e))
+                time.sleep(0.01)
+            i += batch
+    except Exception as e:
+        logger.error(f"Memory stress worker {idx} error: {e}")
+        results[idx] = {
+            "status": "error",
+            "error": str(e),
+            "keys_written": written,
+            "errors": errors + 1,
+        }
+        return
+    finally:
+        try:
+            client.close()
+        except Exception as e:
+            logger.warning(f"Worker {idx} client close error: {e}")
+
+    results[idx] = {
+        "status": "complete",
+        "keys_written": written,
+        "errors": errors,
+        "error_samples": error_samples,
+        "bytes_written": written * value_size_bytes,
+    }
+
+
+def _legacy_run(context, key_prefix, cleanup_after):
+    duration = int(os.environ.get("STRESS_DURATION", "300"))
+    workers = int(os.environ.get("MEMORY_WORKERS", "24"))
+    keys_per_worker = int(os.environ.get("MEMORY_KEYS_PER_WORKER", "5000"))
+    value_size_kb = int(os.environ.get("MEMORY_VALUE_SIZE", "4096"))
+    pipeline_size = int(os.environ.get("MEMORY_PIPELINE_SIZE", "5"))
+    write_ttl = int(os.environ.get("MEMORY_WRITE_TTL", "0"))
+    value_size_bytes = value_size_kb * 1024
+    total_target_bytes = workers * keys_per_worker * value_size_bytes
+    total_target_gb = round(total_target_bytes / (1024 ** 3), 2)
+
+    logger.info(
+        f"Memory stress (flat): {workers} workers x {keys_per_worker} keys x {value_size_kb}KB "
+        f"(pipeline={pipeline_size}, ttl={write_ttl}) = {total_target_gb}GB target over {duration}s"
+    )
+
+    info_client = get_redis_client()
+    try:
+        info_client.ping()
+        info_before = info_client.info()
+        used_memory_before = info_before.get("used_memory_human", "?")
+        used_memory_bytes_before = info_before.get("used_memory", 0)
+        maxmemory = info_before.get("maxmemory", 0)
+        eviction_policy = info_before.get("eviction_policy", "?")
+    finally:
+        try:
+            info_client.close()
+        except Exception as e:
+            logger.warning(f"info_client close error: {e}")
+
+    results = [None] * workers
+    threads = []
+    end_time = time.time() + duration
+
+    initial_client = get_redis_client()
+    use_cluster = _is_cluster_enabled(initial_client)
+    initial_client.close()
+
+    for i in range(workers):
+        t = threading.Thread(
+            target=memory_worker,
+            args=(i, key_prefix, keys_per_worker, value_size_bytes, pipeline_size, write_ttl, use_cluster, results),
+        )
+        t.daemon = True
+        t.start()
+        threads.append(t)
+
+    for t in threads:
+        t.join(timeout=duration + 120)
+
+    info_after, used_memory_after, evicted_keys, keyspace_hits, keyspace_misses, connected_clients = _read_info_metrics()
+
+    total_written = sum(r["keys_written"] for r in results if r and r.get("status") == "complete") if results else 0
+    total_errors = sum(r["errors"] for r in results if r) if results else 0
+    total_bytes = sum(r.get("bytes_written", 0) for r in results if r) if results else 0
+    total_gb_written = round(total_bytes / (1024 ** 3), 2)
+    worker_errors = sum(1 for r in results if r and r.get("status") == "error")
+
+    keys_cleaned = 0
+    if cleanup_after:
+        keys_cleaned = _cleanup_stress_keys(context, key_prefix)
+        logger.info(f"Cleaned {keys_cleaned} stress keys")
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps({
+            "mode": "flat",
+            "stress_type": os.environ.get("STRESS_TYPE", "memory_stress"),
+            "workers": workers,
+            "keys_per_worker": keys_per_worker,
+            "value_size_kb": value_size_kb,
+            "pipeline_size": pipeline_size,
+            "write_ttl": write_ttl,
+            "total_keys_written": total_written,
+            "total_bytes_written_gb": total_gb_written,
+            "write_errors": total_errors,
+            "worker_errors": worker_errors,
+            "keys_cleaned": keys_cleaned,
+            "used_memory_before": used_memory_before,
+            "used_memory_after": used_memory_after,
+            "maxmemory": maxmemory,
+            "eviction_policy": eviction_policy,
+            "evicted_keys": evicted_keys,
+            "keyspace_hits": keyspace_hits,
+            "keyspace_misses": keyspace_misses,
+            "connected_clients": connected_clients,
+            "elapsed_seconds": duration,
+        }),
+    }
+
+
+def _read_info_metrics():
+    info_client = get_redis_client()
+    try:
+        info_after = info_client.info()
+        used_memory_after = info_after.get("used_memory_human", "?")
+        evicted_keys = info_after.get("evicted_keys", 0)
+        keyspace_hits = info_after.get("keyspace_hits", 0)
+        keyspace_misses = info_after.get("keyspace_misses", 0)
+        connected_clients = info_after.get("connected_clients", 0)
+        return info_after, used_memory_after, evicted_keys, keyspace_hits, keyspace_misses, connected_clients
+    finally:
+        try:
+            info_client.close()
+        except Exception as e:
+            logger.warning(f"info_client close error: {e}")
+
+
+def _run_phased(context, key_prefix, cleanup_after):
+    durations = _parse_csv("MEMORY_PHASE_DURATIONS", default="240,240,240", cast=int)
+    target_percents = _parse_csv("MEMORY_PHASE_TARGET_PERCENT", default="60,85,100", cast=float)
+    worker_counts = _parse_csv("MEMORY_PHASE_WORKERS", default="8,12,24", cast=int)
+
+    if not (len(durations) == len(target_percents) == len(worker_counts)):
+        raise ValueError("MEMORY_PHASE_DURATIONS, MEMORY_PHASE_TARGET_PERCENT and MEMORY_PHASE_WORKERS must all have the same length")
+    if not durations:
+        raise ValueError("At least one phase is required when MEMORY_PHASE_TARGET_PERCENT is set")
+    if any(d <= 0 for d in durations):
+        raise ValueError("All MEMORY_PHASE_DURATIONS values must be positive integers")
+    if any(p <= 0 or p > 100 for p in target_percents):
+        raise ValueError("All MEMORY_PHASE_TARGET_PERCENT values must be in (0, 100]")
+    if any(w <= 0 for w in worker_counts):
+        raise ValueError("All MEMORY_PHASE_WORKERS values must be positive integers")
+
+    value_size_kb = int(os.environ.get("MEMORY_VALUE_SIZE", "512"))
+    pipeline_size = int(os.environ.get("MEMORY_PIPELINE_SIZE", "5"))
+    write_ttl = int(os.environ.get("MEMORY_WRITE_TTL", "0"))
+    value_size_bytes = value_size_kb * 1024
+
+    info_client = get_redis_client()
+    try:
+        info_client.ping()
+        info_before = info_client.info()
+        used_memory_before = info_before.get("used_memory_human", "?")
+        used_memory_bytes_before = info_before.get("used_memory", 0)
+        maxmemory = info_before.get("maxmemory", 0)
+        eviction_policy = info_before.get("eviction_policy", "?")
+        use_cluster = _is_cluster_enabled(info_client)
+    finally:
+        try:
+            info_client.close()
+        except Exception as e:
+            logger.warning(f"info_client close error: {e}")
+
+    if maxmemory <= 0:
+        raise RuntimeError("maxmemory is not configured or reported as zero; cannot compute phased memory targets")
+
+    start_ts = time.time()
+    current_used = used_memory_bytes_before
+    phase_summaries = []
+    cumulative_offset = 0.0
+
+    for phase_idx, phase_duration in enumerate(durations):
+        phase_start = start_ts + cumulative_offset
+        phase_end = phase_start + phase_duration
+        cumulative_offset += phase_duration
+
+        target_pct = target_percents[phase_idx]
+        target_bytes = int(maxmemory * target_pct / 100.0)
+        bytes_to_add = max(0, target_bytes - current_used)
+        keys_to_add = bytes_to_add // value_size_bytes
+        workers = worker_counts[phase_idx]
+
+        logger.info(
+            f"Phase {phase_idx + 1}: target {target_pct}% of maxmemory ({target_bytes} bytes), "
+            f"currently {current_used} bytes, adding {bytes_to_add} bytes ({keys_to_add} keys) via {workers} workers"
+        )
+
+        results = [None] * workers
+        if keys_to_add > 0 and workers > 0:
+            base = keys_to_add // workers
+            extra = keys_to_add % workers
+            threads = []
+            for worker_idx in range(workers):
+                worker_keys = base + (1 if worker_idx < extra else 0)
+                if worker_keys <= 0:
+                    results[worker_idx] = {"status": "complete", "keys_written": 0, "errors": 0, "bytes_written": 0}
+                    continue
+                t = threading.Thread(
+                    target=memory_worker,
+                    args=(worker_idx, key_prefix, worker_keys, value_size_bytes, pipeline_size, write_ttl, use_cluster, results),
+                )
+                t.daemon = True
+                t.start()
+                threads.append(t)
+
+            for t in threads:
+                t.join(timeout=phase_duration + 120)
+
+            phase_keys_written = sum(r["keys_written"] for r in results if r and r.get("status") == "complete")
+            phase_errors = sum(r["errors"] for r in results if r)
+            phase_bytes = sum(r.get("bytes_written", 0) for r in results if r)
+        else:
+            phase_keys_written = 0
+            phase_errors = 0
+            phase_bytes = 0
+
+        for fill_attempt in range(5):
+            fill_check = get_redis_client()
+            try:
+                actual_used = fill_check.info().get("used_memory", 0)
+            finally:
+                try:
+                    fill_check.close()
+                except Exception:
+                    pass
+
+            if actual_used >= target_bytes:
+                logger.info(
+                    f"Phase {phase_idx + 1}: target reached "
+                    f"({actual_used}/{target_bytes} bytes)"
+                )
+                break
+
+            gap = target_bytes - actual_used
+            fill_keys = max(1, gap // value_size_bytes)
+            logger.info(
+                f"Phase {phase_idx + 1}: fill attempt {fill_attempt + 1}, "
+                f"used={actual_used}, target={target_bytes}, gap={gap}, "
+                f"writing {fill_keys} more keys"
+            )
+
+            fill_results = [None]
+            fill_id = 900 + phase_idx * 10 + fill_attempt
+            ft = threading.Thread(
+                target=memory_worker,
+                args=(fill_id, key_prefix, fill_keys, value_size_bytes,
+                      pipeline_size, write_ttl, use_cluster, fill_results),
+            )
+            ft.daemon = True
+            ft.start()
+            ft.join(timeout=120)
+
+            fr = fill_results[0]
+            if fr and fr.get("status") == "complete":
+                phase_keys_written += fr.get("keys_written", 0)
+                phase_bytes += fr.get("bytes_written", 0)
+                phase_errors += fr.get("errors", 0)
+                if fr.get("keys_written", 0) == 0:
+                    logger.warning(
+                        f"Phase {phase_idx + 1}: fill wrote 0 keys, stopping"
+                    )
+                    break
+            else:
+                logger.warning(
+                    f"Phase {phase_idx + 1}: fill failed, stopping"
+                )
+                break
+
+        _, used_memory_str, *_ = _read_info_metrics()
+        next_client = get_redis_client()
+        try:
+            current_used = next_client.info().get("used_memory", current_used)
+        finally:
+            try:
+                next_client.close()
+            except Exception:
+                pass
+
+        phase_summaries.append({
+            "phase": phase_idx + 1,
+            "target_percent": target_pct,
+            "target_bytes": target_bytes,
+            "workers": workers,
+            "keys_written": phase_keys_written,
+            "bytes_written": phase_bytes,
+            "errors": phase_errors,
+            "used_memory_after": used_memory_str,
+        })
+
+        now = time.time()
+        if now < phase_end:
+            time.sleep(phase_end - now)
+
+    info_after, used_memory_after, evicted_keys, keyspace_hits, keyspace_misses, connected_clients = _read_info_metrics()
+
+    total_keys_written = sum(p["keys_written"] for p in phase_summaries)
+    total_errors = sum(p["errors"] for p in phase_summaries)
+    total_bytes = sum(p["bytes_written"] for p in phase_summaries)
+    total_gb_written = round(total_bytes / (1024 ** 3), 2)
+
+    keys_cleaned = 0
+    if cleanup_after:
+        keys_cleaned = _cleanup_stress_keys(context, key_prefix)
+        logger.info(f"Cleaned {keys_cleaned} stress keys")
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps({
+            "mode": "phased",
+            "stress_type": os.environ.get("STRESS_TYPE", "memory_stress"),
+            "phases": phase_summaries,
+            "value_size_kb": value_size_kb,
+            "pipeline_size": pipeline_size,
+            "write_ttl": write_ttl,
+            "total_keys_written": total_keys_written,
+            "total_bytes_written_gb": total_gb_written,
+            "write_errors": total_errors,
+            "keys_cleaned": keys_cleaned,
+            "used_memory_before": used_memory_before,
+            "used_memory_after": used_memory_after,
+            "maxmemory": maxmemory,
+            "eviction_policy": eviction_policy,
+            "evicted_keys": evicted_keys,
+            "keyspace_hits": keyspace_hits,
+            "keyspace_misses": keyspace_misses,
+            "connected_clients": connected_clients,
+            "elapsed_seconds": int(time.time() - start_ts),
+        }),
+    }
+
+
+def _unlink_keys_safely(client, keys):
+    pipe = client.pipeline()
+    for key in keys:
+        pipe.unlink(key)
+    pipe.execute()
+
+
+def _cleanup_stress_keys(context, key_prefix):
+    cluster_client = None
+    standalone_client = None
+    deleted = 0
+    batch_size = 1000
+    min_remaining_ms = 30000
+    keys_batch = []
+
+    try:
+        try:
+            cluster_client = _cluster_client_from_env()
+            client = cluster_client
+            logger.info("Cleanup: using RedisCluster client to scan all nodes")
+        except Exception as e:
+            logger.warning(f"Cleanup: cluster client failed ({e}), falling back to standalone")
+            standalone_client = get_redis_client()
+            client = standalone_client
+
+        for key in client.scan_iter(match=f"{key_prefix}*", count=batch_size):
+            keys_batch.append(key)
+            if len(keys_batch) >= batch_size:
+                _unlink_keys_safely(client, keys_batch)
+                deleted += len(keys_batch)
+                keys_batch = []
+                if context.get_remaining_time_in_millis() < min_remaining_ms:
+                    logger.info("Stopping cleanup: nearing Lambda timeout")
+                    return deleted
+        if keys_batch:
+            _unlink_keys_safely(client, keys_batch)
+            deleted += len(keys_batch)
+    finally:
+        for c in (cluster_client, standalone_client):
+            if c is not None:
+                try:
+                    c.close()
+                except Exception:
+                    pass
+
+    return deleted
+
+
+def lambda_handler(event, context):
+    cleanup_after = os.environ.get("MEMORY_CLEANUP_AFTER_STRESS", "true").lower() == "true"
+    key_prefix = os.environ.get("KEY_PREFIX", "stress:test:")
+
+    if os.environ.get("MEMORY_PHASE_TARGET_PERCENT", "").strip():
+        return _run_phased(context, key_prefix, cleanup_after)
+
+    return _legacy_run(context, key_prefix, cleanup_after)

--- a/terraform/aws/modules/composition/elasticache-stress-test/src/mixed_workload.py
+++ b/terraform/aws/modules/composition/elasticache-stress-test/src/mixed_workload.py
@@ -1,0 +1,538 @@
+"""
+Mixed workload Lambda for Redis/Valkey.
+
+Open-loop, fixed-arrival-rate stress test that sends a configurable mix of
+Redis commands (GET, SET, HGET, HSET, INCR) at a target ops/sec per phase.
+Measures latency percentiles (p50/p95/p99/p99.9) and optionally emits
+CloudWatch custom metrics.
+
+Open-loop means the send schedule is based on absolute time, not on when
+the previous response returned.  If Redis is slow the worker falls behind
+and does NOT self-throttle or catch up -- it simply resumes at the target
+rate from the current time.
+
+Environment variables (all mapped from Terraform variables in main.tf):
+  WORKLOAD_PHASE_DURATIONS="60,180,180"
+  WORKLOAD_PHASE_OPS_PER_SEC="20000,35000,45000"
+  WORKLOAD_COMMAND_MIX="get:60,set:20,hget:10,hset:5,incr:5"
+  WORKLOAD_PIPELINE_SIZE=1
+  WORKLOAD_KEY_PATTERN="stress:test:{id}"
+  WORKLOAD_KEY_COUNT=100000
+  WORKLOAD_VALUE_SIZE_BYTES=256
+  WORKLOAD_EMIT_CLOUDWATCH_METRICS=false
+  WORKLOAD_PHASE_CYCLE_PERIOD_SECONDS=2
+  WORKLOAD_THREADS=32        (dedicated thread count; falls back to THREADS)
+  ENVIRONMENT=sbx            (from common env, used for CW metric dimension)
+"""
+
+import json
+import logging
+import math
+import os
+import random
+import threading
+import time
+
+from common import get_redis_client
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+_SUPPORTED_COMMANDS = ("get", "set", "hget", "hset", "incr")
+
+# Cap per-worker latency samples to avoid OOM on high-RPS tests.
+# Reservoir sampling keeps a random subset of this size.
+_MAX_LATENCY_SAMPLES = 100000
+
+
+def _parse_csv(env_var, default=None, cast=str):
+    raw = os.environ.get(env_var, default)
+    if raw is None:
+        return []
+    return [cast(item.strip()) for item in raw.split(",") if item.strip()]
+
+
+def _parse_command_mix(raw):
+    """Parse ``get:60,set:20,hget:10,hset:5,incr:5`` into ``[(cmd, weight), ...]``.
+
+    Weights need NOT sum to 100; they are normalised by their total at
+    selection time.
+    """
+    pairs = []
+    for item in raw.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        if ":" not in item:
+            raise ValueError(
+                f"Invalid command mix entry '{item}': expected 'command:weight'"
+            )
+        cmd, weight_str = item.rsplit(":", 1)
+        cmd = cmd.strip().lower()
+        weight = float(weight_str.strip())
+        if cmd not in _SUPPORTED_COMMANDS:
+            raise ValueError(
+                f"Unsupported command '{cmd}' in mix. "
+                f"Supported: {', '.join(_SUPPORTED_COMMANDS)}"
+            )
+        if weight <= 0:
+            raise ValueError(f"Weight for '{cmd}' must be positive, got {weight}")
+        pairs.append((cmd, weight))
+    if not pairs:
+        raise ValueError(
+            "WORKLOAD_COMMAND_MIX must contain at least one command:weight pair"
+        )
+    return pairs
+
+
+def _percentile(sorted_values, pct):
+    """Return the *pct*-th percentile of *sorted_values* using nearest-rank.
+
+    Args:
+        sorted_values: list of floats sorted in ascending order.
+        pct: percentile in the range (0, 100].
+
+    Returns:
+        float value at the requested percentile, or 0.0 for an empty list.
+    """
+    if not sorted_values:
+        return 0.0
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    rank = math.ceil((pct / 100.0) * len(sorted_values))
+    rank = max(1, min(rank, len(sorted_values)))
+    return sorted_values[rank - 1]
+
+
+def _build_command(cmd, key_pattern, key_count, value_size):
+    """Return ``(method_name, args_tuple)`` for *cmd*.
+
+    The caller invokes ``getattr(client_or_pipe, method_name)(*args)``.
+    """
+    key_id = random.randint(0, key_count - 1)
+    key = key_pattern.replace("{id}", str(key_id))
+
+    if cmd == "get":
+        return ("get", (key,))
+    if cmd == "set":
+        value = os.urandom(value_size)
+        return ("set", (key, value))
+    if cmd == "hget":
+        field = f"field:{random.randint(0, 99)}"
+        return ("hget", (key, field))
+    if cmd == "hset":
+        field = f"field:{random.randint(0, 99)}"
+        value = os.urandom(value_size)
+        return ("hset", (key, field, value))
+    if cmd == "incr":
+        return ("incr", (key,))
+    raise ValueError(f"Unsupported command: {cmd}")
+
+
+def _pick_command(mix, total_weight):
+    """Pick a command from the weighted *mix* using cumulative weights."""
+    r = random.uniform(0, total_weight)
+    cumulative = 0.0
+    for cmd, weight in mix:
+        cumulative += weight
+        if r <= cumulative:
+            return cmd
+    return mix[-1][0]
+
+
+def _emit_cloudwatch_metrics(environment, phase_idx, operations, errors,
+                             p50_ms, p99_ms):
+    """Emit CloudWatch custom metrics for a completed phase."""
+    try:
+        import boto3
+
+        cw = boto3.client(
+            "cloudwatch",
+            region_name=os.environ.get("AWS_REGION", "us-east-1"),
+        )
+        dimensions = [
+            {"Name": "StressType", "Value": "mixed_workload"},
+            {"Name": "Environment", "Value": environment},
+        ]
+        cw.put_metric_data(
+            Namespace="Hyperswitch/ElastiCacheStress",
+            MetricData=[
+                {
+                    "MetricName": "Operations",
+                    "Value": operations,
+                    "Unit": "Count",
+                    "Dimensions": dimensions,
+                },
+                {
+                    "MetricName": "Errors",
+                    "Value": errors,
+                    "Unit": "Count",
+                    "Dimensions": dimensions,
+                },
+                {
+                    "MetricName": "P50Latency",
+                    "Value": p50_ms,
+                    "Unit": "Milliseconds",
+                    "Dimensions": dimensions,
+                },
+                {
+                    "MetricName": "P99Latency",
+                    "Value": p99_ms,
+                    "Unit": "Milliseconds",
+                    "Dimensions": dimensions,
+                },
+            ],
+        )
+        logger.info(
+            "Emitted CloudWatch metrics for phase %d: ops=%d, errors=%d, "
+            "p50=%.2fms, p99=%.2fms",
+            phase_idx + 1, operations, errors, p50_ms, p99_ms,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to emit CloudWatch metrics for phase %d: %s",
+            phase_idx + 1, exc,
+        )
+
+
+def _ping_with_retry(client_factory, attempts=3, backoff_seconds=5):
+    last_error = None
+    for attempt in range(1, attempts + 1):
+        client = None
+        try:
+            client = client_factory()
+            client.ping()
+            client.close()
+            logger.info("Redis connectivity check passed on attempt %d", attempt)
+            return True
+        except Exception as exc:
+            last_error = exc
+            logger.warning(
+                "Redis connectivity check attempt %d failed: %s", attempt, exc
+            )
+            if client is not None:
+                try:
+                    client.close()
+                except Exception:
+                    pass
+            if attempt < attempts:
+                time.sleep(backoff_seconds)
+    logger.error(
+        "Redis connectivity check failed after %d attempts: %s",
+        attempts, last_error,
+    )
+    return False
+
+
+def _worker(worker_id, client_factory, phase_idx, phase_start, phase_end,
+            per_thread_ops_sec, mix, total_weight, key_pattern, key_count,
+            value_size, pipeline_size, jitter_max, phase_latencies,
+            results, index_in_results):
+    """Open-loop worker: sends commands at fixed intervals.
+
+    The schedule is based on absolute wall-clock time.  If the worker falls
+    behind because Redis is slow, it does NOT self-throttle or catch up --
+    it simply resumes at the target rate from the current time.
+    """
+    client = None
+    ops = 0
+    errors = 0
+    local_latencies = []
+    latency_sample_count = 0
+
+    try:
+        client = client_factory()
+    except Exception as exc:
+        logger.exception("[mixed-w%d] failed to create Redis client", worker_id)
+        results[index_in_results] = {
+            "worker": worker_id,
+            "phase": phase_idx + 1,
+            "error": str(exc),
+            "operations": 0,
+            "errors": 0,
+            "latency_ms": {},
+        }
+        return
+
+    try:
+        sleep_to_start = phase_start - time.time()
+        if sleep_to_start > 0:
+            time.sleep(sleep_to_start)
+
+        if jitter_max > 0:
+            time.sleep(random.uniform(0, jitter_max))
+
+        # Each loop iteration sends one pipeline batch (pipeline_size commands).
+        # Schedule batches so the per-thread ops/sec matches the target.
+        interval = (
+            pipeline_size / per_thread_ops_sec
+            if per_thread_ops_sec > 0 else 0
+        )
+        next_send = time.time()
+
+        logger.info(
+            "[mixed-w%d] phase %d started: %.1f ops/sec, interval=%.5fs, "
+            "pipeline=%d",
+            worker_id, phase_idx + 1, per_thread_ops_sec, interval,
+            pipeline_size,
+        )
+
+        while time.time() < phase_end:
+            now = time.time()
+            if now < next_send:
+                time.sleep(next_send - now)
+
+            start_ts = time.perf_counter()
+            try:
+                if pipeline_size > 1:
+                    pipe = client.pipeline()
+                    for _ in range(pipeline_size):
+                        cmd = _pick_command(mix, total_weight)
+                        method_name, args = _build_command(
+                            cmd, key_pattern, key_count, value_size
+                        )
+                        getattr(pipe, method_name)(*args)
+                    pipe.execute()
+                    ops += pipeline_size
+                else:
+                    cmd = _pick_command(mix, total_weight)
+                    method_name, args = _build_command(
+                        cmd, key_pattern, key_count, value_size
+                    )
+                    getattr(client, method_name)(*args)
+                    ops += 1
+            except Exception as exc:
+                errors += 1
+                logger.warning(
+                    "[mixed-w%d] command failed: %s", worker_id, exc
+                )
+            finally:
+                elapsed_ms = (time.perf_counter() - start_ts) * 1000.0
+                latency_sample_count += 1
+                if len(local_latencies) < _MAX_LATENCY_SAMPLES:
+                    local_latencies.append(elapsed_ms)
+                else:
+                    # Reservoir sampling: keep a random fixed-size subset so
+                    # high-RPS tests don't OOM while still computing percentiles.
+                    idx = random.randint(0, latency_sample_count - 1)
+                    if idx < _MAX_LATENCY_SAMPLES:
+                        local_latencies[idx] = elapsed_ms
+
+            next_send += interval
+            if next_send < time.time():
+                next_send = time.time()
+
+    except Exception as exc:
+        logger.exception(
+            "[mixed-w%d] unhandled exception in phase %d",
+            worker_id, phase_idx + 1,
+        )
+        results[index_in_results] = {
+            "worker": worker_id,
+            "phase": phase_idx + 1,
+            "error": str(exc),
+            "operations": ops,
+            "errors": errors,
+            "latency_ms": {},
+        }
+    finally:
+        if client is not None:
+            try:
+                client.close()
+            except Exception:
+                pass
+
+        phase_latencies.extend(local_latencies)
+
+        local_latencies.sort()
+        results[index_in_results] = {
+            "worker": worker_id,
+            "phase": phase_idx + 1,
+            "operations": ops,
+            "errors": errors,
+            "latency_samples": latency_sample_count,
+            "latency_ms": {
+                "p50": round(_percentile(local_latencies, 50), 3),
+                "p95": round(_percentile(local_latencies, 95), 3),
+                "p99": round(_percentile(local_latencies, 99), 3),
+                "p99.9": round(_percentile(local_latencies, 99.9), 3),
+            },
+        }
+
+
+def lambda_handler(event, context):
+    _ = event
+    _ = context
+
+    durations = _parse_csv(
+        "WORKLOAD_PHASE_DURATIONS", default="60,180,180", cast=int
+    )
+    ops_per_sec = _parse_csv(
+        "WORKLOAD_PHASE_OPS_PER_SEC", default="20000,35000,45000", cast=int
+    )
+    command_mix_raw = os.environ.get(
+        "WORKLOAD_COMMAND_MIX", "get:60,set:20,hget:10,hset:5,incr:5"
+    )
+    pipeline_size = int(os.environ.get("WORKLOAD_PIPELINE_SIZE", "1"))
+    key_pattern = os.environ.get("WORKLOAD_KEY_PATTERN", "stress:test:{id}")
+    key_count = int(os.environ.get("WORKLOAD_KEY_COUNT", "100000"))
+    value_size = int(os.environ.get("WORKLOAD_VALUE_SIZE_BYTES", "256"))
+    emit_cw = os.environ.get(
+        "WORKLOAD_EMIT_CLOUDWATCH_METRICS", "false"
+    ).lower() == "true"
+    jitter_max = int(os.environ.get(
+        "WORKLOAD_PHASE_CYCLE_PERIOD_SECONDS", "2"
+    ))
+    num_threads = int(
+        os.environ.get("WORKLOAD_THREADS", os.environ.get("THREADS", "4"))
+    )
+    environment = os.environ.get("ENVIRONMENT", "unknown")
+
+    if len(durations) != len(ops_per_sec):
+        raise ValueError(
+            "WORKLOAD_PHASE_DURATIONS and WORKLOAD_PHASE_OPS_PER_SEC must "
+            "have the same length"
+        )
+    if not durations:
+        raise ValueError("At least one phase is required")
+    if any(d <= 0 for d in durations):
+        raise ValueError("All WORKLOAD_PHASE_DURATIONS values must be positive")
+    if any(o <= 0 for o in ops_per_sec):
+        raise ValueError(
+            "All WORKLOAD_PHASE_OPS_PER_SEC values must be positive"
+        )
+    if pipeline_size < 1:
+        raise ValueError("WORKLOAD_PIPELINE_SIZE must be >= 1")
+    if key_count < 1:
+        raise ValueError("WORKLOAD_KEY_COUNT must be >= 1")
+    if value_size < 1:
+        raise ValueError("WORKLOAD_VALUE_SIZE_BYTES must be >= 1")
+    if jitter_max < 0:
+        raise ValueError("WORKLOAD_PHASE_CYCLE_PERIOD_SECONDS must be >= 0")
+    if num_threads < 1:
+        raise ValueError("STRESS_THREADS must be >= 1")
+
+    mix = _parse_command_mix(command_mix_raw)
+    total_weight = sum(w for _, w in mix)
+
+    _ping_with_retry(get_redis_client)
+
+    total_duration = sum(durations)
+    start_ts = time.time()
+    results_by_phase = [None] * len(durations)
+    phase_latency_lists = [None] * len(durations)
+    threads = []
+    cumulative_offset = 0.0
+
+    for phase_idx, phase_duration in enumerate(durations):
+        phase_start = start_ts + cumulative_offset
+        phase_end = phase_start + phase_duration
+        cumulative_offset += phase_duration
+
+        target_ops = ops_per_sec[phase_idx]
+        per_thread_ops_sec = target_ops / num_threads
+
+        phase_latencies = []
+        phase_latency_lists[phase_idx] = phase_latencies
+        phase_results = [None] * num_threads
+        results_by_phase[phase_idx] = {
+            "phase": phase_idx + 1,
+            "duration_seconds": phase_duration,
+            "target_ops_per_sec": target_ops,
+            "threads": num_threads,
+            "per_thread_ops_per_sec": round(per_thread_ops_sec, 2),
+            "pipeline_size": pipeline_size,
+            "jitter_max_seconds": jitter_max,
+            "command_mix": command_mix_raw,
+            "workers": phase_results,
+        }
+
+        for worker_idx in range(num_threads):
+            t = threading.Thread(
+                target=_worker,
+                args=(
+                    worker_idx,
+                    get_redis_client,
+                    phase_idx,
+                    phase_start,
+                    phase_end,
+                    per_thread_ops_sec,
+                    mix,
+                    total_weight,
+                    key_pattern,
+                    key_count,
+                    value_size,
+                    pipeline_size,
+                    jitter_max,
+                    phase_latencies,
+                    phase_results,
+                    worker_idx,
+                ),
+            )
+            t.daemon = True
+            t.start()
+            threads.append(t)
+
+        logger.info(
+            "Scheduled phase %d: %d threads, %ss duration, %d ops/sec target "
+            "(%.1f/thread), pipeline=%d",
+            phase_idx + 1, num_threads, phase_duration, target_ops,
+            per_thread_ops_sec, pipeline_size,
+        )
+
+    deadline = start_ts + total_duration + 120
+    for t in threads:
+        remaining = max(0, deadline - time.time())
+        t.join(timeout=remaining)
+
+    for phase_idx in range(len(durations)):
+        phase_data = results_by_phase[phase_idx]
+        if phase_data is None:
+            continue
+
+        workers = phase_data["workers"]
+        total_ops = sum(w.get("operations", 0) for w in workers if w)
+        total_errors = sum(w.get("errors", 0) for w in workers if w)
+
+        phase_latencies = phase_latency_lists[phase_idx]
+        phase_latencies.sort()
+        p50 = _percentile(phase_latencies, 50)
+        p95 = _percentile(phase_latencies, 95)
+        p99 = _percentile(phase_latencies, 99)
+        p999 = _percentile(phase_latencies, 99.9)
+
+        phase_data["total_operations"] = total_ops
+        phase_data["total_errors"] = total_errors
+        phase_data["ops_per_sec"] = (
+            round(total_ops / durations[phase_idx], 2)
+            if durations[phase_idx] > 0 else 0
+        )
+        phase_data["latency_ms"] = {
+            "p50": round(p50, 3),
+            "p95": round(p95, 3),
+            "p99": round(p99, 3),
+            "p99.9": round(p999, 3),
+        }
+        phase_data["latency_samples"] = len(phase_latencies)
+
+        if emit_cw:
+            _emit_cloudwatch_metrics(
+                environment, phase_idx, total_ops, total_errors, p50, p99
+            )
+
+    return {
+        "statusCode": 200,
+        "mode": "phased",
+        "total_duration_seconds": total_duration,
+        "phases": results_by_phase,
+        "command_mix": command_mix_raw,
+        "pipeline_size": pipeline_size,
+        "key_pattern": key_pattern,
+        "key_count": key_count,
+        "value_size_bytes": value_size,
+        "emit_cloudwatch_metrics": emit_cw,
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(lambda_handler({}, None)))

--- a/terraform/aws/modules/composition/elasticache-stress-test/variables.tf
+++ b/terraform/aws/modules/composition/elasticache-stress-test/variables.tf
@@ -1,0 +1,343 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment short name for resource naming (e.g., sbx, prod)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for resource naming and tagging"
+  type        = string
+  default     = ""
+}
+
+variable "redis_endpoint" {
+  description = "Elasticache Redis/Valkey endpoint (configuration endpoint for cluster mode, primary endpoint for standalone)"
+  type        = string
+}
+
+variable "redis_port" {
+  description = "Redis/Valkey port"
+  type        = number
+  default     = 6379
+}
+
+variable "redis_cluster_mode" {
+  description = "Whether Redis has cluster mode enabled. If true, uses redis.cluster.RedisCluster client connecting to configuration endpoint. If false, uses redis.Redis client connecting to primary endpoint."
+  type        = bool
+  default     = true
+}
+
+variable "redis_auth_token" {
+  description = "AUTH token for Redis (if enabled). Leave empty for no AUTH."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "redis_use_tls" {
+  description = "Whether Redis has TLS enabled (transit_encryption_enabled)"
+  type        = bool
+  default     = false
+}
+
+variable "vpc_id" {
+  description = "VPC ID where Lambda functions will be deployed"
+  type        = string
+}
+
+variable "lambda_subnet_ids" {
+  description = "List of subnet IDs for Lambda VPC config (use lambda subnets)"
+  type        = list(string)
+}
+
+variable "create_security_group" {
+  description = "Create a dedicated security group for Lambda. If false, provide lambda_security_group_id (e.g., reuse jump host SG)"
+  type        = bool
+  default     = false
+}
+
+variable "lambda_security_group_id" {
+  description = "Existing security group ID for Lambda (required when create_security_group = false)"
+  type        = string
+  default     = ""
+}
+
+variable "redis_security_group_id" {
+  description = "Redis security group ID (required when create_security_group = true, to add ingress rule for port 6379)"
+  type        = string
+  default     = ""
+}
+
+variable "lambda_runtime" {
+  description = "Lambda runtime (must match compatible_runtimes of the redis-py layer)"
+  type        = string
+  default     = "python3.11"
+}
+
+variable "lambda_layers" {
+  description = "List of Lambda layer ARNs (e.g., existing redis-py-python311 layer)"
+  type        = list(string)
+  default     = []
+}
+
+variable "lambda_timeout" {
+  description = "Lambda timeout in seconds for stress test functions (max 900)"
+  type        = number
+  default     = 900
+}
+
+variable "lambda_memory_size" {
+  description = "Lambda memory size in MB for stress test functions"
+  type        = number
+  default     = 512
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch log group retention in days"
+  type        = number
+  default     = 14
+}
+
+variable "stress_duration" {
+  description = "Default stress test duration in seconds"
+  type        = number
+  default     = 300
+}
+
+variable "stress_clients" {
+  description = "Default number of concurrent clients/connections for stress tests"
+  type        = number
+  default     = 50
+}
+
+variable "stress_threads" {
+  description = "Default number of worker threads for stress tests"
+  type        = number
+  default     = 4
+}
+
+variable "cpu_burn_iterations" {
+  description = "Number of Lua iterations in the CPU stress script (default 500k ≈ 20-50ms on cache.m6g.large)"
+  type        = number
+  default     = 500000
+}
+
+variable "cpu_mixed_mode" {
+  description = "If true, CPU stress mixes SET/GET/INCR with Lua burn. If false, runs pure Lua burn (higher EngineCPU)."
+  type        = bool
+  default     = false
+}
+
+variable "memory_key_count" {
+  description = "Number of keys to write for memory stress test (legacy; prefer memory_keys_per_worker)"
+  type        = number
+  default     = 10000
+}
+
+variable "memory_value_size_kb" {
+  description = "Size of each value in KB for memory stress test"
+  type        = number
+  default     = 4096
+}
+
+variable "memory_workers" {
+  description = "Number of per-worker threads (each with its own redis client) for memory stress test"
+  type        = number
+  default     = 24
+}
+
+variable "memory_keys_per_worker" {
+  description = "Number of keys each memory stress worker writes before stopping"
+  type        = number
+  default     = 5000
+}
+
+variable "memory_pipeline_size" {
+  description = "Number of SET commands per pipeline batch in memory stress test"
+  type        = number
+  default     = 5
+}
+
+variable "memory_write_ttl" {
+  description = "TTL in seconds for memory stress keys (0 = no TTL, keys persist until eviction or cleanup)"
+  type        = number
+  default     = 0
+}
+
+variable "memory_cleanup_after_stress" {
+  description = "If true, memory_stress automatically unlinks all stress keys before returning"
+  type        = bool
+  default     = true
+}
+
+variable "connection_target" {
+  description = "Target number of concurrent connections for connection exhaustion test (legacy; prefer connection_target_total)"
+  type        = number
+  default     = 1000
+}
+
+variable "connection_threads" {
+  description = "Number of worker threads for connection exhaustion test"
+  type        = number
+  default     = 48
+}
+
+variable "connection_batch_size" {
+  description = "Number of raw TCP sockets opened per batch per worker in connection exhaustion test"
+  type        = number
+  default     = 100
+}
+
+variable "connection_target_total" {
+  description = "Total number of held connections across all workers before switching to churn mode"
+  type        = number
+  default     = 850
+}
+
+variable "connection_rapid_churn" {
+  description = "If true, after reaching connection_target_total workers churn (open/handshake/close) while holding the pool"
+  type        = bool
+  default     = false
+}
+
+variable "redis_replication_group_id" {
+  description = "ElastiCache replication group ID for the failover Lambda (TestFailover API)"
+  type        = string
+  default     = ""
+}
+
+variable "redis_node_group_id" {
+  description = "ElastiCache node group / shard ID for the failover Lambda (e.g., 0001)"
+  type        = string
+  default     = "0001"
+}
+
+variable "failover_timeout_seconds" {
+  description = "Maximum time in seconds to wait for the replication group to return to available after TestFailover"
+  type        = number
+  default     = 600
+}
+
+variable "failover_poll_interval_seconds" {
+  description = "Polling interval in seconds between describe_replication_groups calls during failover recovery"
+  type        = number
+  default     = 15
+}
+
+variable "cpu_phase_durations" {
+  description = "Comma-separated phase durations in seconds for staged CPU stress (e.g. 60,300,300 = 1min warmup + 5min + 5min)"
+  type        = string
+  default     = "60,180,180"
+}
+
+variable "cpu_phase_threads" {
+  description = "Comma-separated thread counts per CPU stress phase (e.g. 8,8,8). With the linear D/N duty model, 8 threads is usually enough for a smooth 90-97% EngineCPU plateau."
+  type        = string
+  default     = "8,8,8"
+}
+
+variable "cpu_phase_duty" {
+  description = "Comma-separated duty cycles per CPU stress phase (e.g. 0.97,0.98,1.0). Values <1.0 throttle the aggregate offered load so EngineCPU stays below 100%."
+  type        = string
+  default     = "0.97,0.98,1.0"
+}
+
+variable "cpu_phase_cycle_period_seconds" {
+  description = "Max random startup jitter in seconds for CPU stress workers (e.g. 2). Small jitter is enough when per-cycle jitter is also applied; large jitter distorts 1-minute CloudWatch averages."
+  type        = number
+  default     = 2
+}
+
+variable "memory_phase_durations" {
+  description = "Comma-separated phase durations in seconds for staged memory stress (e.g. 240,240,240)"
+  type        = string
+  default     = "240,240,240"
+}
+
+variable "memory_phase_target_percent" {
+  description = "Comma-separated target used_memory percentages of maxmemory per memory stress phase (e.g. 60,85,100)"
+  type        = string
+  default     = "60,85,100"
+}
+
+variable "memory_phase_workers" {
+  description = "Comma-separated writer counts per memory stress phase (e.g. 8,12,24)"
+  type        = string
+  default     = "8,12,24"
+}
+
+variable "key_prefix" {
+  description = "Prefix for all keys created by stress tests (used by cleanup function)"
+  type        = string
+  default     = "stress:test:"
+}
+
+variable "workload_phase_durations" {
+  description = "Comma-separated phase durations in seconds for mixed workload stress (e.g. 60,180,180)"
+  type        = string
+  default     = "60,180,180"
+}
+
+variable "workload_phase_ops_per_sec" {
+  description = "Comma-separated target total ops/sec per mixed workload phase (e.g. 20000,35000,45000)"
+  type        = string
+  default     = "20000,35000,45000"
+}
+
+variable "workload_command_mix" {
+  description = "Command mix for mixed workload stress as command:weight pairs (e.g. get:60,set:20,hget:10,hset:5,incr:5). Weights are normalised by their total."
+  type        = string
+  default     = "get:60,set:20,hget:10,hset:5,incr:5"
+}
+
+variable "workload_pipeline_size" {
+  description = "Number of commands per pipeline batch in mixed workload stress (1 = no pipelining)"
+  type        = number
+  default     = 1
+}
+
+variable "workload_key_pattern" {
+  description = "Key pattern for mixed workload stress. Use {id} as placeholder for random integer in [0, workload_key_count)"
+  type        = string
+  default     = "stress:test:{id}"
+}
+
+variable "workload_key_count" {
+  description = "Upper bound for random key ID selection in mixed workload stress (keys are in [0, workload_key_count))"
+  type        = number
+  default     = 100000
+}
+
+variable "workload_value_size_bytes" {
+  description = "Size of random byte string values for SET/HSET commands in mixed workload stress"
+  type        = number
+  default     = 256
+}
+
+variable "workload_emit_cloudwatch_metrics" {
+  description = "If true, mixed workload stress emits custom CloudWatch metrics (Operations, Errors, P50Latency, P99Latency) per phase"
+  type        = bool
+  default     = false
+}
+
+variable "workload_phase_cycle_period_seconds" {
+  description = "Max random startup jitter in seconds for mixed workload workers (desynchronises thread send schedules)"
+  type        = number
+  default     = 2
+}
+
+variable "workload_threads" {
+  description = "Number of worker threads for mixed workload stress (each with its own Redis client). Dedicated knob so the generator can scale independently of other stress types."
+  type        = number
+  default     = 32
+}
+
+variable "tags" {
+  description = "Additional tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/aws/modules/composition/elasticache-stress-test/versions.tf
+++ b/terraform/aws/modules/composition/elasticache-stress-test/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">= 2.4"
+    }
+  }
+}

--- a/terraform/aws/modules/composition/fis-experiments/README.md
+++ b/terraform/aws/modules/composition/fis-experiments/README.md
@@ -64,3 +64,139 @@ module "fis_experiments" {
 - `enable_ec2_termination` — enable destructive instance termination experiments
 
 See `variables.tf` for the full input list and `outputs.tf` for emitted experiment IDs.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | >= 1.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_awscc"></a> [awscc](#provider\_awscc) | >= 1.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_metric_alarm.fis_stop_condition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.fis_stop_connections](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.fis_stop_memory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.redis_connections_stop](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.redis_cpu_stop](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.redis_memory_stop](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.redis_replica_lag_stop](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_fis_experiment_template.aurora_failover](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fis_experiment_template) | resource |
+| [aws_fis_experiment_template.combined_failover_reboot](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fis_experiment_template) | resource |
+| [aws_fis_experiment_template.connection_exhaustion_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fis_experiment_template) | resource |
+| [aws_fis_experiment_template.cpu_stress_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fis_experiment_template) | resource |
+| [aws_fis_experiment_template.ec2_termination](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fis_experiment_template) | resource |
+| [aws_fis_experiment_template.memory_stress_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fis_experiment_template) | resource |
+| [aws_fis_experiment_template.network_latency](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fis_experiment_template) | resource |
+| [aws_fis_experiment_template.network_latency_simple](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fis_experiment_template) | resource |
+| [aws_fis_experiment_template.rds_reboot](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fis_experiment_template) | resource |
+| [aws_fis_experiment_template.redis_connection_exhaustion_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fis_experiment_template) | resource |
+| [aws_fis_experiment_template.redis_cpu_stress_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fis_experiment_template) | resource |
+| [aws_fis_experiment_template.redis_failover](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fis_experiment_template) | resource |
+| [aws_fis_experiment_template.redis_failover_under_stress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fis_experiment_template) | resource |
+| [aws_fis_experiment_template.redis_memory_stress_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/fis_experiment_template) | resource |
+| [aws_iam_role.fis_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.fis_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [awscc_fis_experiment_template.az_power_interruption](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/fis_experiment_template) | resource |
+| [awscc_fis_experiment_template.network_disruption](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/fis_experiment_template) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | AWS Account ID | `string` | `""` | no |
+| <a name="input_az_interruption_duration"></a> [az\_interruption\_duration](#input\_az\_interruption\_duration) | Duration for AZ power interruption experiment (ISO 8601 format, e.g. PT30M = 30 minutes) | `string` | `"PT30M"` | no |
+| <a name="input_ec2_termination_target_instance_arns"></a> [ec2\_termination\_target\_instance\_arns](#input\_ec2\_termination\_target\_instance\_arns) | List of EC2 instance ARNs to terminate. FIS will use the aws:ec2:terminate-instances action. ⚠️ This permanently destroys the instances — only target disposable/test instances. | `list(string)` | `[]` | no |
+| <a name="input_enable_az_interruption"></a> [enable\_az\_interruption](#input\_enable\_az\_interruption) | Enable FIS experiment: AZ power interruption (compound) | `bool` | `false` | no |
+| <a name="input_enable_combined"></a> [enable\_combined](#input\_enable\_combined) | Enable FIS experiment: Combined failover + wait + reboot | `bool` | `true` | no |
+| <a name="input_enable_ec2_termination"></a> [enable\_ec2\_termination](#input\_enable\_ec2\_termination) | Enable FIS experiment: EC2 instance termination via aws:ec2:terminate-instances. ⚠️ Permanently destroys targeted instances. | `bool` | `false` | no |
+| <a name="input_enable_failover"></a> [enable\_failover](#input\_enable\_failover) | Enable FIS experiment: Aurora cluster failover | `bool` | `true` | no |
+| <a name="input_enable_network_disruption"></a> [enable\_network\_disruption](#input\_enable\_network\_disruption) | Enable FIS experiment: Network connectivity loss to DB | `bool` | `false` | no |
+| <a name="input_enable_network_latency"></a> [enable\_network\_latency](#input\_enable\_network\_latency) | Enable FIS experiment: Network latency injection on EC2 instances via aws:ssm:send-command + AWSFIS-Run-Network-Latency-Sources (tc netem) | `bool` | `false` | no |
+| <a name="input_enable_network_latency_simple"></a> [enable\_network\_latency\_simple](#input\_enable\_network\_latency\_simple) | Enable FIS experiment: Simple network latency on ALL traffic via AWSFIS-Run-Network-Latency (no source targeting, no jitter) | `bool` | `false` | no |
+| <a name="input_enable_reboot"></a> [enable\_reboot](#input\_enable\_reboot) | Enable FIS experiment: DB instance reboot | `bool` | `true` | no |
+| <a name="input_enable_redis_failover"></a> [enable\_redis\_failover](#input\_enable\_redis\_failover) | Enable FIS experiment: standalone Redis replication group failover (TestFailover via Lambda invoked through SSM on jump host) | `bool` | `false` | no |
+| <a name="input_enable_redis_failover_under_stress"></a> [enable\_redis\_failover\_under\_stress](#input\_enable\_redis\_failover\_under\_stress) | Enable FIS experiment: Redis failover triggered under CPU stress (stress starts → wait 2 minutes → failover while stress continues) | `bool` | `false` | no |
+| <a name="input_enable_redis_stress_alarms"></a> [enable\_redis\_stress\_alarms](#input\_enable\_redis\_stress\_alarms) | Enable CloudWatch alarms for Redis stress tests (EngineCPUUtilization > 90%, FreeableMemory < 100MB, CurrConnections > 64000) | `bool` | `false` | no |
+| <a name="input_enable_redis_stress_tests"></a> [enable\_redis\_stress\_tests](#input\_enable\_redis\_stress\_tests) | Enable FIS experiments: Redis CPU/memory/connection stress test Lambda invocation via SSM on jump host (ElastiCache) | `bool` | `false` | no |
+| <a name="input_enable_stress_alarms"></a> [enable\_stress\_alarms](#input\_enable\_stress\_alarms) | Enable additional CloudWatch alarms for stress tests (FreeableMemory < 2GB, DatabaseConnections > 68) | `bool` | `false` | no |
+| <a name="input_enable_stress_tests"></a> [enable\_stress\_tests](#input\_enable\_stress\_tests) | Enable FIS experiments: CPU/memory/connection stress test Lambda invocation via SM on jump host (RDS Aurora) | `bool` | `false` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (e.g., sandbox, prod) | `string` | n/a | yes |
+| <a name="input_fis_role_name"></a> [fis\_role\_name](#input\_fis\_role\_name) | Base name of the IAM role for FIS experiment execution | `string` | `"FISExperimentRole"` | no |
+| <a name="input_jumphost_instance_id"></a> [jumphost\_instance\_id](#input\_jumphost\_instance\_id) | EC2 instance ID of the jump host used to invoke stress test Lambda functions via SSM. Leave empty to skip stress test templates. | `string` | `""` | no |
+| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | KMS key ARN used by the RDS cluster for storage encryption. FIS needs kms:Decrypt/Encrypt to reboot/failover encrypted clusters. Leave empty to allow all keys. | `string` | `""` | no |
+| <a name="input_network_disruption_duration"></a> [network\_disruption\_duration](#input\_network\_disruption\_duration) | Duration for network disruption experiment (ISO 8601 format, e.g. PT3M = 3 minutes) | `string` | `"PT3M"` | no |
+| <a name="input_network_latency_delay_ms"></a> [network\_latency\_delay\_ms](#input\_network\_latency\_delay\_ms) | Network latency to inject in milliseconds | `number` | `200` | no |
+| <a name="input_network_latency_duration"></a> [network\_latency\_duration](#input\_network\_latency\_duration) | FIS action duration (ISO 8601, e.g. PT5M = 5 minutes). Must be >= network\_latency\_duration\_seconds. | `string` | `"PT5M"` | no |
+| <a name="input_network_latency_duration_seconds"></a> [network\_latency\_duration\_seconds](#input\_network\_latency\_duration\_seconds) | SSM document DurationSeconds — how long the tc netem delay rule stays active on the instance (in seconds). Must be <= FIS action duration in seconds. | `number` | `300` | no |
+| <a name="input_network_latency_flows_percent"></a> [network\_latency\_flows\_percent](#input\_network\_latency\_flows\_percent) | Percentage of network flows to affect (1-100) | `number` | `100` | no |
+| <a name="input_network_latency_install_dependencies"></a> [network\_latency\_install\_dependencies](#input\_network\_latency\_install\_dependencies) | Whether to install tc/netem dependencies via SSM. Set to false if dependencies are already baked into the AMI (e.g. custom FIS AMI) or instances are in private subnet without package repo access. | `bool` | `true` | no |
+| <a name="input_network_latency_interface"></a> [network\_latency\_interface](#input\_network\_latency\_interface) | Network interface to target: DEFAULT (primary interface), ALL (all interfaces), or specific name (e.g. eth0) | `string` | `"DEFAULT"` | no |
+| <a name="input_network_latency_jitter_ms"></a> [network\_latency\_jitter\_ms](#input\_network\_latency\_jitter\_ms) | Jitter to inject in milliseconds (added on top of delay, normal distribution) | `number` | `10` | no |
+| <a name="input_network_latency_simple_delay_ms"></a> [network\_latency\_simple\_delay\_ms](#input\_network\_latency\_simple\_delay\_ms) | Network latency to inject in milliseconds for the simple all-traffic variant (no source targeting, no jitter) | `number` | `200` | no |
+| <a name="input_network_latency_simple_interface"></a> [network\_latency\_simple\_interface](#input\_network\_latency\_simple\_interface) | Network interface for simple latency: eth0, eth1, etc. Default is eth0 (primary) | `string` | `"eth0"` | no |
+| <a name="input_network_latency_simple_sources"></a> [network\_latency\_simple\_sources](#input\_network\_latency\_simple\_sources) | Comma-separated sources for simple latency. Default ALL = all traffic. Set to specific IPs/CIDRs/domains/AZs to target only that traffic. Uses AWSFIS-Run-Network-Latency-Sources SSM document. | `string` | `"ALL"` | no |
+| <a name="input_network_latency_sources"></a> [network\_latency\_sources](#input\_network\_latency\_sources) | Comma-separated list of sources to apply latency to. Values: IPv4 address, CIDR block, domain name, AZ name (e.g. ap-south-1a), AZ ID, ALL, DYNAMODB, S3. No spaces after commas. | `string` | `"ALL"` | no |
+| <a name="input_network_latency_target_environment_tag"></a> [network\_latency\_target\_environment\_tag](#input\_network\_latency\_target\_environment\_tag) | Value of the Environment tag used to filter network latency targets. Defaults to var.environment. Set to environment.short if your live instances use the short environment code (e.g., sbx). | `string` | `""` | no |
+| <a name="input_network_latency_target_instance_arns"></a> [network\_latency\_target\_instance\_arns](#input\_network\_latency\_target\_instance\_arns) | List of EC2 instance ARNs to target for network latency injection. Used when network\_latency\_target\_resource\_tags is empty. FIS will run the AWSFIS-Run-Network-Latency-Sources SSM document on these instances via aws:ssm:send-command. | `list(string)` | `[]` | no |
+| <a name="input_network_latency_target_resource_tags"></a> [network\_latency\_target\_resource\_tags](#input\_network\_latency\_target\_resource\_tags) | Map of tags to select EC2 instances for network latency injection (e.g., {Service="envoy-proxy", Environment="dev"}). When non-empty, takes precedence over network\_latency\_target\_instance\_arns. FIS resolves targets at experiment start time, so instances can be replaced without re-applying. | `map(string)` | `{}` | no |
+| <a name="input_network_latency_target_service_names"></a> [network\_latency\_target\_service\_names](#input\_network\_latency\_target\_service\_names) | List of EC2 Service tag values to target for network latency injection (e.g., ["envoy-proxy", "locker"]). Uses FIS filters so multiple values are OR-ed. Takes precedence over instance ARNs and resource\_tags. | `list(string)` | `[]` | no |
+| <a name="input_network_latency_traffic_type"></a> [network\_latency\_traffic\_type](#input\_network\_latency\_traffic\_type) | Traffic type to apply latency to: ingress or egress | `string` | `"egress"` | no |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name for resource naming and tagging | `string` | `""` | no |
+| <a name="input_rds_cluster_arn"></a> [rds\_cluster\_arn](#input\_rds\_cluster\_arn) | ARN of the RDS Aurora cluster to target for failover experiments | `string` | n/a | yes |
+| <a name="input_rds_cluster_identifier"></a> [rds\_cluster\_identifier](#input\_rds\_cluster\_identifier) | Identifier of the RDS Aurora cluster (used for CloudWatch alarm dimension) | `string` | n/a | yes |
+| <a name="input_rds_instance_arns"></a> [rds\_instance\_arns](#input\_rds\_instance\_arns) | List of RDS DB instance ARNs to target for reboot experiments | `list(string)` | n/a | yes |
+| <a name="input_rds_security_group_id"></a> [rds\_security\_group\_id](#input\_rds\_security\_group\_id) | Security group ID of the test DB instance. Used to filter only the DB's ENIs for network disruption (not all ENIs in the subnet) | `string` | `""` | no |
+| <a name="input_redis_cluster_id"></a> [redis\_cluster\_id](#input\_redis\_cluster\_id) | Elasticache CacheClusterId (per-node cluster ID, NOT replication group ID) for Redis stress test CloudWatch alarm dimensions. E.g., sbx-test-redis-0001-001. Leave empty to skip Redis stress alarms. | `string` | `""` | no |
+| <a name="input_redis_failover_lambda_function_arn"></a> [redis\_failover\_lambda\_function\_arn](#input\_redis\_failover\_lambda\_function\_arn) | ARN of the Lambda function that triggers ElastiCache TestFailover. Used for FIS execution role IAM permissions (lambda:InvokeFunction). | `string` | `""` | no |
+| <a name="input_redis_failover_lambda_function_name"></a> [redis\_failover\_lambda\_function\_name](#input\_redis\_failover\_lambda\_function\_name) | Name of the Lambda function that triggers ElastiCache TestFailover for the Redis replication group. Invoked via SSM on the jump host. | `string` | `""` | no |
+| <a name="input_redis_node_group_id"></a> [redis\_node\_group\_id](#input\_redis\_node\_group\_id) | ElastiCache Redis node group ID (shard number) for the replication group, used as a dimension for the ReplicationLag stop-condition alarm. E.g., 0001 | `string` | `"0001"` | no |
+| <a name="input_redis_replication_group_id"></a> [redis\_replication\_group\_id](#input\_redis\_replication\_group\_id) | ElastiCache Redis replication group ID for failover experiments and replica-lag alarm dimension (e.g., sbx-test-redis). Leave empty to skip the replica-lag stop-condition alarm. | `string` | `""` | no |
+| <a name="input_redis_stress_lambda_arns"></a> [redis\_stress\_lambda\_arns](#input\_redis\_stress\_lambda\_arns) | List of Lambda function ARNs for Redis stress testing. Used for IAM permissions. Leave empty to skip Redis stress test templates. | `list(string)` | `[]` | no |
+| <a name="input_redis_stress_lambda_function_names"></a> [redis\_stress\_lambda\_function\_names](#input\_redis\_stress\_lambda\_function\_names) | Map of Redis stress type to Lambda function name. Keys must be: cpu\_stress, memory\_stress, connection\_exhaustion | `map(string)` | `{}` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS region | `string` | n/a | yes |
+| <a name="input_stress_duration_seconds"></a> [stress\_duration\_seconds](#input\_stress\_duration\_seconds) | Duration for stress test experiments in seconds (used to calculate FIS action duration) | `number` | `300` | no |
+| <a name="input_stress_lambda_arns"></a> [stress\_lambda\_arns](#input\_stress\_lambda\_arns) | List of Lambda function ARNs for stress testing. Used for IAM permissions. Leave empty to skip stress test templates. | `list(string)` | `[]` | no |
+| <a name="input_stress_lambda_function_names"></a> [stress\_lambda\_function\_names](#input\_stress\_lambda\_function\_names) | Map of stress type to Lambda function name. Keys must be: cpu\_stress, memory\_stress, connection\_exhaustion | `map(string)` | `{}` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_target_az"></a> [target\_az](#input\_target\_az) | Target availability zone for AZ power interruption experiment (e.g. ap-south-1a) | `string` | `""` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_az_interruption_experiment_id"></a> [az\_interruption\_experiment\_id](#output\_az\_interruption\_experiment\_id) | ID of the AZ power interruption experiment template |
+| <a name="output_combined_experiment_id"></a> [combined\_experiment\_id](#output\_combined\_experiment\_id) | ID of the combined failover + wait + reboot experiment template |
+| <a name="output_connection_exhaustion_experiment_id"></a> [connection\_exhaustion\_experiment\_id](#output\_connection\_exhaustion\_experiment\_id) | ID of the connection exhaustion Lambda experiment template |
+| <a name="output_cpu_stress_experiment_id"></a> [cpu\_stress\_experiment\_id](#output\_cpu\_stress\_experiment\_id) | ID of the CPU stress Lambda experiment template |
+| <a name="output_ec2_termination_experiment_id"></a> [ec2\_termination\_experiment\_id](#output\_ec2\_termination\_experiment\_id) | ID of the EC2 instance termination experiment template |
+| <a name="output_failover_experiment_id"></a> [failover\_experiment\_id](#output\_failover\_experiment\_id) | ID of the Aurora failover experiment template |
+| <a name="output_fis_role_arn"></a> [fis\_role\_arn](#output\_fis\_role\_arn) | ARN of the FIS IAM role |
+| <a name="output_fis_role_name"></a> [fis\_role\_name](#output\_fis\_role\_name) | Name of the FIS IAM role |
+| <a name="output_memory_stress_experiment_id"></a> [memory\_stress\_experiment\_id](#output\_memory\_stress\_experiment\_id) | ID of the memory stress Lambda experiment template |
+| <a name="output_network_disruption_experiment_id"></a> [network\_disruption\_experiment\_id](#output\_network\_disruption\_experiment\_id) | ID of the network connectivity loss experiment template |
+| <a name="output_network_latency_experiment_ids"></a> [network\_latency\_experiment\_ids](#output\_network\_latency\_experiment\_ids) | Map of network latency injection experiment template IDs keyed by target (Service name or default) |
+| <a name="output_network_latency_simple_experiment_ids"></a> [network\_latency\_simple\_experiment\_ids](#output\_network\_latency\_simple\_experiment\_ids) | Map of simple network latency (all traffic) experiment template IDs keyed by target (Service name or default) |
+| <a name="output_reboot_experiment_id"></a> [reboot\_experiment\_id](#output\_reboot\_experiment\_id) | ID of the RDS reboot experiment template |
+| <a name="output_redis_connection_exhaustion_experiment_id"></a> [redis\_connection\_exhaustion\_experiment\_id](#output\_redis\_connection\_exhaustion\_experiment\_id) | ID of the Redis connection exhaustion Lambda experiment template |
+| <a name="output_redis_cpu_stress_experiment_id"></a> [redis\_cpu\_stress\_experiment\_id](#output\_redis\_cpu\_stress\_experiment\_id) | ID of the Redis CPU stress Lambda experiment template |
+| <a name="output_redis_failover_experiment_id"></a> [redis\_failover\_experiment\_id](#output\_redis\_failover\_experiment\_id) | ID of the Redis replication group failover (standalone) experiment template |
+| <a name="output_redis_failover_under_stress_experiment_id"></a> [redis\_failover\_under\_stress\_experiment\_id](#output\_redis\_failover\_under\_stress\_experiment\_id) | ID of the Redis failover under CPU stress experiment template |
+| <a name="output_redis_memory_stress_experiment_id"></a> [redis\_memory\_stress\_experiment\_id](#output\_redis\_memory\_stress\_experiment\_id) | ID of the Redis memory stress Lambda experiment template |
+| <a name="output_stop_condition_alarm_arn"></a> [stop\_condition\_alarm\_arn](#output\_stop\_condition\_alarm\_arn) | ARN of the CloudWatch alarm used as the stop condition |
+<!-- END_TF_DOCS -->

--- a/terraform/aws/modules/composition/fis-experiments/README.md
+++ b/terraform/aws/modules/composition/fis-experiments/README.md
@@ -1,0 +1,66 @@
+# AWS FIS Chaos Experiments Module
+
+Generic Terraform module that creates AWS Fault Injection Service (FIS) experiment templates for RDS Aurora, ElastiCache Redis/Valkey, EC2, and network paths.
+
+## What it creates
+
+- FIS execution IAM role with policies for RDS, EC2, ElastiCache, Lambda, SSM, CloudWatch, and KMS
+- CloudWatch stop-condition alarms
+- FIS experiment templates:
+  - Aurora cluster failover
+  - RDS DB instance reboot
+  - Combined failover + wait + reboot
+  - Network connectivity loss to DB
+  - AZ power interruption
+  - EC2 network latency injection (via SSM / tc netem)
+  - EC2 instance termination
+  - CPU/memory/connection stress via Lambda (Aurora and Redis)
+  - Redis replication group failover and failover-under-stress
+
+## Usage
+
+```hcl
+module "fis_experiments" {
+  source = "./terraform/aws/modules/composition/fis-experiments"
+
+  region      = "us-east-1"
+  environment = "dev"
+  account_id  = "123456789012"
+
+  rds_cluster_arn      = "arn:aws:rds:us-east-1:123456789012:cluster:my-cluster"
+  rds_cluster_identifier = "my-cluster"
+  rds_instance_arns    = ["arn:aws:rds:us-east-1:123456789012:db:my-instance-1"]
+
+  jumphost_instance_id = "i-0123456789abcdef0"
+
+  stress_lambda_arns = [
+    "arn:aws:lambda:us-east-1:123456789012:function:dev-aurora-stress-cpu_stress",
+  ]
+  stress_lambda_function_names = {
+    cpu_stress            = "dev-aurora-stress-cpu_stress"
+    memory_stress         = "dev-aurora-stress-memory_stress"
+    connection_exhaustion = "dev-aurora-stress-connection_exhaustion"
+  }
+
+  tags = {
+    Project = "my-project"
+  }
+}
+```
+
+## Required inputs
+
+- `region`
+- `environment`
+- `rds_cluster_arn`
+- `rds_cluster_identifier`
+- `rds_instance_arns`
+
+## Optional highlights
+
+- `enable_*` flags — selectively enable experiment templates
+- `redis_*` variables — add Redis/ElastiCache experiments
+- `network_latency_*` variables — configure EC2 network latency injection
+- `enable_ec2_termination` — enable destructive instance termination experiments
+
+See `variables.tf` for the full input list and `outputs.tf` for emitted experiment IDs.

--- a/terraform/aws/modules/composition/fis-experiments/main.tf
+++ b/terraform/aws/modules/composition/fis-experiments/main.tf
@@ -1,0 +1,1452 @@
+# ============================================================================
+# FIS Experiments Module - Main Resources
+# ============================================================================
+# Creates:
+#   1. IAM role + inline policy for FIS experiment execution
+#   2. CloudWatch metric alarm as stop condition (CPU > 95% for 2 min)
+#   3. CloudWatch metric alarm: FreeableMemory < 2GB (stop condition)
+#   4. CloudWatch metric alarm: DatabaseConnections > 68 (stop condition)
+#   5. FIS experiment template: Aurora cluster failover
+#   6. FIS experiment template: DB instance reboot
+#   7. FIS experiment template: Combined failover + wait + reboot
+#   8. FIS experiment template: Network connectivity loss to DB
+#   9. FIS experiment template: AZ power interruption (compound)
+#  10. FIS experiment template: CPU stress via Lambda (SSM → aws lambda invoke)
+#  11. FIS experiment template: Memory stress via Lambda (SSM → aws lambda invoke)
+#  12. FIS experiment template: Connection exhaustion via Lambda
+#  13. CloudWatch metric alarm: Redis ReplicationLag (stop condition)
+#  14. FIS experiment template: Redis replication group failover (standalone)
+#  15. FIS experiment template: Redis failover under CPU stress
+#  16. FIS experiment template: Network latency injection on EC2 (tc netem via SSM)
+#  17. FIS experiment template: Simple network latency on EC2 (all traffic, tc netem)
+#  18. FIS experiment template: EC2 instance termination
+# ============================================================================
+
+locals {
+  common_tags = merge(var.tags, {
+    Environment = var.environment
+    Project     = var.project_name
+    ManagedBy   = "terraform-IaC"
+    Component   = "fis-experiments"
+  })
+
+  network_latency_target_environment_tag = var.network_latency_target_environment_tag != "" ? var.network_latency_target_environment_tag : var.environment
+  network_latency_use_service_names      = length(var.network_latency_target_service_names) > 0
+  network_latency_template_keys          = local.network_latency_use_service_names ? toset(var.network_latency_target_service_names) : toset(["default"])
+  network_latency_service_tags = local.network_latency_use_service_names ? {
+    for svc in var.network_latency_target_service_names :
+    svc => {
+      Environment = local.network_latency_target_environment_tag
+      Service     = svc
+    }
+  } : {}
+}
+
+# ============================================================================
+# IAM Role for FIS Experiment Execution
+# ============================================================================
+
+resource "aws_iam_role" "fis_execution" {
+  name        = "${var.fis_role_name}-${var.environment}"
+  description = "IAM role for AWS Fault Injection Service experiment execution"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "fis.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy" "fis_execution" {
+  name = "fis-experiment-permissions"
+  role = aws_iam_role.fis_execution.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "rds:FailoverDBCluster"
+        ]
+        Resource = "arn:aws:rds:*:*:cluster:*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "rds:RebootDBInstance"
+        ]
+        Resource = "arn:aws:rds:*:*:db:*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "rds:DescribeDBClusters",
+          "rds:DescribeDBInstances",
+          "tag:GetResources",
+          "cloudwatch:DescribeAlarms",
+          "cloudwatch:PutMetricData"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ]
+        Resource = var.kms_key_arn != "" ? var.kms_key_arn : "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeNetworkAcls",
+          "ec2:DescribeInstances",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeVpcs",
+          "ec2:CreateNetworkAcl",
+          "ec2:CreateNetworkAclEntry",
+          "ec2:ReplaceNetworkAclAssociation",
+          "ec2:DeleteNetworkAcl",
+          "ec2:DeleteNetworkAclEntry",
+          "ec2:TerminateInstances"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:SendCommand",
+          "ssm:ListCommands",
+          "ssm:CancelCommands",
+          "ssm:GetCommandInvocation"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "lambda:InvokeFunction"
+        ]
+        Resource = concat(
+          var.stress_lambda_arns,
+          var.redis_stress_lambda_arns,
+          var.redis_failover_lambda_function_arn != "" ? [var.redis_failover_lambda_function_arn] : []
+        )
+      }
+    ]
+  })
+}
+
+# ============================================================================
+# CloudWatch Alarm - Stop Condition
+# ============================================================================
+# Triggers if RDS CPU stays above 95% for 2 minutes, stopping the experiment
+
+resource "aws_cloudwatch_metric_alarm" "fis_stop_condition" {
+  alarm_name          = "fis-stop-${var.rds_cluster_identifier}"
+  alarm_description   = "Stop condition for FIS experiments - triggers if CPU > 95% for 2 minutes"
+  namespace           = "AWS/RDS"
+  metric_name         = "CPUUtilization"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 95
+  period              = 60
+  evaluation_periods  = 2
+  statistic           = "Average"
+
+  dimensions = {
+    DBClusterIdentifier = var.rds_cluster_identifier
+  }
+
+  tags = local.common_tags
+}
+
+# ============================================================================
+# CloudWatch Alarm - Stop Condition: Low FreeableMemory
+# ============================================================================
+
+resource "aws_cloudwatch_metric_alarm" "fis_stop_memory" {
+  count               = var.enable_stress_alarms ? 1 : 0
+  alarm_name          = "fis-stop-memory-${var.rds_cluster_identifier}"
+  alarm_description   = "Stop condition for FIS experiments - triggers if FreeableMemory drops below 2GB"
+  namespace           = "AWS/RDS"
+  metric_name         = "FreeableMemory"
+  comparison_operator = "LessThanThreshold"
+  threshold           = 2048000000
+  period              = 60
+  evaluation_periods  = 2
+  statistic           = "Minimum"
+
+  dimensions = {
+    DBClusterIdentifier = var.rds_cluster_identifier
+  }
+
+  tags = local.common_tags
+}
+
+# ============================================================================
+# CloudWatch Alarm - Stop Condition: High Connection Count
+# ============================================================================
+
+resource "aws_cloudwatch_metric_alarm" "fis_stop_connections" {
+  count               = var.enable_stress_alarms ? 1 : 0
+  alarm_name          = "fis-stop-connections-${var.rds_cluster_identifier}"
+  alarm_description   = "Stop condition for FIS experiments - triggers if connections exceed 80% of max"
+  namespace           = "AWS/RDS"
+  metric_name         = "DatabaseConnections"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 68
+  period              = 60
+  evaluation_periods  = 2
+  statistic           = "Maximum"
+
+  dimensions = {
+    DBClusterIdentifier = var.rds_cluster_identifier
+  }
+
+  tags = local.common_tags
+}
+
+# ============================================================================
+# FIS Experiment Template 1: Aurora Cluster Failover
+# ============================================================================
+
+resource "aws_fis_experiment_template" "aurora_failover" {
+  count       = var.enable_failover ? 1 : 0
+  description = "Trigger Aurora PostgreSQL cluster failover in ${var.environment}"
+  role_arn    = aws_iam_role.fis_execution.arn
+
+  stop_condition {
+    source = "aws:cloudwatch:alarm"
+    value  = aws_cloudwatch_metric_alarm.fis_stop_condition.arn
+  }
+
+  action {
+    name        = "aurora-failover"
+    action_id   = "aws:rds:failover-db-cluster"
+    description = "Failover Aurora PostgreSQL cluster to a replica"
+
+    target {
+      key   = "Clusters"
+      value = "aurora-cluster-target"
+    }
+  }
+
+  target {
+    name           = "aurora-cluster-target"
+    resource_type  = "aws:rds:cluster"
+    selection_mode = "COUNT(1)"
+    resource_arns  = [var.rds_cluster_arn]
+  }
+
+  experiment_options {
+    account_targeting            = "single-account"
+    empty_target_resolution_mode = "skip"
+  }
+
+  tags = merge(local.common_tags, {
+    Experiment = "aurora-failover"
+  })
+}
+
+# ============================================================================
+# FIS Experiment Template 2: DB Instance Reboot
+# ============================================================================
+
+resource "aws_fis_experiment_template" "rds_reboot" {
+  count       = var.enable_reboot ? 1 : 0
+  description = "Reboot RDS DB instances in ${var.environment}"
+  role_arn    = aws_iam_role.fis_execution.arn
+
+  stop_condition {
+    source = "aws:cloudwatch:alarm"
+    value  = aws_cloudwatch_metric_alarm.fis_stop_condition.arn
+  }
+
+  action {
+    name        = "rds-reboot"
+    action_id   = "aws:rds:reboot-db-instances"
+    description = "Reboot RDS DB instances"
+
+    target {
+      key   = "DBInstances"
+      value = "rds-instance-target"
+    }
+  }
+
+  target {
+    name           = "rds-instance-target"
+    resource_type  = "aws:rds:db"
+    selection_mode = "ALL"
+    resource_arns  = var.rds_instance_arns
+  }
+
+  experiment_options {
+    account_targeting            = "single-account"
+    empty_target_resolution_mode = "skip"
+  }
+
+  tags = merge(local.common_tags, {
+    Experiment = "rds-reboot"
+  })
+}
+
+# ============================================================================
+# FIS Experiment Template 3: Combined Failover + Wait + Reboot
+# ============================================================================
+
+resource "aws_fis_experiment_template" "combined_failover_reboot" {
+  count       = var.enable_combined ? 1 : 0
+  description = "Failover Aurora cluster, wait, then reboot instances in ${var.environment}"
+  role_arn    = aws_iam_role.fis_execution.arn
+
+  stop_condition {
+    source = "aws:cloudwatch:alarm"
+    value  = aws_cloudwatch_metric_alarm.fis_stop_condition.arn
+  }
+
+  action {
+    name      = "step1-failover"
+    action_id = "aws:rds:failover-db-cluster"
+
+    target {
+      key   = "Clusters"
+      value = "aurora-cluster-target-combined"
+    }
+  }
+
+  action {
+    name        = "step2-wait"
+    action_id   = "aws:fis:wait"
+    start_after = ["step1-failover"]
+
+    parameter {
+      key   = "duration"
+      value = "PT5M"
+    }
+  }
+
+  action {
+    name        = "step3-reboot"
+    action_id   = "aws:rds:reboot-db-instances"
+    start_after = ["step2-wait"]
+
+    target {
+      key   = "DBInstances"
+      value = "rds-instance-target-combined"
+    }
+  }
+
+  target {
+    name           = "aurora-cluster-target-combined"
+    resource_type  = "aws:rds:cluster"
+    selection_mode = "COUNT(1)"
+    resource_arns  = [var.rds_cluster_arn]
+  }
+
+  target {
+    name           = "rds-instance-target-combined"
+    resource_type  = "aws:rds:db"
+    selection_mode = "ALL"
+    resource_arns  = var.rds_instance_arns
+  }
+
+  experiment_options {
+    account_targeting            = "single-account"
+    empty_target_resolution_mode = "skip"
+  }
+
+  tags = merge(local.common_tags, {
+    Experiment = "combined-failover-reboot"
+  })
+}
+
+# ============================================================================
+# FIS Experiment Template 4: Network Connectivity Loss to DB Instance
+# ============================================================================
+# Uses awscc provider because the aws provider doesn't support
+# "NetworkInterfaces" as a target key for aws:network:disrupt-connectivity.
+
+resource "awscc_fis_experiment_template" "network_disruption" {
+  count       = var.enable_network_disruption ? 1 : 0
+  description = "Disrupt network connectivity to test DB instance for ${var.network_disruption_duration} in ${var.environment}"
+  role_arn    = aws_iam_role.fis_execution.arn
+
+  stop_conditions = [
+    {
+      source = "aws:cloudwatch:alarm"
+      value  = aws_cloudwatch_metric_alarm.fis_stop_condition.arn
+    }
+  ]
+
+  actions = {
+    "network-disrupt" = {
+      action_id   = "aws:network:disrupt-connectivity"
+      description = "Deny all traffic to/from the test DB instance network interfaces"
+      parameters = {
+        duration = var.network_disruption_duration
+      }
+      targets = {
+        NetworkInterfaces = "db-instance-enis"
+      }
+    }
+  }
+
+  targets = {
+    "db-instance-enis" = {
+      resource_type  = "aws:ec2:network-interfaces"
+      selection_mode = "ALL"
+      filters = [
+        {
+          path   = "group-id"
+          values = [var.rds_security_group_id]
+        }
+      ]
+    }
+  }
+
+  experiment_options = {
+    account_targeting            = "single-account"
+    empty_target_resolution_mode = "skip"
+  }
+
+  tags = merge(local.common_tags, {
+    Experiment = "network-disruption"
+  })
+}
+
+# ============================================================================
+# FIS Experiment Template 5: DB AZ Power Interruption (Compound)
+# ============================================================================
+# Simulates the DB instance losing power in its AZ:
+#   1. Disrupt network to the DB's ENIs in the target AZ (duration = 30 min)
+#   2. Reboot the DB instance (simulates power loss crash)
+# RDS instances are not EC2 — no EBS volumes to pause, no ec2:StopInstances.
+
+resource "awscc_fis_experiment_template" "az_power_interruption" {
+  count       = var.enable_az_interruption ? 1 : 0
+  description = "DB AZ power interruption: network disruption + DB reboot in ${var.target_az} for ${var.az_interruption_duration} in ${var.environment}"
+  role_arn    = aws_iam_role.fis_execution.arn
+
+  stop_conditions = [
+    {
+      source = "aws:cloudwatch:alarm"
+      value  = aws_cloudwatch_metric_alarm.fis_stop_condition.arn
+    }
+  ]
+
+  actions = {
+    "disrupt-db-network" = {
+      action_id   = "aws:network:disrupt-connectivity"
+      description = "Deny all traffic to/from the DB instance ENIs in target AZ"
+      parameters = {
+        duration = var.az_interruption_duration
+      }
+      targets = {
+        NetworkInterfaces = "db-az-enis"
+      }
+    }
+
+    "reboot-db" = {
+      action_id   = "aws:rds:reboot-db-instances"
+      description = "Reboot DB instance to simulate power loss crash"
+      start_after = ["disrupt-db-network"]
+      targets = {
+        DBInstances = "db-az-instance"
+      }
+    }
+  }
+
+  targets = {
+    "db-az-enis" = {
+      resource_type  = "aws:ec2:network-interfaces"
+      selection_mode = "ALL"
+      filters = [
+        {
+          path   = "group-id"
+          values = [var.rds_security_group_id]
+        },
+        {
+          path   = "availabilityZone"
+          values = [var.target_az]
+        }
+      ]
+    }
+
+    "db-az-instance" = {
+      resource_type  = "aws:rds:db"
+      selection_mode = "ALL"
+      resource_arns  = var.rds_instance_arns
+    }
+  }
+
+  experiment_options = {
+    account_targeting            = "single-account"
+    empty_target_resolution_mode = "skip"
+  }
+
+  tags = merge(local.common_tags, {
+    Experiment = "az-power-interruption"
+  })
+}
+
+# ============================================================================
+# FIS Experiment Template 6: CPU Stress via Lambda (SSM → aws lambda invoke)
+# ============================================================================
+# FIS sends SSM command to jump host, which invokes the CPU stress Lambda.
+# The Lambda runs a TPC-B-like concurrent workload via ThreadPoolExecutor.
+# Requires: jump host instance profile must have lambda:InvokeFunction permission.
+
+resource "aws_fis_experiment_template" "cpu_stress_lambda" {
+  count       = var.enable_stress_tests && var.jumphost_instance_id != "" && length(var.stress_lambda_arns) > 0 ? 1 : 0
+  description = "Trigger CPU stress test Lambda via SSM on jump host in ${var.environment}"
+  role_arn    = aws_iam_role.fis_execution.arn
+
+  stop_condition {
+    source = "aws:cloudwatch:alarm"
+    value  = aws_cloudwatch_metric_alarm.fis_stop_condition.arn
+  }
+
+  dynamic "stop_condition" {
+    for_each = var.enable_stress_alarms ? [1] : []
+    content {
+      source = "aws:cloudwatch:alarm"
+      value  = aws_cloudwatch_metric_alarm.fis_stop_memory[0].arn
+    }
+  }
+
+  action {
+    name        = "cpu-stress-via-lambda"
+    action_id   = "aws:ssm:send-command"
+    description = "Invoke CPU stress Lambda function via SSM on jump host"
+
+    parameter {
+      key   = "duration"
+      value = "PT${var.stress_duration_seconds / 60}M"
+    }
+
+    parameter {
+      key   = "documentArn"
+      value = "arn:aws:ssm:${var.region}::document/AWS-RunShellScript"
+    }
+
+    parameter {
+      key = "documentParameters"
+      value = jsonencode({
+        commands = [
+          "aws lambda invoke --function-name ${var.stress_lambda_function_names["cpu_stress"]} --region ${var.region} --payload '{}' /tmp/cpu-stress-output.json && cat /tmp/cpu-stress-output.json"
+        ]
+      })
+    }
+
+    target {
+      key   = "Instances"
+      value = "jumphost-target-cpu"
+    }
+  }
+
+  target {
+    name           = "jumphost-target-cpu"
+    resource_type  = "aws:ec2:instance"
+    selection_mode = "COUNT(1)"
+    resource_arns  = ["arn:aws:ec2:${var.region}:${var.account_id}:instance/${var.jumphost_instance_id}"]
+  }
+
+  experiment_options {
+    account_targeting            = "single-account"
+    empty_target_resolution_mode = "skip"
+  }
+
+  tags = merge(local.common_tags, {
+    Experiment = "cpu-stress-lambda"
+  })
+}
+
+# ============================================================================
+# FIS Experiment Template 7: Memory Stress via Lambda
+# ============================================================================
+
+resource "aws_fis_experiment_template" "memory_stress_lambda" {
+  count       = var.enable_stress_tests && var.jumphost_instance_id != "" && length(var.stress_lambda_arns) > 0 ? 1 : 0
+  description = "Trigger memory stress test Lambda via SSM on jump host in ${var.environment}"
+  role_arn    = aws_iam_role.fis_execution.arn
+
+  stop_condition {
+    source = "aws:cloudwatch:alarm"
+    value  = aws_cloudwatch_metric_alarm.fis_stop_condition.arn
+  }
+
+  dynamic "stop_condition" {
+    for_each = var.enable_stress_alarms ? [1] : []
+    content {
+      source = "aws:cloudwatch:alarm"
+      value  = aws_cloudwatch_metric_alarm.fis_stop_memory[0].arn
+    }
+  }
+
+  dynamic "stop_condition" {
+    for_each = var.enable_stress_alarms ? [1] : []
+    content {
+      source = "aws:cloudwatch:alarm"
+      value  = aws_cloudwatch_metric_alarm.fis_stop_connections[0].arn
+    }
+  }
+
+  action {
+    name        = "memory-stress-via-lambda"
+    action_id   = "aws:ssm:send-command"
+    description = "Invoke memory stress Lambda function via SSM on jump host"
+
+    parameter {
+      key   = "duration"
+      value = "PT${var.stress_duration_seconds / 60}M"
+    }
+
+    parameter {
+      key   = "documentArn"
+      value = "arn:aws:ssm:${var.region}::document/AWS-RunShellScript"
+    }
+
+    parameter {
+      key = "documentParameters"
+      value = jsonencode({
+        commands = [
+          "aws lambda invoke --function-name ${var.stress_lambda_function_names["memory_stress"]} --region ${var.region} --payload '{}' /tmp/memory-stress-output.json && cat /tmp/memory-stress-output.json"
+        ]
+      })
+    }
+
+    target {
+      key   = "Instances"
+      value = "jumphost-target-memory"
+    }
+  }
+
+  target {
+    name           = "jumphost-target-memory"
+    resource_type  = "aws:ec2:instance"
+    selection_mode = "COUNT(1)"
+    resource_arns  = ["arn:aws:ec2:${var.region}:${var.account_id}:instance/${var.jumphost_instance_id}"]
+  }
+
+  experiment_options {
+    account_targeting            = "single-account"
+    empty_target_resolution_mode = "skip"
+  }
+
+  tags = merge(local.common_tags, {
+    Experiment = "memory-stress-lambda"
+  })
+}
+
+# ============================================================================
+# FIS Experiment Template 8: Connection Pool Exhaustion via Lambda
+# ============================================================================
+
+resource "aws_fis_experiment_template" "connection_exhaustion_lambda" {
+  count       = var.enable_stress_tests && var.jumphost_instance_id != "" && length(var.stress_lambda_arns) > 0 ? 1 : 0
+  description = "Trigger connection exhaustion test Lambda via SSM on jump host in ${var.environment}"
+  role_arn    = aws_iam_role.fis_execution.arn
+
+  stop_condition {
+    source = "aws:cloudwatch:alarm"
+    value  = aws_cloudwatch_metric_alarm.fis_stop_condition.arn
+  }
+
+  dynamic "stop_condition" {
+    for_each = var.enable_stress_alarms ? [1] : []
+    content {
+      source = "aws:cloudwatch:alarm"
+      value  = aws_cloudwatch_metric_alarm.fis_stop_connections[0].arn
+    }
+  }
+
+  action {
+    name        = "conn-exhaustion-via-lambda"
+    action_id   = "aws:ssm:send-command"
+    description = "Invoke connection exhaustion Lambda function via SSM on jump host"
+
+    parameter {
+      key   = "duration"
+      value = "PT${var.stress_duration_seconds / 60}M"
+    }
+
+    parameter {
+      key   = "documentArn"
+      value = "arn:aws:ssm:${var.region}::document/AWS-RunShellScript"
+    }
+
+    parameter {
+      key = "documentParameters"
+      value = jsonencode({
+        commands = [
+          "aws lambda invoke --function-name ${var.stress_lambda_function_names["connection_exhaustion"]} --region ${var.region} --payload '{}' /tmp/conn-exhaust-output.json && cat /tmp/conn-exhaust-output.json"
+        ]
+      })
+    }
+
+    target {
+      key   = "Instances"
+      value = "jumphost-target-conn"
+    }
+  }
+
+  target {
+    name           = "jumphost-target-conn"
+    resource_type  = "aws:ec2:instance"
+    selection_mode = "COUNT(1)"
+    resource_arns  = ["arn:aws:ec2:${var.region}:${var.account_id}:instance/${var.jumphost_instance_id}"]
+  }
+
+  experiment_options {
+    account_targeting            = "single-account"
+    empty_target_resolution_mode = "skip"
+  }
+
+  tags = merge(local.common_tags, {
+    Experiment = "connection-exhaustion-lambda"
+  })
+}
+
+# ============================================================================
+# CloudWatch Alarms - Redis/Elasticache Stop Conditions
+# ============================================================================
+
+resource "aws_cloudwatch_metric_alarm" "redis_cpu_stop" {
+  count               = var.enable_redis_stress_alarms && var.redis_cluster_id != "" ? 1 : 0
+  alarm_name          = "fis-stop-redis-cpu-${var.redis_cluster_id}"
+  alarm_description   = "Stop condition for Redis FIS experiments - EngineCPUUtilization > 90% for 2 minutes"
+  namespace           = "AWS/ElastiCache"
+  metric_name         = "EngineCPUUtilization"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 90
+  period              = 60
+  evaluation_periods  = 2
+  statistic           = "Average"
+
+  dimensions = {
+    CacheClusterId = var.redis_cluster_id
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "redis_memory_stop" {
+  count               = var.enable_redis_stress_alarms && var.redis_cluster_id != "" ? 1 : 0
+  alarm_name          = "fis-stop-redis-memory-${var.redis_cluster_id}"
+  alarm_description   = "Stop condition for Redis FIS experiments - FreeableMemory < 100MB"
+  namespace           = "AWS/ElastiCache"
+  metric_name         = "FreeableMemory"
+  comparison_operator = "LessThanThreshold"
+  threshold           = 104857600
+  period              = 60
+  evaluation_periods  = 2
+  statistic           = "Minimum"
+
+  dimensions = {
+    CacheClusterId = var.redis_cluster_id
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "redis_connections_stop" {
+  count               = var.enable_redis_stress_alarms && var.redis_cluster_id != "" ? 1 : 0
+  alarm_name          = "fis-stop-redis-connections-${var.redis_cluster_id}"
+  alarm_description   = "Stop condition for Redis FIS experiments - CurrConnections > 64000"
+  namespace           = "AWS/ElastiCache"
+  metric_name         = "CurrConnections"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 64000
+  period              = 60
+  evaluation_periods  = 2
+  statistic           = "Maximum"
+
+  dimensions = {
+    CacheClusterId = var.redis_cluster_id
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "redis_replica_lag_stop" {
+  count               = var.enable_redis_stress_alarms && var.redis_replication_group_id != "" ? 1 : 0
+  alarm_name          = "fis-stop-redis-replica-lag-${var.redis_replication_group_id}"
+  alarm_description   = "Stop condition for Redis FIS experiments - ReplicationLag > 60 seconds for 2 minutes"
+  namespace           = "AWS/ElastiCache"
+  metric_name         = "ReplicationLag"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 60
+  period              = 60
+  evaluation_periods  = 2
+  statistic           = "Maximum"
+
+  dimensions = {
+    ReplicationGroupId = var.redis_replication_group_id
+    NodeGroupId        = var.redis_node_group_id
+  }
+
+  tags = local.common_tags
+}
+
+# ============================================================================
+# FIS Experiment Template 9: Redis CPU Stress via Lambda
+# ============================================================================
+
+resource "aws_fis_experiment_template" "redis_cpu_stress_lambda" {
+  count       = var.enable_redis_stress_tests && var.jumphost_instance_id != "" && length(var.redis_stress_lambda_arns) > 0 ? 1 : 0
+  description = "Trigger Redis CPU stress test Lambda via SSM on jump host in ${var.environment}"
+  role_arn    = aws_iam_role.fis_execution.arn
+
+  stop_condition {
+    source = "aws:cloudwatch:alarm"
+    value  = aws_cloudwatch_metric_alarm.fis_stop_condition.arn
+  }
+
+  dynamic "stop_condition" {
+    for_each = var.enable_redis_stress_alarms ? [1] : []
+    content {
+      source = "aws:cloudwatch:alarm"
+      value  = aws_cloudwatch_metric_alarm.redis_cpu_stop[0].arn
+    }
+  }
+
+  action {
+    name        = "redis-cpu-stress-via-lambda"
+    action_id   = "aws:ssm:send-command"
+    description = "Invoke Redis CPU stress Lambda function via SSM on jump host"
+
+    parameter {
+      key   = "duration"
+      value = "PT${var.stress_duration_seconds / 60}M"
+    }
+
+    parameter {
+      key   = "documentArn"
+      value = "arn:aws:ssm:${var.region}::document/AWS-RunShellScript"
+    }
+
+    parameter {
+      key = "documentParameters"
+      value = jsonencode({
+        commands = [
+          "aws lambda invoke --function-name ${var.redis_stress_lambda_function_names["cpu_stress"]} --region ${var.region} --payload '{}' /tmp/redis-cpu-stress-output.json && cat /tmp/redis-cpu-stress-output.json"
+        ]
+      })
+    }
+
+    target {
+      key   = "Instances"
+      value = "jumphost-target-redis-cpu"
+    }
+  }
+
+  target {
+    name           = "jumphost-target-redis-cpu"
+    resource_type  = "aws:ec2:instance"
+    selection_mode = "COUNT(1)"
+    resource_arns  = ["arn:aws:ec2:${var.region}:${var.account_id}:instance/${var.jumphost_instance_id}"]
+  }
+
+  experiment_options {
+    account_targeting            = "single-account"
+    empty_target_resolution_mode = "skip"
+  }
+
+  tags = merge(local.common_tags, {
+    Experiment = "redis-cpu-stress-lambda"
+  })
+}
+
+# ============================================================================
+# FIS Experiment Template 10: Redis Memory Stress via Lambda
+# ============================================================================
+
+resource "aws_fis_experiment_template" "redis_memory_stress_lambda" {
+  count       = var.enable_redis_stress_tests && var.jumphost_instance_id != "" && length(var.redis_stress_lambda_arns) > 0 ? 1 : 0
+  description = "Trigger Redis memory stress test Lambda via SSM on jump host in ${var.environment}"
+  role_arn    = aws_iam_role.fis_execution.arn
+
+  stop_condition {
+    source = "aws:cloudwatch:alarm"
+    value  = aws_cloudwatch_metric_alarm.fis_stop_condition.arn
+  }
+
+  dynamic "stop_condition" {
+    for_each = var.enable_redis_stress_alarms ? [1] : []
+    content {
+      source = "aws:cloudwatch:alarm"
+      value  = aws_cloudwatch_metric_alarm.redis_memory_stop[0].arn
+    }
+  }
+
+  action {
+    name        = "redis-memory-stress-via-lambda"
+    action_id   = "aws:ssm:send-command"
+    description = "Invoke Redis memory stress Lambda function via SSM on jump host"
+
+    parameter {
+      key   = "duration"
+      value = "PT${var.stress_duration_seconds / 60}M"
+    }
+
+    parameter {
+      key   = "documentArn"
+      value = "arn:aws:ssm:${var.region}::document/AWS-RunShellScript"
+    }
+
+    parameter {
+      key = "documentParameters"
+      value = jsonencode({
+        commands = [
+          "aws lambda invoke --function-name ${var.redis_stress_lambda_function_names["memory_stress"]} --region ${var.region} --payload '{}' /tmp/redis-memory-stress-output.json && cat /tmp/redis-memory-stress-output.json"
+        ]
+      })
+    }
+
+    target {
+      key   = "Instances"
+      value = "jumphost-target-redis-memory"
+    }
+  }
+
+  target {
+    name           = "jumphost-target-redis-memory"
+    resource_type  = "aws:ec2:instance"
+    selection_mode = "COUNT(1)"
+    resource_arns  = ["arn:aws:ec2:${var.region}:${var.account_id}:instance/${var.jumphost_instance_id}"]
+  }
+
+  experiment_options {
+    account_targeting            = "single-account"
+    empty_target_resolution_mode = "skip"
+  }
+
+  tags = merge(local.common_tags, {
+    Experiment = "redis-memory-stress-lambda"
+  })
+}
+
+# ============================================================================
+# FIS Experiment Template 11: Redis Connection Exhaustion via Lambda
+# ============================================================================
+
+resource "aws_fis_experiment_template" "redis_connection_exhaustion_lambda" {
+  count       = var.enable_redis_stress_tests && var.jumphost_instance_id != "" && length(var.redis_stress_lambda_arns) > 0 ? 1 : 0
+  description = "Trigger Redis connection exhaustion test Lambda via SSM on jump host in ${var.environment}"
+  role_arn    = aws_iam_role.fis_execution.arn
+
+  stop_condition {
+    source = "aws:cloudwatch:alarm"
+    value  = aws_cloudwatch_metric_alarm.fis_stop_condition.arn
+  }
+
+  dynamic "stop_condition" {
+    for_each = var.enable_redis_stress_alarms ? [1] : []
+    content {
+      source = "aws:cloudwatch:alarm"
+      value  = aws_cloudwatch_metric_alarm.redis_connections_stop[0].arn
+    }
+  }
+
+  action {
+    name        = "redis-conn-exhaustion-via-lambda"
+    action_id   = "aws:ssm:send-command"
+    description = "Invoke Redis connection exhaustion Lambda function via SSM on jump host"
+
+    parameter {
+      key   = "duration"
+      value = "PT${var.stress_duration_seconds / 60}M"
+    }
+
+    parameter {
+      key   = "documentArn"
+      value = "arn:aws:ssm:${var.region}::document/AWS-RunShellScript"
+    }
+
+    parameter {
+      key = "documentParameters"
+      value = jsonencode({
+        commands = [
+          "aws lambda invoke --function-name ${var.redis_stress_lambda_function_names["connection_exhaustion"]} --region ${var.region} --payload '{}' /tmp/redis-conn-exhaust-output.json && cat /tmp/redis-conn-exhaust-output.json"
+        ]
+      })
+    }
+
+    target {
+      key   = "Instances"
+      value = "jumphost-target-redis-conn"
+    }
+  }
+
+  target {
+    name           = "jumphost-target-redis-conn"
+    resource_type  = "aws:ec2:instance"
+    selection_mode = "COUNT(1)"
+    resource_arns  = ["arn:aws:ec2:${var.region}:${var.account_id}:instance/${var.jumphost_instance_id}"]
+  }
+
+  experiment_options {
+    account_targeting            = "single-account"
+    empty_target_resolution_mode = "skip"
+  }
+
+  tags = merge(local.common_tags, {
+    Experiment = "redis-connection-exhaustion-lambda"
+  })
+}
+
+# ============================================================================
+# FIS Experiment Template 12: Redis Replication Group Failover (Standalone)
+# ============================================================================
+# Triggers an ElastiCache TestFailover for the Redis replication group by
+# invoking the failover Lambda via SSM on the jump host.
+
+resource "aws_fis_experiment_template" "redis_failover" {
+  count       = var.enable_redis_failover && var.jumphost_instance_id != "" && var.redis_failover_lambda_function_name != "" ? 1 : 0
+  description = "Trigger ElastiCache Redis replication group failover (TestFailover) via Lambda on jump host in ${var.environment}"
+  role_arn    = aws_iam_role.fis_execution.arn
+
+  stop_condition {
+    source = "aws:cloudwatch:alarm"
+    value  = aws_cloudwatch_metric_alarm.fis_stop_condition.arn
+  }
+
+  dynamic "stop_condition" {
+    for_each = var.enable_redis_stress_alarms && var.redis_cluster_id != "" ? [1] : []
+    content {
+      source = "aws:cloudwatch:alarm"
+      value  = aws_cloudwatch_metric_alarm.redis_cpu_stop[0].arn
+    }
+  }
+
+  dynamic "stop_condition" {
+    for_each = var.enable_redis_stress_alarms && var.redis_cluster_id != "" ? [1] : []
+    content {
+      source = "aws:cloudwatch:alarm"
+      value  = aws_cloudwatch_metric_alarm.redis_memory_stop[0].arn
+    }
+  }
+
+  dynamic "stop_condition" {
+    for_each = var.enable_redis_stress_alarms && var.redis_cluster_id != "" ? [1] : []
+    content {
+      source = "aws:cloudwatch:alarm"
+      value  = aws_cloudwatch_metric_alarm.redis_connections_stop[0].arn
+    }
+  }
+
+  dynamic "stop_condition" {
+    for_each = var.enable_redis_stress_alarms && var.redis_replication_group_id != "" ? [1] : []
+    content {
+      source = "aws:cloudwatch:alarm"
+      value  = aws_cloudwatch_metric_alarm.redis_replica_lag_stop[0].arn
+    }
+  }
+
+  action {
+    name        = "redis-failover"
+    action_id   = "aws:ssm:send-command"
+    description = "Invoke Redis failover Lambda function via SSM on jump host"
+
+    parameter {
+      key   = "duration"
+      value = "PT2M"
+    }
+
+    parameter {
+      key   = "documentArn"
+      value = "arn:aws:ssm:${var.region}::document/AWS-RunShellScript"
+    }
+
+    parameter {
+      key = "documentParameters"
+      value = jsonencode({
+        commands = [
+          "aws lambda invoke --function-name ${var.redis_failover_lambda_function_name} --region ${var.region} --payload '{}' /tmp/redis-failover-output.json && cat /tmp/redis-failover-output.json"
+        ]
+      })
+    }
+
+    target {
+      key   = "Instances"
+      value = "jumphost-target-redis-failover"
+    }
+  }
+
+  target {
+    name           = "jumphost-target-redis-failover"
+    resource_type  = "aws:ec2:instance"
+    selection_mode = "COUNT(1)"
+    resource_arns  = ["arn:aws:ec2:${var.region}:${var.account_id}:instance/${var.jumphost_instance_id}"]
+  }
+
+  experiment_options {
+    account_targeting            = "single-account"
+    empty_target_resolution_mode = "skip"
+  }
+
+  tags = merge(local.common_tags, {
+    Experiment = "redis-failover"
+  })
+}
+
+# ============================================================================
+# FIS Experiment Template 13: Redis Failover Under CPU Stress
+# ============================================================================
+# CPU stress starts first (T=0, runs for stress_duration_seconds).
+# After 2 minutes (wait action), the failover Lambda is invoked while the
+# stress action is still running, simulating a failover under load.
+
+resource "aws_fis_experiment_template" "redis_failover_under_stress" {
+  count       = var.enable_redis_failover_under_stress && var.jumphost_instance_id != "" && var.redis_failover_lambda_function_name != "" && length(var.redis_stress_lambda_arns) > 0 ? 1 : 0
+  description = "Redis failover under CPU stress: stress starts, waits 2 minutes, then triggers failover while stress continues in ${var.environment}"
+  role_arn    = aws_iam_role.fis_execution.arn
+
+  stop_condition {
+    source = "aws:cloudwatch:alarm"
+    value  = aws_cloudwatch_metric_alarm.fis_stop_condition.arn
+  }
+
+  dynamic "stop_condition" {
+    for_each = var.enable_redis_stress_alarms && var.redis_cluster_id != "" ? [1] : []
+    content {
+      source = "aws:cloudwatch:alarm"
+      value  = aws_cloudwatch_metric_alarm.redis_cpu_stop[0].arn
+    }
+  }
+
+  dynamic "stop_condition" {
+    for_each = var.enable_redis_stress_alarms && var.redis_cluster_id != "" ? [1] : []
+    content {
+      source = "aws:cloudwatch:alarm"
+      value  = aws_cloudwatch_metric_alarm.redis_memory_stop[0].arn
+    }
+  }
+
+  dynamic "stop_condition" {
+    for_each = var.enable_redis_stress_alarms && var.redis_cluster_id != "" ? [1] : []
+    content {
+      source = "aws:cloudwatch:alarm"
+      value  = aws_cloudwatch_metric_alarm.redis_connections_stop[0].arn
+    }
+  }
+
+  dynamic "stop_condition" {
+    for_each = var.enable_redis_stress_alarms && var.redis_replication_group_id != "" ? [1] : []
+    content {
+      source = "aws:cloudwatch:alarm"
+      value  = aws_cloudwatch_metric_alarm.redis_replica_lag_stop[0].arn
+    }
+  }
+
+  action {
+    name        = "redis-stress"
+    action_id   = "aws:ssm:send-command"
+    description = "Invoke Redis CPU stress Lambda function via SSM on jump host"
+
+    parameter {
+      key   = "duration"
+      value = "PT${var.stress_duration_seconds / 60}M"
+    }
+
+    parameter {
+      key   = "documentArn"
+      value = "arn:aws:ssm:${var.region}::document/AWS-RunShellScript"
+    }
+
+    parameter {
+      key = "documentParameters"
+      value = jsonencode({
+        commands = [
+          "aws lambda invoke --function-name ${var.redis_stress_lambda_function_names["cpu_stress"]} --region ${var.region} --payload '{}' /tmp/redis-failover-stress-output.json && cat /tmp/redis-failover-stress-output.json"
+        ]
+      })
+    }
+
+    target {
+      key   = "Instances"
+      value = "jumphost-target-redis-failover-stress"
+    }
+  }
+
+  action {
+    name        = "wait-for-stress"
+    action_id   = "aws:fis:wait"
+    start_after = ["redis-stress"]
+
+    parameter {
+      key   = "duration"
+      value = "PT2M"
+    }
+  }
+
+  action {
+    name        = "redis-failover"
+    action_id   = "aws:ssm:send-command"
+    description = "Invoke Redis failover Lambda function via SSM on jump host while stress continues"
+    start_after = ["wait-for-stress"]
+
+    parameter {
+      key   = "duration"
+      value = "PT2M"
+    }
+
+    parameter {
+      key   = "documentArn"
+      value = "arn:aws:ssm:${var.region}::document/AWS-RunShellScript"
+    }
+
+    parameter {
+      key = "documentParameters"
+      value = jsonencode({
+        commands = [
+          "aws lambda invoke --function-name ${var.redis_failover_lambda_function_name} --region ${var.region} --payload '{}' /tmp/redis-failover-under-stress-output.json && cat /tmp/redis-failover-under-stress-output.json"
+        ]
+      })
+    }
+
+    target {
+      key   = "Instances"
+      value = "jumphost-target-redis-failover-stress"
+    }
+  }
+
+  target {
+    name           = "jumphost-target-redis-failover-stress"
+    resource_type  = "aws:ec2:instance"
+    selection_mode = "COUNT(1)"
+    resource_arns  = ["arn:aws:ec2:${var.region}:${var.account_id}:instance/${var.jumphost_instance_id}"]
+  }
+
+  experiment_options {
+    account_targeting            = "single-account"
+    empty_target_resolution_mode = "skip"
+  }
+
+  tags = merge(local.common_tags, {
+    Experiment = "redis-failover-under-stress"
+  })
+}
+
+# ============================================================================
+# FIS Experiment Template: Network Latency Injection on EC2
+# ============================================================================
+# Uses aws:ssm:send-command with the AWS-published SSM document
+# AWSFIS-Run-Network-Latency-Sources to inject network delay + jitter via
+# Linux tc netem on target EC2 instances. Blast radius is instance-level
+# (only targeted instances are affected, not the entire subnet).
+# The SSM document has built-in rollback via atd + signal handlers.
+
+resource "aws_fis_experiment_template" "network_latency" {
+  for_each    = var.enable_network_latency ? local.network_latency_template_keys : toset([])
+  description = local.network_latency_use_service_names ? "Inject network latency (${var.network_latency_delay_ms}ms ± ${var.network_latency_jitter_ms}ms jitter) on ${each.value} EC2 instances in ${var.environment}" : "Inject network latency (${var.network_latency_delay_ms}ms ± ${var.network_latency_jitter_ms}ms jitter) on EC2 instances in ${var.environment}"
+  role_arn    = aws_iam_role.fis_execution.arn
+
+  stop_condition {
+    source = "aws:cloudwatch:alarm"
+    value  = aws_cloudwatch_metric_alarm.fis_stop_condition.arn
+  }
+
+  action {
+    name        = "network-latency"
+    action_id   = "aws:ssm:send-command"
+    description = "Inject ${var.network_latency_delay_ms}ms latency with ${var.network_latency_jitter_ms}ms jitter via tc netem on ${var.network_latency_traffic_type} traffic to ${var.network_latency_sources}"
+
+    parameter {
+      key   = "duration"
+      value = var.network_latency_duration
+    }
+
+    parameter {
+      key   = "documentArn"
+      value = "arn:aws:ssm:${var.region}::document/AWSFIS-Run-Network-Latency-Sources"
+    }
+
+    parameter {
+      key = "documentParameters"
+      value = jsonencode({
+        DelayMilliseconds   = tostring(var.network_latency_delay_ms)
+        JitterMilliseconds  = tostring(var.network_latency_jitter_ms)
+        Sources             = var.network_latency_sources
+        Interface           = var.network_latency_interface
+        TrafficType         = var.network_latency_traffic_type
+        FlowsPercent        = tostring(var.network_latency_flows_percent)
+        DurationSeconds     = tostring(var.network_latency_duration_seconds)
+        InstallDependencies = var.network_latency_install_dependencies ? "True" : "False"
+      })
+    }
+
+    target {
+      key   = "Instances"
+      value = "network-latency-target"
+    }
+  }
+
+  target {
+    name           = "network-latency-target"
+    resource_type  = "aws:ec2:instance"
+    selection_mode = "ALL"
+
+    resource_arns = local.network_latency_use_service_names || length(var.network_latency_target_resource_tags) > 0 ? null : var.network_latency_target_instance_arns
+
+    dynamic "resource_tag" {
+      for_each = local.network_latency_use_service_names ? local.network_latency_service_tags[each.value] : var.network_latency_target_resource_tags
+      content {
+        key   = resource_tag.key
+        value = resource_tag.value
+      }
+    }
+  }
+
+  experiment_options {
+    account_targeting            = "single-account"
+    empty_target_resolution_mode = "skip"
+  }
+
+  tags = merge(
+    local.common_tags,
+    { Experiment = "network-latency" },
+    local.network_latency_use_service_names ? { Service = each.value } : {}
+  )
+}
+
+# ============================================================================
+# FIS Experiment Template: Simple Network Latency on EC2
+# ============================================================================
+# Uses AWSFIS-Run-Network-Latency-Sources — same SSM doc as the advanced
+# variant but with fewer knobs (no jitter, no traffic_type, no flows_percent).
+# Sources defaults to ALL (all traffic). Set to specific IPs/CIDRs/domains
+# to target only that traffic. Reuses network_latency_target_instance_arns
+# and network_latency_duration* variables from the -Sources template.
+
+resource "aws_fis_experiment_template" "network_latency_simple" {
+  for_each    = var.enable_network_latency_simple ? local.network_latency_template_keys : toset([])
+  description = local.network_latency_use_service_names ? "Inject ${var.network_latency_simple_delay_ms}ms network latency on ${each.value} EC2 instances in ${var.environment} (sources: ${var.network_latency_simple_sources})" : "Inject ${var.network_latency_simple_delay_ms}ms network latency on EC2 instances in ${var.environment} (sources: ${var.network_latency_simple_sources})"
+  role_arn    = aws_iam_role.fis_execution.arn
+
+  stop_condition {
+    source = "aws:cloudwatch:alarm"
+    value  = aws_cloudwatch_metric_alarm.fis_stop_condition.arn
+  }
+
+  action {
+    name        = "network-latency-simple"
+    action_id   = "aws:ssm:send-command"
+    description = "Inject ${var.network_latency_simple_delay_ms}ms latency via tc netem on ${var.network_latency_simple_sources} traffic on interface ${var.network_latency_simple_interface}"
+
+    parameter {
+      key   = "duration"
+      value = var.network_latency_duration
+    }
+
+    parameter {
+      key   = "documentArn"
+      value = "arn:aws:ssm:${var.region}::document/AWSFIS-Run-Network-Latency-Sources"
+    }
+
+    parameter {
+      key = "documentParameters"
+      value = jsonencode({
+        DelayMilliseconds   = tostring(var.network_latency_simple_delay_ms)
+        Sources             = var.network_latency_simple_sources
+        Interface           = var.network_latency_simple_interface
+        DurationSeconds     = tostring(var.network_latency_duration_seconds)
+        InstallDependencies = var.network_latency_install_dependencies ? "True" : "False"
+      })
+    }
+
+    target {
+      key   = "Instances"
+      value = "network-latency-simple-target"
+    }
+  }
+
+  target {
+    name           = "network-latency-simple-target"
+    resource_type  = "aws:ec2:instance"
+    selection_mode = "ALL"
+
+    resource_arns = local.network_latency_use_service_names || length(var.network_latency_target_resource_tags) > 0 ? null : var.network_latency_target_instance_arns
+
+    dynamic "resource_tag" {
+      for_each = local.network_latency_use_service_names ? local.network_latency_service_tags[each.value] : var.network_latency_target_resource_tags
+      content {
+        key   = resource_tag.key
+        value = resource_tag.value
+      }
+    }
+  }
+
+  experiment_options {
+    account_targeting            = "single-account"
+    empty_target_resolution_mode = "skip"
+  }
+
+  tags = merge(
+    local.common_tags,
+    { Experiment = "network-latency-simple" },
+    local.network_latency_use_service_names ? { Service = each.value } : {}
+  )
+}
+
+# ============================================================================
+# FIS Experiment Template: EC2 Instance Termination
+# ============================================================================
+# Uses aws:ec2:terminate-instances — a native FIS action that permanently
+# terminates the targeted EC2 instances. No duration parameter needed;
+# the action completes once instances are terminated.
+# ⚠️ DESTRUCTIVE: Instances are permanently destroyed. Only target
+# disposable/test instances. Ensure ASG self-healing or manual recreation
+# is in place before enabling.
+
+resource "aws_fis_experiment_template" "ec2_termination" {
+  count       = var.enable_ec2_termination && length(var.ec2_termination_target_instance_arns) > 0 ? 1 : 0
+  description = "Terminate EC2 instances in ${var.environment} to test instance loss resilience"
+  role_arn    = aws_iam_role.fis_execution.arn
+
+  stop_condition {
+    source = "aws:cloudwatch:alarm"
+    value  = aws_cloudwatch_metric_alarm.fis_stop_condition.arn
+  }
+
+  action {
+    name        = "terminate-instances"
+    action_id   = "aws:ec2:terminate-instances"
+    description = "Permanently terminate targeted EC2 instances"
+
+    target {
+      key   = "Instances"
+      value = "ec2-termination-target"
+    }
+  }
+
+  target {
+    name           = "ec2-termination-target"
+    resource_type  = "aws:ec2:instance"
+    selection_mode = "ALL"
+    resource_arns  = var.ec2_termination_target_instance_arns
+  }
+
+  experiment_options {
+    account_targeting            = "single-account"
+    empty_target_resolution_mode = "skip"
+  }
+
+  tags = merge(local.common_tags, {
+    Experiment = "ec2-termination"
+  })
+}

--- a/terraform/aws/modules/composition/fis-experiments/outputs.tf
+++ b/terraform/aws/modules/composition/fis-experiments/outputs.tf
@@ -1,0 +1,94 @@
+output "fis_role_arn" {
+  description = "ARN of the FIS IAM role"
+  value       = aws_iam_role.fis_execution.arn
+}
+
+output "fis_role_name" {
+  description = "Name of the FIS IAM role"
+  value       = aws_iam_role.fis_execution.name
+}
+
+output "failover_experiment_id" {
+  description = "ID of the Aurora failover experiment template"
+  value       = length(aws_fis_experiment_template.aurora_failover) > 0 ? aws_fis_experiment_template.aurora_failover[0].id : null
+}
+
+output "reboot_experiment_id" {
+  description = "ID of the RDS reboot experiment template"
+  value       = length(aws_fis_experiment_template.rds_reboot) > 0 ? aws_fis_experiment_template.rds_reboot[0].id : null
+}
+
+output "combined_experiment_id" {
+  description = "ID of the combined failover + wait + reboot experiment template"
+  value       = length(aws_fis_experiment_template.combined_failover_reboot) > 0 ? aws_fis_experiment_template.combined_failover_reboot[0].id : null
+}
+
+output "network_disruption_experiment_id" {
+  description = "ID of the network connectivity loss experiment template"
+  value       = length(awscc_fis_experiment_template.network_disruption) > 0 ? awscc_fis_experiment_template.network_disruption[0].id : null
+}
+
+output "az_interruption_experiment_id" {
+  description = "ID of the AZ power interruption experiment template"
+  value       = length(awscc_fis_experiment_template.az_power_interruption) > 0 ? awscc_fis_experiment_template.az_power_interruption[0].id : null
+}
+
+output "stop_condition_alarm_arn" {
+  description = "ARN of the CloudWatch alarm used as the stop condition"
+  value       = aws_cloudwatch_metric_alarm.fis_stop_condition.arn
+}
+
+output "cpu_stress_experiment_id" {
+  description = "ID of the CPU stress Lambda experiment template"
+  value       = length(aws_fis_experiment_template.cpu_stress_lambda) > 0 ? aws_fis_experiment_template.cpu_stress_lambda[0].id : null
+}
+
+output "memory_stress_experiment_id" {
+  description = "ID of the memory stress Lambda experiment template"
+  value       = length(aws_fis_experiment_template.memory_stress_lambda) > 0 ? aws_fis_experiment_template.memory_stress_lambda[0].id : null
+}
+
+output "connection_exhaustion_experiment_id" {
+  description = "ID of the connection exhaustion Lambda experiment template"
+  value       = length(aws_fis_experiment_template.connection_exhaustion_lambda) > 0 ? aws_fis_experiment_template.connection_exhaustion_lambda[0].id : null
+}
+
+output "redis_cpu_stress_experiment_id" {
+  description = "ID of the Redis CPU stress Lambda experiment template"
+  value       = length(aws_fis_experiment_template.redis_cpu_stress_lambda) > 0 ? aws_fis_experiment_template.redis_cpu_stress_lambda[0].id : null
+}
+
+output "redis_memory_stress_experiment_id" {
+  description = "ID of the Redis memory stress Lambda experiment template"
+  value       = length(aws_fis_experiment_template.redis_memory_stress_lambda) > 0 ? aws_fis_experiment_template.redis_memory_stress_lambda[0].id : null
+}
+
+output "redis_connection_exhaustion_experiment_id" {
+  description = "ID of the Redis connection exhaustion Lambda experiment template"
+  value       = length(aws_fis_experiment_template.redis_connection_exhaustion_lambda) > 0 ? aws_fis_experiment_template.redis_connection_exhaustion_lambda[0].id : null
+}
+
+output "redis_failover_experiment_id" {
+  description = "ID of the Redis replication group failover (standalone) experiment template"
+  value       = length(aws_fis_experiment_template.redis_failover) > 0 ? aws_fis_experiment_template.redis_failover[0].id : null
+}
+
+output "redis_failover_under_stress_experiment_id" {
+  description = "ID of the Redis failover under CPU stress experiment template"
+  value       = length(aws_fis_experiment_template.redis_failover_under_stress) > 0 ? aws_fis_experiment_template.redis_failover_under_stress[0].id : null
+}
+
+output "network_latency_experiment_ids" {
+  description = "Map of network latency injection experiment template IDs keyed by target (Service name or default)"
+  value       = { for k, tmpl in aws_fis_experiment_template.network_latency : k => tmpl.id }
+}
+
+output "network_latency_simple_experiment_ids" {
+  description = "Map of simple network latency (all traffic) experiment template IDs keyed by target (Service name or default)"
+  value       = { for k, tmpl in aws_fis_experiment_template.network_latency_simple : k => tmpl.id }
+}
+
+output "ec2_termination_experiment_id" {
+  description = "ID of the EC2 instance termination experiment template"
+  value       = length(aws_fis_experiment_template.ec2_termination) > 0 ? aws_fis_experiment_template.ec2_termination[0].id : null
+}

--- a/terraform/aws/modules/composition/fis-experiments/variables.tf
+++ b/terraform/aws/modules/composition/fis-experiments/variables.tf
@@ -1,0 +1,386 @@
+# ============================================================================
+# FIS Experiments Module - Variables
+# ============================================================================
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (e.g., sandbox, prod)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for resource naming and tagging"
+  type        = string
+  default     = ""
+}
+
+variable "account_id" {
+  description = "AWS Account ID"
+  type        = string
+  default     = ""
+}
+
+# ============================================================================
+# FIS IAM Role
+# ============================================================================
+
+variable "fis_role_name" {
+  description = "Base name of the IAM role for FIS experiment execution"
+  type        = string
+  default     = "FISExperimentRole"
+}
+
+# ============================================================================
+# RDS Target Resources
+# ============================================================================
+
+variable "rds_cluster_arn" {
+  description = "ARN of the RDS Aurora cluster to target for failover experiments"
+  type        = string
+}
+
+variable "rds_cluster_identifier" {
+  description = "Identifier of the RDS Aurora cluster (used for CloudWatch alarm dimension)"
+  type        = string
+}
+
+variable "rds_instance_arns" {
+  description = "List of RDS DB instance ARNs to target for reboot experiments"
+  type        = list(string)
+}
+
+# ============================================================================
+# KMS Key (for encrypted RDS clusters)
+# ============================================================================
+
+variable "kms_key_arn" {
+  description = "KMS key ARN used by the RDS cluster for storage encryption. FIS needs kms:Decrypt/Encrypt to reboot/failover encrypted clusters. Leave empty to allow all keys."
+  type        = string
+  default     = ""
+}
+
+# ============================================================================
+# Tags
+# ============================================================================
+
+variable "tags" {
+  description = "Additional tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+# ============================================================================
+# Network Disruption Experiment
+# ============================================================================
+
+variable "rds_security_group_id" {
+  description = "Security group ID of the test DB instance. Used to filter only the DB's ENIs for network disruption (not all ENIs in the subnet)"
+  type        = string
+  default     = ""
+}
+
+variable "network_disruption_duration" {
+  description = "Duration for network disruption experiment (ISO 8601 format, e.g. PT3M = 3 minutes)"
+  type        = string
+  default     = "PT3M"
+}
+
+# ============================================================================
+# Network Latency Injection Experiment (EC2)
+# ============================================================================
+
+variable "network_latency_target_instance_arns" {
+  description = "List of EC2 instance ARNs to target for network latency injection. Used when network_latency_target_resource_tags is empty. FIS will run the AWSFIS-Run-Network-Latency-Sources SSM document on these instances via aws:ssm:send-command."
+  type        = list(string)
+  default     = []
+}
+
+variable "network_latency_target_resource_tags" {
+  description = "Map of tags to select EC2 instances for network latency injection (e.g., {Service=\"envoy-proxy\", Environment=\"dev\"}). When non-empty, takes precedence over network_latency_target_instance_arns. FIS resolves targets at experiment start time, so instances can be replaced without re-applying."
+  type        = map(string)
+  default     = {}
+}
+
+variable "network_latency_target_service_names" {
+  description = "List of EC2 Service tag values to target for network latency injection (e.g., [\"envoy-proxy\", \"locker\"]). Uses FIS filters so multiple values are OR-ed. Takes precedence over instance ARNs and resource_tags."
+  type        = list(string)
+  default     = []
+}
+
+variable "network_latency_target_environment_tag" {
+  description = "Value of the Environment tag used to filter network latency targets. Defaults to var.environment. Set to environment.short if your live instances use the short environment code (e.g., sbx)."
+  type        = string
+  default     = ""
+}
+
+variable "network_latency_duration" {
+  description = "FIS action duration (ISO 8601, e.g. PT5M = 5 minutes). Must be >= network_latency_duration_seconds."
+  type        = string
+  default     = "PT5M"
+}
+
+variable "network_latency_duration_seconds" {
+  description = "SSM document DurationSeconds — how long the tc netem delay rule stays active on the instance (in seconds). Must be <= FIS action duration in seconds."
+  type        = number
+  default     = 300
+}
+
+variable "network_latency_delay_ms" {
+  description = "Network latency to inject in milliseconds"
+  type        = number
+  default     = 200
+}
+
+variable "network_latency_jitter_ms" {
+  description = "Jitter to inject in milliseconds (added on top of delay, normal distribution)"
+  type        = number
+  default     = 10
+}
+
+variable "network_latency_sources" {
+  description = "Comma-separated list of sources to apply latency to. Values: IPv4 address, CIDR block, domain name, AZ name (e.g. ap-south-1a), AZ ID, ALL, DYNAMODB, S3. No spaces after commas."
+  type        = string
+  default     = "ALL"
+}
+
+variable "network_latency_interface" {
+  description = "Network interface to target: DEFAULT (primary interface), ALL (all interfaces), or specific name (e.g. eth0)"
+  type        = string
+  default     = "DEFAULT"
+}
+
+variable "network_latency_traffic_type" {
+  description = "Traffic type to apply latency to: ingress or egress"
+  type        = string
+  default     = "egress"
+}
+
+variable "network_latency_flows_percent" {
+  description = "Percentage of network flows to affect (1-100)"
+  type        = number
+  default     = 100
+}
+
+# ============================================================================
+# Network Latency Simple (All Traffic) Experiment (EC2)
+# ============================================================================
+
+variable "network_latency_install_dependencies" {
+  description = "Whether to install tc/netem dependencies via SSM. Set to false if dependencies are already baked into the AMI (e.g. custom FIS AMI) or instances are in private subnet without package repo access."
+  type        = bool
+  default     = true
+}
+
+variable "network_latency_simple_delay_ms" {
+  description = "Network latency to inject in milliseconds for the simple all-traffic variant (no source targeting, no jitter)"
+  type        = number
+  default     = 200
+}
+
+variable "network_latency_simple_interface" {
+  description = "Network interface for simple latency: eth0, eth1, etc. Default is eth0 (primary)"
+  type        = string
+  default     = "eth0"
+}
+
+variable "network_latency_simple_sources" {
+  description = "Comma-separated sources for simple latency. Default ALL = all traffic. Set to specific IPs/CIDRs/domains/AZs to target only that traffic. Uses AWSFIS-Run-Network-Latency-Sources SSM document."
+  type        = string
+  default     = "ALL"
+}
+
+# ============================================================================
+# EC2 Instance Termination Experiment
+# ============================================================================
+
+variable "ec2_termination_target_instance_arns" {
+  description = "List of EC2 instance ARNs to terminate. FIS will use the aws:ec2:terminate-instances action. ⚠️ This permanently destroys the instances — only target disposable/test instances."
+  type        = list(string)
+  default     = []
+}
+
+# ============================================================================
+# AZ Power Interruption Experiment
+# ============================================================================
+
+variable "target_az" {
+  description = "Target availability zone for AZ power interruption experiment (e.g. ap-south-1a)"
+  type        = string
+  default     = ""
+}
+
+variable "az_interruption_duration" {
+  description = "Duration for AZ power interruption experiment (ISO 8601 format, e.g. PT30M = 30 minutes)"
+  type        = string
+  default     = "PT30M"
+}
+
+# ============================================================================
+# Stress Test Experiments (CPU/Memory/Connection via Lambda)
+# ============================================================================
+
+variable "jumphost_instance_id" {
+  description = "EC2 instance ID of the jump host used to invoke stress test Lambda functions via SSM. Leave empty to skip stress test templates."
+  type        = string
+  default     = ""
+}
+
+variable "stress_lambda_arns" {
+  description = "List of Lambda function ARNs for stress testing. Used for IAM permissions. Leave empty to skip stress test templates."
+  type        = list(string)
+  default     = []
+}
+
+variable "stress_lambda_function_names" {
+  description = "Map of stress type to Lambda function name. Keys must be: cpu_stress, memory_stress, connection_exhaustion"
+  type        = map(string)
+  default     = {}
+}
+
+variable "stress_duration_seconds" {
+  description = "Duration for stress test experiments in seconds (used to calculate FIS action duration)"
+  type        = number
+  default     = 300
+}
+
+variable "enable_stress_alarms" {
+  description = "Enable additional CloudWatch alarms for stress tests (FreeableMemory < 2GB, DatabaseConnections > 68)"
+  type        = bool
+  default     = false
+}
+
+# ============================================================================
+# Redis/Elasticache Stress Test Experiments
+# ============================================================================
+
+variable "redis_cluster_id" {
+  description = "Elasticache CacheClusterId (per-node cluster ID, NOT replication group ID) for Redis stress test CloudWatch alarm dimensions. E.g., sbx-test-redis-0001-001. Leave empty to skip Redis stress alarms."
+  type        = string
+  default     = ""
+}
+
+variable "redis_stress_lambda_arns" {
+  description = "List of Lambda function ARNs for Redis stress testing. Used for IAM permissions. Leave empty to skip Redis stress test templates."
+  type        = list(string)
+  default     = []
+}
+
+variable "redis_stress_lambda_function_names" {
+  description = "Map of Redis stress type to Lambda function name. Keys must be: cpu_stress, memory_stress, connection_exhaustion"
+  type        = map(string)
+  default     = {}
+}
+
+variable "enable_redis_stress_alarms" {
+  description = "Enable CloudWatch alarms for Redis stress tests (EngineCPUUtilization > 90%, FreeableMemory < 100MB, CurrConnections > 64000)"
+  type        = bool
+  default     = false
+}
+
+# ============================================================================
+# Redis/ElastiCache Failover Experiments
+# ============================================================================
+
+variable "redis_replication_group_id" {
+  description = "ElastiCache Redis replication group ID for failover experiments and replica-lag alarm dimension (e.g., sbx-test-redis). Leave empty to skip the replica-lag stop-condition alarm."
+  type        = string
+  default     = ""
+}
+
+variable "redis_node_group_id" {
+  description = "ElastiCache Redis node group ID (shard number) for the replication group, used as a dimension for the ReplicationLag stop-condition alarm. E.g., 0001"
+  type        = string
+  default     = "0001"
+}
+
+variable "redis_failover_lambda_function_name" {
+  description = "Name of the Lambda function that triggers ElastiCache TestFailover for the Redis replication group. Invoked via SSM on the jump host."
+  type        = string
+  default     = ""
+}
+
+variable "redis_failover_lambda_function_arn" {
+  description = "ARN of the Lambda function that triggers ElastiCache TestFailover. Used for FIS execution role IAM permissions (lambda:InvokeFunction)."
+  type        = string
+  default     = ""
+}
+
+# ============================================================================
+# Experiment Toggles
+# ============================================================================
+
+variable "enable_failover" {
+  description = "Enable FIS experiment: Aurora cluster failover"
+  type        = bool
+  default     = true
+}
+
+variable "enable_reboot" {
+  description = "Enable FIS experiment: DB instance reboot"
+  type        = bool
+  default     = true
+}
+
+variable "enable_combined" {
+  description = "Enable FIS experiment: Combined failover + wait + reboot"
+  type        = bool
+  default     = true
+}
+
+variable "enable_network_disruption" {
+  description = "Enable FIS experiment: Network connectivity loss to DB"
+  type        = bool
+  default     = false
+}
+
+variable "enable_az_interruption" {
+  description = "Enable FIS experiment: AZ power interruption (compound)"
+  type        = bool
+  default     = false
+}
+
+variable "enable_redis_failover" {
+  description = "Enable FIS experiment: standalone Redis replication group failover (TestFailover via Lambda invoked through SSM on jump host)"
+  type        = bool
+  default     = false
+}
+
+variable "enable_redis_failover_under_stress" {
+  description = "Enable FIS experiment: Redis failover triggered under CPU stress (stress starts → wait 2 minutes → failover while stress continues)"
+  type        = bool
+  default     = false
+}
+
+variable "enable_network_latency" {
+  description = "Enable FIS experiment: Network latency injection on EC2 instances via aws:ssm:send-command + AWSFIS-Run-Network-Latency-Sources (tc netem)"
+  type        = bool
+  default     = false
+}
+
+variable "enable_network_latency_simple" {
+  description = "Enable FIS experiment: Simple network latency on ALL traffic via AWSFIS-Run-Network-Latency (no source targeting, no jitter)"
+  type        = bool
+  default     = false
+}
+
+variable "enable_ec2_termination" {
+  description = "Enable FIS experiment: EC2 instance termination via aws:ec2:terminate-instances. ⚠️ Permanently destroys targeted instances."
+  type        = bool
+  default     = false
+}
+
+variable "enable_stress_tests" {
+  description = "Enable FIS experiments: CPU/memory/connection stress test Lambda invocation via SM on jump host (RDS Aurora)"
+  type        = bool
+  default     = false
+}
+
+variable "enable_redis_stress_tests" {
+  description = "Enable FIS experiments: Redis CPU/memory/connection stress test Lambda invocation via SSM on jump host (ElastiCache)"
+  type        = bool
+  default     = false
+}

--- a/terraform/aws/modules/composition/fis-experiments/versions.tf
+++ b/terraform/aws/modules/composition/fis-experiments/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    awscc = {
+      source  = "hashicorp/awscc"
+      version = ">= 1.0"
+    }
+  }
+}

--- a/terraform/aws/modules/composition/lambda-layer/README.md
+++ b/terraform/aws/modules/composition/lambda-layer/README.md
@@ -1,0 +1,37 @@
+# Lambda Layer Module
+
+Generic Terraform module that publishes an AWS Lambda Layer from a pre-built zip file.
+
+## What it creates
+
+- `aws_lambda_layer_version` resource with optional source hash, runtime compatibility, license info, and tags
+
+## Usage
+
+```hcl
+module "redis_py_layer" {
+  source = "./terraform/aws/modules/composition/lambda-layer"
+
+  layer_name          = "redis-py"
+  description         = "redis-py library for Redis/Valkey Lambdas"
+  zip_path            = "${path.module}/redis-py.zip"
+  compatible_runtimes = ["python3.11"]
+
+  tags = {
+    Project = "my-project"
+  }
+}
+```
+
+## Required inputs
+
+- `layer_name`
+- `zip_path`
+
+## Optional highlights
+
+- `source_hash` — pre-computed Base64 SHA256 of the zip
+- `compatible_runtimes` — defaults to `["python3.11"]`
+- `license_info` — license string for the layer
+
+See `variables.tf` and `outputs.tf` for full input/output listings.

--- a/terraform/aws/modules/composition/lambda-layer/README.md
+++ b/terraform/aws/modules/composition/lambda-layer/README.md
@@ -35,3 +35,50 @@ module "redis_py_layer" {
 - `license_info` — license string for the layer
 
 See `variables.tf` and `outputs.tf` for full input/output listings.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_lambda_layer_version.layer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_layer_version) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_compatible_runtimes"></a> [compatible\_runtimes](#input\_compatible\_runtimes) | List of compatible Lambda runtimes | `list(string)` | <pre>[<br/>  "python3.11"<br/>]</pre> | no |
+| <a name="input_description"></a> [description](#input\_description) | Description of the Lambda layer | `string` | `""` | no |
+| <a name="input_layer_name"></a> [layer\_name](#input\_layer\_name) | Name of the Lambda layer | `string` | n/a | yes |
+| <a name="input_license_info"></a> [license\_info](#input\_license\_info) | License information for the layer | `string` | `""` | no |
+| <a name="input_source_hash"></a> [source\_hash](#input\_source\_hash) | Base64-encoded SHA256 hash of the zip file | `string` | `""` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to the layer | `map(string)` | `{}` | no |
+| <a name="input_zip_path"></a> [zip\_path](#input\_zip\_path) | Path to the layer zip file | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_layer_arn"></a> [layer\_arn](#output\_layer\_arn) | ARN of the Lambda layer (with version) |
+| <a name="output_layer_name"></a> [layer\_name](#output\_layer\_name) | Name of the Lambda layer |
+| <a name="output_layer_version_arn"></a> [layer\_version\_arn](#output\_layer\_version\_arn) | ARN of the Lambda layer version |
+| <a name="output_source_code_hash"></a> [source\_code\_hash](#output\_source\_code\_hash) | Hash of the layer source code |
+| <a name="output_version"></a> [version](#output\_version) | Version number of the Lambda layer |
+<!-- END_TF_DOCS -->

--- a/terraform/aws/modules/composition/lambda-layer/main.tf
+++ b/terraform/aws/modules/composition/lambda-layer/main.tf
@@ -1,0 +1,13 @@
+# ============================================================================
+# Lambda Layer Module - Main
+# Creates an AWS Lambda Layer for shared dependencies
+# ============================================================================
+
+resource "aws_lambda_layer_version" "layer" {
+  layer_name          = var.layer_name
+  description         = var.description
+  filename            = var.zip_path
+  source_code_hash    = var.source_hash != "" ? var.source_hash : filebase64sha256(var.zip_path)
+  compatible_runtimes = var.compatible_runtimes
+  license_info        = var.license_info
+}

--- a/terraform/aws/modules/composition/lambda-layer/outputs.tf
+++ b/terraform/aws/modules/composition/lambda-layer/outputs.tf
@@ -1,0 +1,28 @@
+# ============================================================================
+# Lambda Layer Module - Outputs
+# ============================================================================
+
+output "layer_arn" {
+  description = "ARN of the Lambda layer (with version)"
+  value       = aws_lambda_layer_version.layer.arn
+}
+
+output "layer_version_arn" {
+  description = "ARN of the Lambda layer version"
+  value       = aws_lambda_layer_version.layer.layer_arn
+}
+
+output "layer_name" {
+  description = "Name of the Lambda layer"
+  value       = aws_lambda_layer_version.layer.layer_name
+}
+
+output "version" {
+  description = "Version number of the Lambda layer"
+  value       = aws_lambda_layer_version.layer.version
+}
+
+output "source_code_hash" {
+  description = "Hash of the layer source code"
+  value       = aws_lambda_layer_version.layer.source_code_hash
+}

--- a/terraform/aws/modules/composition/lambda-layer/variables.tf
+++ b/terraform/aws/modules/composition/lambda-layer/variables.tf
@@ -1,0 +1,43 @@
+# ============================================================================
+# Lambda Layer Module - Variables
+# ============================================================================
+
+variable "layer_name" {
+  description = "Name of the Lambda layer"
+  type        = string
+}
+
+variable "description" {
+  description = "Description of the Lambda layer"
+  type        = string
+  default     = ""
+}
+
+variable "zip_path" {
+  description = "Path to the layer zip file"
+  type        = string
+}
+
+variable "source_hash" {
+  description = "Base64-encoded SHA256 hash of the zip file"
+  type        = string
+  default     = ""
+}
+
+variable "compatible_runtimes" {
+  description = "List of compatible Lambda runtimes"
+  type        = list(string)
+  default     = ["python3.11"]
+}
+
+variable "license_info" {
+  description = "License information for the layer"
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "Tags to apply to the layer"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/aws/modules/composition/lambda-layer/versions.tf
+++ b/terraform/aws/modules/composition/lambda-layer/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Open-sources the internal chaos-engineering / resilience-testing modules into `hyperswitch-suite` so they can be reused by downstream projects.

## Modules added

| Module | Path | Purpose |
|---|---|---|
| `aurora-fault-injection` | `terraform/aws/modules/composition/aurora-fault-injection/` | Lambda-based fault injection (crash, replica failure, disk failure/congestion) and stress tests for Aurora PostgreSQL |
| `elasticache-stress-test` | `terraform/aws/modules/composition/elasticache-stress-test/` | Lambda-based Redis/Valkey stress tests: CPU burn, mixed open-loop workload, memory pressure, connection exhaustion, failover, cleanup |
| `fis-experiments` | `terraform/aws/modules/composition/fis-experiments/` | AWS FIS experiment templates for Aurora, ElastiCache, EC2, network latency, and stress-under-failure |
| `lambda-layer` | `terraform/aws/modules/composition/lambda-layer/` | Generic Lambda layer publisher; used to ship `redis-py` and `psycopg2` dependencies for the stress-test lambdas |


## Validation performed
- `terraform fmt -recursive -write=true` 
- `terraform validate`  for `aurora-fault-injection`, `elasticache-stress-test`, `fis-experiments`, and `lambda-layer`
- `python3 -m py_compile` on all Lambda source files 

## Usage note
The `lambda-layer` module consumes a pre-built zip. Typical usage is to publish `redis-py` for the Redis/Valkey stress lambdas and `psycopg2` for the Aurora fault-injection/stress lambdas.