### PR TITLE
feat(terraform): add GCP equivalents for composition and application-…

### DIFF
--- a/.github/workflows/terraform-docs.yml
+++ b/.github/workflows/terraform-docs.yml
@@ -25,12 +25,22 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
 
-      - name: Generate Terraform docs for module layers
+      - name: Generate Terraform docs for AWS module layers
         uses: terraform-docs/gh-actions@v1.4.1
         with:
           find-dir: terraform/aws/modules
           output-file: README.md
           output-method: inject
           config-file: terraform/aws/modules/.terraform-docs.yml
+          git-push: "false"
+          git-commit-message: "docs(terraform): auto-update module documentation [skip ci]"
+
+      - name: Generate Terraform docs for GCP module layers
+        uses: terraform-docs/gh-actions@v1.4.1
+        with:
+          find-dir: terraform/gcp/modules
+          output-file: README.md
+          output-method: inject
+          config-file: terraform/gcp/modules/.terraform-docs.yml
           git-push: "true"
           git-commit-message: "docs(terraform): auto-update module documentation [skip ci]"

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -199,14 +199,25 @@ jobs:
         with:
           terraform_version: "~1.5"
 
-      - name: Create CI provider override
+      - name: Create CI provider overrides
         run: |
-          cat > /tmp/ci_providers_override.tf << 'EOF'
+          cat > /tmp/ci_providers_override_aws.tf << 'EOF'
           provider "aws" {
             region                      = "eu-central-1"
             skip_credentials_validation = true
             skip_metadata_api_check     = true
             skip_requesting_account_id  = true
+          }
+          EOF
+
+          cat > /tmp/ci_providers_override_gcp.tf << 'EOF'
+          provider "google" {
+            project = "ci-validate"
+            region  = "europe-west1"
+          }
+          provider "google-beta" {
+            project = "ci-validate"
+            region  = "europe-west1"
           }
           EOF
 
@@ -228,12 +239,15 @@ jobs:
             echo "Validating: $dir"
             echo "=================================================="
             
-            cp /tmp/ci_providers_override.tf "$dir/" 2>/dev/null || true
-            
+            case "$dir" in
+              terraform/gcp/*) cp /tmp/ci_providers_override_gcp.tf "$dir/ci_providers_override.tf" 2>/dev/null || true ;;
+              *) cp /tmp/ci_providers_override_aws.tf "$dir/ci_providers_override.tf" 2>/dev/null || true ;;
+            esac
+
             echo "Running terraform init -backend=false..."
             INIT_OUTPUT=$(terraform init -backend=false -get=true -upgrade "$dir" 2>&1)
             INIT_EXIT=$?
-            
+
             rm -f "$dir/ci_providers_override.tf" 2>/dev/null || true
             
             if [ $INIT_EXIT -ne 0 ]; then

--- a/justfile
+++ b/justfile
@@ -12,19 +12,26 @@ default:
 # Terraform Documentation
 # ============================================================================
 
-# Generate terraform-docs for all module layers (base, composition, application-resources)
+# Generate terraform-docs for all module layers (aws: base, composition, application-resources; gcp: composition, application-resources)
 gen-docs:
 	@echo "Generating terraform-docs for all module layers..."
 	@for dir in $$(find terraform/aws/modules/base terraform/aws/modules/composition terraform/aws/modules/application-resources -name "main.tf" -exec dirname {} \; | sort); do \
 		echo "  $$dir"; \
 		terraform-docs --config terraform/aws/modules/.terraform-docs.yml "$$dir" >/dev/null 2>&1 || true; \
 		done
+	@for dir in $$(find terraform/gcp/modules/composition terraform/gcp/modules/application-resources -name "main.tf" -exec dirname {} \; | sort); do \
+		echo "  $$dir"; \
+		terraform-docs --config terraform/gcp/modules/.terraform-docs.yml "$$dir" >/dev/null 2>&1 || true; \
+		done
 	@echo "Done."
 
-# Generate terraform-docs for a specific module directory
+# Generate terraform-docs for a specific module directory (config file auto-selected by path: terraform/gcp/* uses the gcp config, everything else uses the aws config)
 gen-docs-module MODULE_DIR:
 	@echo "Generating terraform-docs for {{MODULE_DIR}}..."
-	@terraform-docs --config terraform/aws/modules/.terraform-docs.yml {{MODULE_DIR}}
+	@case "{{MODULE_DIR}}" in \
+		terraform/gcp/*) terraform-docs --config terraform/gcp/modules/.terraform-docs.yml {{MODULE_DIR}} ;; \
+		*) terraform-docs --config terraform/aws/modules/.terraform-docs.yml {{MODULE_DIR}} ;; \
+	esac
 
 # Check if terraform-docs is installed
 check-docs:

--- a/terraform/gcp/modules/.terraform-docs.yml
+++ b/terraform/gcp/modules/.terraform-docs.yml
@@ -1,0 +1,34 @@
+formatter: "markdown table"
+version: ">= 0.20.0"
+
+header-from: "main.tf"
+
+recursive:
+  enabled: false
+  path: modules
+  include-main: true
+
+output:
+  file: README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->
+
+sort:
+  enabled: true
+  by: name
+
+settings:
+  anchor: true
+  default: true
+  escape: true
+  hide-empty: false
+  html: true
+  indent: 2
+  lockfile: true
+  read-comments: true
+  required: true
+  sensitive: true
+  type: true

--- a/terraform/gcp/modules/README.md
+++ b/terraform/gcp/modules/README.md
@@ -1,0 +1,88 @@
+# GCP Terraform Modules
+
+GCP equivalents of `terraform/aws/modules/{composition,application-resources}`, built so Hyperswitch can be deployed on GCP with the same module layering the AWS tree uses. See `terraform/aws/ARCHITECTURE.md` for the layering philosophy this tree follows.
+
+Only **composition** and **application-resources** are ported — no `base/` layer, no `live/` roots, no `bootstrap/`, no `cloudfront-resources/`. Where an AWS composition module leans on `../../base/*`, its GCP counterpart calls an **official** registry module instead (`terraform-google-modules/*` / `GoogleCloudPlatform/*` — the Google Cloud Foundation Toolkit). No third-party or community modules are used anywhere in this tree.
+
+## Why no `base/` layer
+
+Only 5 of the 23 AWS composition modules touch `base/` at all, and each has a direct official-module replacement:
+
+| AWS composition | `base/` modules used | Official GCP replacement |
+|---|---|---|
+| `vpc-network` | vpc, subnet ×14, route-table ×13, network-acl, vpc-endpoint, security-group | `terraform-google-modules/network` (root module handles VPC + subnets + routes + firewall in one call) |
+| `squid-proxy` | s3-bucket ×2, iam-role, nlb, target-group, nlb-listener ×2, launch-template, asg | `cloud-storage//modules/simple_bucket`, `service-accounts`, `vm//modules/{instance_template,mig}`, `lb-internal` |
+| `cassandra` | lambda, api-gateway | `GoogleCloudPlatform/cloud-functions` (a single HTTP-triggered Gen2 function needs no separate API Gateway resource on GCP) |
+| `terraform-backend` | s3-bucket, dynamodb-table | `cloud-storage//modules/simple_bucket` (GCS backend locks natively — no lock-table equivalent) |
+| `eks` | eks | `kubernetes-engine//modules/private-cluster` |
+
+`application-resources/` never touched `base/` on the AWS side either.
+
+## Module map
+
+### composition/ (23 modules)
+
+| GCP module | AWS module | Built from |
+|---|---|---|
+| `vpc-network` | `vpc-network` | `network`, `cloud-router`, `cloud-nat`, `network//modules/private-service-access` |
+| `gke` | `eks` | `kubernetes-engine//modules/private-cluster` |
+| `gke-kubernetes-resources` | `eks-kubernetes-resources` | `kubernetes`/`helm` providers direct |
+| `cloud-sql` | `database` | `sql-db//modules/postgresql`, `kms` |
+| `memorystore` | `elasticache` | `memorystore` |
+| `cloud-dns` | `route53` | `cloud-dns` |
+| `artifact-registry` | `ecr` | raw `google_artifact_registry_repository` |
+| `certificate-manager` | `acm` | raw `google_certificate_manager_*` (no official module exists) |
+| `cloud-cdn` | `cloudfront` | raw `google_compute_backend_bucket`/URL map/proxy, `cloud-storage` |
+| `cloud-monitoring` | `cloudwatch` | raw `google_monitoring_*`, `log-export` |
+| `filestore` | `efs` | raw `google_filestore_instance`/`google_filestore_backup` (no official module exists) |
+| `pubsub` | `sns` | `pubsub` |
+| `load-balancer` | `load-balancer` | `lb-http` / `lb-internal` |
+| `gcs-backend` | `terraform-backend` | `cloud-storage//modules/simple_bucket` |
+| `firewall-rules` | `security-rules` | `network//modules/firewall-rules` |
+| `bastion-host` | `jump-host` | `bastion-host`, `cloud-storage`, `log-export` |
+| `envoy-proxy` | `envoy-proxy` | `vm//modules/{instance_template,mig}`, `lb-http`, `cloud-armor`, `secret-manager` |
+| `squid-proxy` | `squid-proxy` | `vm//modules/{instance_template,mig}`, `lb-internal`, `cloud-storage` |
+| `kafka` | `kafka` | `vm//modules/{instance_template,compute_instance}`, `service-accounts` |
+| `cassandra` | `cassandra` | `vm//modules/{instance_template,compute_instance}`, `cloud-functions` |
+| `clickhouse` | `clickhouse` | `vm//modules/{instance_template,umig,compute_instance}`, `lb-internal` |
+| `opensearch` | `opensearch` | `vm//modules/{instance_template,umig}`, `lb-internal` |
+| `locker` | `locker` | `vm//modules/{instance_template,umig}`, `kms`, `lb-internal`, `../cloud-sql` |
+
+### application-resources/ (14 modules)
+
+| GCP module | AWS module | Notes |
+|---|---|---|
+| `gke-workload-identity` | `eks-iam` | Generic Workload Identity + optional bucket variant |
+| `shared-iam-roles` | `shared-policy` | Custom IAM roles, `for_each` over `var.roles` |
+| `gateway-controller` | `alb-controller` | GKE's Gateway/Ingress controller is built in — no Helm chart to install |
+| `istio` | `istio` | Same istio-release Helm charts |
+| `argocd` | `argocd` | Cross-project impersonation instead of cross-account assume-role |
+| `external-secrets-operator` | `external-secrets-operator` | Secret Manager instead of Secrets Manager |
+| `hyperswitch` | `hyperswitch` | KMS, GCS buckets, Secret Manager (SMTP), Cloud Functions, cross-project impersonation |
+| `loki` | `loki` | GCS + Pub/Sub notification instead of S3 + SNS/SQS |
+| `vector` | `vector` | GCS + Pub/Sub topic/subscription instead of S3 + SQS |
+| `otel-collector` | `otel-collector` | Workload Identity + Cloud Operations roles |
+| `grafana` | `grafana` | `../../composition/cloud-sql` via a single `database_config` object |
+| `superposition` | `superposition` | Same `database_config` object shape as `grafana` |
+| `decision-engine` | `decision-engine` | Secret Manager instead of SES |
+| `ratelimiter` | `ratelimiter` | `../../composition/memorystore` + `../../composition/firewall-rules` |
+
+## Intentional gaps and divergences
+
+- **No NACL equivalent** in `vpc-network` — GCP firewall rules are stateful, making NACLs redundant.
+- **No DynamoDB-style lock table** in `gcs-backend` — the GCS Terraform backend locks natively via object generation.
+- **CloudFront Functions have no Cloud CDN equivalent** — `cloud-cdn` has no edge-compute hook; the nearest GCP-native path is a Cloud Run/Cloud Functions origin.
+- **SES has no GCP equivalent** — `hyperswitch` and `decision-engine` take a `smtp_secret_id` pointing at a Secret Manager secret instead.
+- **GKE's Gateway API resources (Gateway/HTTPRoute) are not created by Terraform** in `istio` or `gateway-controller` — they're Kubernetes-native custom resources with no first-class `hashicorp/kubernetes` provider type, so they're left to your GitOps/kubectl flow, the same boundary the rest of this tree draws between infrastructure and Kubernetes-native config.
+- **Relative paths, not pinned `git::` refs**, for cross-module composition (`locker` → `../cloud-sql`, `grafana`/`superposition` → `../../composition/cloud-sql`, `ratelimiter` → `../../composition/{memorystore,firewall-rules}`). The AWS tree pins `git::...?ref=database-v0.1.6`; this tree has no released tags yet — switch once it does.
+- **One `database_config` object shape**, used identically by `grafana` and `superposition` — the AWS tree has `grafana` and `superposition` calling the same database module with two different interface styles (flattened vars vs. an object); this tree picked one and kept both callers consistent.
+- **VM-tier modules (`kafka`, `cassandra`, `clickhouse`, `opensearch`, `locker`) are Compute Engine ports, not managed services** — same as their AWS counterparts, which are self-managed EC2 fleets with a pre-baked AMI. There's no first-party managed OpenSearch/Elasticsearch on GCP; the alternative is Elastic Cloud on GCP Marketplace or routing that workload to BigQuery/Log Analytics instead, which would be a different module shape entirely.
+- **Uniform provider version floor.** All 37 modules pin `google >= 6.0` and `terraform >= 1.5.0` (`google-beta >= 6.0` where the GKE/network modules need it). The AWS tree has version drift across its modules (`>= 5.0` / `~> 5.0` / `>= 6.32.1`); this tree does not reproduce that.
+
+## Registry modules used (verified against the Terraform Registry, pinned by exact version)
+
+`terraform-google-modules/network` 18.1.2 · `kubernetes-engine` 44.3.0 · `cloud-storage` 12.3.0 · `sql-db` 28.1.0 · `memorystore` 16.1.1 · `vm` 15.2.1 · `iam` 8.2.0 · `service-accounts` 4.7.0 · `lb-http` (`GoogleCloudPlatform/lb-http`) 14.2.0 · `lb-internal` 7.1.0 · `cloud-dns` 7.1.0 · `pubsub` 8.8.0 · `kms` 4.1.2 · `cloud-router` 9.0.0 · `cloud-nat` 7.0.0 · `bastion-host` 9.0.0 · `log-export` 11.1.0 · `cloud-operations` 0.7.0 · `GoogleCloudPlatform/artifact-registry` 0.8.2 · `GoogleCloudPlatform/secret-manager` 0.9.0 · `GoogleCloudPlatform/cloud-armor` 8.1.1 · `GoogleCloudPlatform/cloud-functions` 0.9.0.
+
+## Conventions
+
+Same as the AWS tree (`terraform/aws/modules/.terraform-docs.yml`, file layout, `locals.tf`/`common_labels` pattern) with two GCP-specific adjustments: `common_tags` → `common_labels` (GCP label values are lowercase-alphanumeric-plus-`-_` only), and READMEs are terraform-docs generated (`just gen-docs`) exactly like the AWS side.

--- a/terraform/gcp/modules/application-resources/argocd/README.md
+++ b/terraform/gcp/modules/application-resources/argocd/README.md
@@ -2,32 +2,32 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ../gke-workload-identity | n/a |
 
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google_service_account_iam_member.cross_project_impersonation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_additional_project_roles"></a> [additional\_project\_roles](#input\_additional\_project\_roles) | Additional project-level IAM roles to grant ArgoCD's service account | `list(string)` | `[]` | no |
 | <a name="input_argocd_namespace"></a> [argocd\_namespace](#input\_argocd\_namespace) | Kubernetes namespace where ArgoCD is deployed | `string` | `"argocd"` | no |
 | <a name="input_argocd_service_accounts"></a> [argocd\_service\_accounts](#input\_argocd\_service\_accounts) | List of ArgoCD Kubernetes service accounts bound to Workload Identity. Only the first is bound directly (Workload Identity is 1:1 GSA<->KSA); grant the rest via kubectl annotation if they should share the same GSA | `list(string)` | <pre>[<br/>  "argocd-application-controller",<br/>  "argocd-applicationset-controller",<br/>  "argocd-server"<br/>]</pre> | no |
@@ -42,7 +42,7 @@
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_k8s_service_account_name"></a> [k8s\_service\_account\_name](#output\_k8s\_service\_account\_name) | Bound Kubernetes service account name |
 | <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of ArgoCD's Google service account |
 <!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/application-resources/argocd/README.md
+++ b/terraform/gcp/modules/application-resources/argocd/README.md
@@ -1,0 +1,48 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ../gke-workload-identity | n/a |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_service_account_iam_member.cross_project_impersonation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_additional_project_roles"></a> [additional\_project\_roles](#input\_additional\_project\_roles) | Additional project-level IAM roles to grant ArgoCD's service account | `list(string)` | `[]` | no |
+| <a name="input_argocd_namespace"></a> [argocd\_namespace](#input\_argocd\_namespace) | Kubernetes namespace where ArgoCD is deployed | `string` | `"argocd"` | no |
+| <a name="input_argocd_service_accounts"></a> [argocd\_service\_accounts](#input\_argocd\_service\_accounts) | List of ArgoCD Kubernetes service accounts bound to Workload Identity. Only the first is bound directly (Workload Identity is 1:1 GSA<->KSA); grant the rest via kubectl annotation if they should share the same GSA | `list(string)` | <pre>[<br/>  "argocd-application-controller",<br/>  "argocd-applicationset-controller",<br/>  "argocd-server"<br/>]</pre> | no |
+| <a name="input_cluster_location"></a> [cluster\_location](#input\_cluster\_location) | Location (region or zone) of the GKE cluster | `string` | n/a | yes |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster hosting ArgoCD | `string` | n/a | yes |
+| <a name="input_cross_project_target_service_accounts"></a> [cross\_project\_target\_service\_accounts](#input\_cross\_project\_target\_service\_accounts) | List of fully qualified service account IDs (in other projects) that ArgoCD is allowed to impersonate for cross-project deployments | `list(string)` | `[]` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to created resources that support them | `map(string)` | `{}` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name for resource naming and labeling | `string` | `"hyperswitch"` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_k8s_service_account_name"></a> [k8s\_service\_account\_name](#output\_k8s\_service\_account\_name) | Bound Kubernetes service account name |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of ArgoCD's Google service account |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/application-resources/argocd/main.tf
+++ b/terraform/gcp/modules/application-resources/argocd/main.tf
@@ -1,0 +1,53 @@
+# ============================================================================
+# ArgoCD (GCP equivalent of application-resources/argocd)
+# ============================================================================
+# GSA + Workload Identity binding for ArgoCD's controller/server/
+# applicationset service accounts, plus optional cross-project deployment
+# support. AWS's cross-account `sts:AssumeRole` has no single GCP
+# equivalent; the nearest is granting ArgoCD's service account
+# `roles/iam.serviceAccountTokenCreator` on target service accounts in
+# other projects, which it then impersonates - so `cross_project_target_sas`
+# plays the role of the AWS module's `cross_account_roles`.
+#
+# Usage:
+#   module "argocd" {
+#     source = "../../modules/application-resources/argocd"
+#
+#     project_id   = "hyperswitch-dev"
+#     environment  = "dev"
+#     project_name = "hyperswitch"
+#
+#     cluster_name     = module.gke.cluster_name
+#     cluster_location = module.gke.location
+#   }
+# ============================================================================
+
+module "workload_identity" {
+  source = "../gke-workload-identity"
+
+  project_id   = var.project_id
+  environment  = var.environment
+  project_name = var.project_name
+  app_name     = "argocd"
+
+  cluster_name             = var.cluster_name
+  cluster_location         = var.cluster_location
+  k8s_namespace            = var.argocd_namespace
+  k8s_service_account_name = var.argocd_service_accounts[0]
+
+  project_roles = var.additional_project_roles
+
+  labels = var.labels
+}
+
+# ==============================================================================
+# Cross-project deployment: grant ArgoCD's GSA impersonation rights on
+# target service accounts in other projects
+# ==============================================================================
+resource "google_service_account_iam_member" "cross_project_impersonation" {
+  for_each = toset(var.cross_project_target_service_accounts)
+
+  service_account_id = each.value
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${module.workload_identity.service_account_email}"
+}

--- a/terraform/gcp/modules/application-resources/argocd/outputs.tf
+++ b/terraform/gcp/modules/application-resources/argocd/outputs.tf
@@ -1,0 +1,9 @@
+output "service_account_email" {
+  description = "Email of ArgoCD's Google service account"
+  value       = module.workload_identity.service_account_email
+}
+
+output "k8s_service_account_name" {
+  description = "Bound Kubernetes service account name"
+  value       = module.workload_identity.k8s_service_account_name
+}

--- a/terraform/gcp/modules/application-resources/argocd/variables.tf
+++ b/terraform/gcp/modules/application-resources/argocd/variables.tf
@@ -1,0 +1,59 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for resource naming and labeling"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "cluster_name" {
+  description = "Name of the GKE cluster hosting ArgoCD"
+  type        = string
+}
+
+variable "cluster_location" {
+  description = "Location (region or zone) of the GKE cluster"
+  type        = string
+}
+
+variable "argocd_namespace" {
+  description = "Kubernetes namespace where ArgoCD is deployed"
+  type        = string
+  default     = "argocd"
+}
+
+variable "argocd_service_accounts" {
+  description = "List of ArgoCD Kubernetes service accounts bound to Workload Identity. Only the first is bound directly (Workload Identity is 1:1 GSA<->KSA); grant the rest via kubectl annotation if they should share the same GSA"
+  type        = list(string)
+  default = [
+    "argocd-application-controller",
+    "argocd-applicationset-controller",
+    "argocd-server",
+  ]
+}
+
+variable "additional_project_roles" {
+  description = "Additional project-level IAM roles to grant ArgoCD's service account"
+  type        = list(string)
+  default     = []
+}
+
+variable "cross_project_target_service_accounts" {
+  description = "List of fully qualified service account IDs (in other projects) that ArgoCD is allowed to impersonate for cross-project deployments"
+  type        = list(string)
+  default     = []
+}
+
+variable "labels" {
+  description = "Labels to apply to created resources that support them"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/application-resources/argocd/versions.tf
+++ b/terraform/gcp/modules/application-resources/argocd/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/application-resources/decision-engine/README.md
+++ b/terraform/gcp/modules/application-resources/decision-engine/README.md
@@ -2,33 +2,33 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_bucket"></a> [bucket](#module\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
 | <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ../gke-workload-identity | n/a |
 
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google_secret_manager_secret_iam_member.smtp_credentials](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_additional_project_roles"></a> [additional\_project\_roles](#input\_additional\_project\_roles) | Additional project-level IAM roles to grant decision-engine's service account | `list(string)` | `[]` | no |
 | <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | Whether to allow bucket deletion with objects in it | `bool` | `false` | no |
 | <a name="input_bucket_location"></a> [bucket\_location](#input\_bucket\_location) | Location for the dedicated bucket | `string` | `"US"` | no |
@@ -47,7 +47,7 @@
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | Name of the dedicated bucket, if created |
 | <a name="output_k8s_service_account_name"></a> [k8s\_service\_account\_name](#output\_k8s\_service\_account\_name) | Bound Kubernetes service account name |
 | <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of decision-engine's Google service account |

--- a/terraform/gcp/modules/application-resources/decision-engine/README.md
+++ b/terraform/gcp/modules/application-resources/decision-engine/README.md
@@ -1,0 +1,54 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_bucket"></a> [bucket](#module\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
+| <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ../gke-workload-identity | n/a |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_secret_manager_secret_iam_member.smtp_credentials](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_additional_project_roles"></a> [additional\_project\_roles](#input\_additional\_project\_roles) | Additional project-level IAM roles to grant decision-engine's service account | `list(string)` | `[]` | no |
+| <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | Whether to allow bucket deletion with objects in it | `bool` | `false` | no |
+| <a name="input_bucket_location"></a> [bucket\_location](#input\_bucket\_location) | Location for the dedicated bucket | `string` | `"US"` | no |
+| <a name="input_cluster_location"></a> [cluster\_location](#input\_cluster\_location) | Location (region or zone) of the GKE cluster | `string` | n/a | yes |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster hosting decision-engine | `string` | n/a | yes |
+| <a name="input_create_bucket"></a> [create\_bucket](#input\_create\_bucket) | Whether to create a dedicated GCS bucket for decision-engine | `bool` | `false` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | Kubernetes namespace decision-engine runs in | `string` | `"hyperswitch"` | no |
+| <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | Kubernetes service account name used by decision-engine | `string` | `"decision-engine"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name for resource naming and labeling | `string` | `"hyperswitch"` | no |
+| <a name="input_s3_bucket_name"></a> [s3\_bucket\_name](#input\_s3\_bucket\_name) | Custom bucket name. If null, auto-generated as '<env>-<project>-decision-engine-storage' | `string` | `null` | no |
+| <a name="input_smtp_secret_id"></a> [smtp\_secret\_id](#input\_smtp\_secret\_id) | Secret Manager secret ID holding SMTP credentials (replaces AWS SES). Null skips granting access | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | Name of the dedicated bucket, if created |
+| <a name="output_k8s_service_account_name"></a> [k8s\_service\_account\_name](#output\_k8s\_service\_account\_name) | Bound Kubernetes service account name |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of decision-engine's Google service account |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/application-resources/decision-engine/locals.tf
+++ b/terraform/gcp/modules/application-resources/decision-engine/locals.tf
@@ -1,0 +1,14 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}-decision-engine"
+
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "application" = "decision-engine"
+    },
+    var.labels
+  )
+
+  bucket_name = var.s3_bucket_name != null ? var.s3_bucket_name : "${local.name_prefix}-storage"
+}

--- a/terraform/gcp/modules/application-resources/decision-engine/main.tf
+++ b/terraform/gcp/modules/application-resources/decision-engine/main.tf
@@ -1,0 +1,72 @@
+# ============================================================================
+# Decision Engine (GCP equivalent of application-resources/decision-engine)
+# ============================================================================
+# GSA + Workload Identity binding, an optional GCS bucket + bucket IAM
+# (equivalent of the AWS module's dedicated S3 bucket + policy), and SMTP
+# credentials sourced from Secret Manager instead of SES (GCP has no
+# first-party transactional email service).
+#
+# Usage:
+#   module "decision_engine" {
+#     source = "../../modules/application-resources/decision-engine"
+#
+#     project_id   = "hyperswitch-dev"
+#     environment  = "dev"
+#     project_name = "hyperswitch"
+#
+#     cluster_name     = module.gke.cluster_name
+#     cluster_location = module.gke.location
+#   }
+# ============================================================================
+
+module "workload_identity" {
+  source = "../gke-workload-identity"
+
+  project_id   = var.project_id
+  environment  = var.environment
+  project_name = var.project_name
+  app_name     = "decision-engine"
+
+  cluster_name             = var.cluster_name
+  cluster_location         = var.cluster_location
+  k8s_namespace            = var.k8s_namespace
+  k8s_service_account_name = var.k8s_service_account_name
+
+  project_roles = var.additional_project_roles
+
+  labels = local.common_labels
+}
+
+module "bucket" {
+  source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
+  version = "12.3.0"
+
+  count = var.create_bucket ? 1 : 0
+
+  project_id    = var.project_id
+  name          = local.bucket_name
+  location      = var.bucket_location
+  force_destroy = var.bucket_force_destroy
+
+  versioning         = true
+  bucket_policy_only = true
+
+  iam_members = [{
+    role   = "roles/storage.objectAdmin"
+    member = "serviceAccount:${module.workload_identity.service_account_email}"
+  }]
+
+  labels = local.common_labels
+}
+
+# ==============================================================================
+# SMTP credentials (replaces SES; sourced from an existing Secret Manager secret)
+# ==============================================================================
+resource "google_secret_manager_secret_iam_member" "smtp_credentials" {
+  count = var.smtp_secret_id != null ? 1 : 0
+
+  project   = var.project_id
+  secret_id = var.smtp_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${module.workload_identity.service_account_email}"
+}

--- a/terraform/gcp/modules/application-resources/decision-engine/outputs.tf
+++ b/terraform/gcp/modules/application-resources/decision-engine/outputs.tf
@@ -1,0 +1,14 @@
+output "service_account_email" {
+  description = "Email of decision-engine's Google service account"
+  value       = module.workload_identity.service_account_email
+}
+
+output "k8s_service_account_name" {
+  description = "Bound Kubernetes service account name"
+  value       = module.workload_identity.k8s_service_account_name
+}
+
+output "bucket_name" {
+  description = "Name of the dedicated bucket, if created"
+  value       = var.create_bucket ? module.bucket[0].name : null
+}

--- a/terraform/gcp/modules/application-resources/decision-engine/variables.tf
+++ b/terraform/gcp/modules/application-resources/decision-engine/variables.tf
@@ -1,0 +1,79 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for resource naming and labeling"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "cluster_name" {
+  description = "Name of the GKE cluster hosting decision-engine"
+  type        = string
+}
+
+variable "cluster_location" {
+  description = "Location (region or zone) of the GKE cluster"
+  type        = string
+}
+
+variable "k8s_namespace" {
+  description = "Kubernetes namespace decision-engine runs in"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "k8s_service_account_name" {
+  description = "Kubernetes service account name used by decision-engine"
+  type        = string
+  default     = "decision-engine"
+}
+
+variable "additional_project_roles" {
+  description = "Additional project-level IAM roles to grant decision-engine's service account"
+  type        = list(string)
+  default     = []
+}
+
+variable "create_bucket" {
+  description = "Whether to create a dedicated GCS bucket for decision-engine"
+  type        = bool
+  default     = false
+}
+
+variable "s3_bucket_name" {
+  description = "Custom bucket name. If null, auto-generated as '<env>-<project>-decision-engine-storage'"
+  type        = string
+  default     = null
+}
+
+variable "bucket_location" {
+  description = "Location for the dedicated bucket"
+  type        = string
+  default     = "US"
+}
+
+variable "bucket_force_destroy" {
+  description = "Whether to allow bucket deletion with objects in it"
+  type        = bool
+  default     = false
+}
+
+variable "smtp_secret_id" {
+  description = "Secret Manager secret ID holding SMTP credentials (replaces AWS SES). Null skips granting access"
+  type        = string
+  default     = null
+}
+
+variable "labels" {
+  description = "Additional labels to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/application-resources/decision-engine/versions.tf
+++ b/terraform/gcp/modules/application-resources/decision-engine/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/application-resources/external-secrets-operator/README.md
+++ b/terraform/gcp/modules/application-resources/external-secrets-operator/README.md
@@ -2,32 +2,32 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ../gke-workload-identity | n/a |
 
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google_secret_manager_secret_iam_member.accessor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_additional_project_roles"></a> [additional\_project\_roles](#input\_additional\_project\_roles) | Additional project-level IAM roles to grant the operator's service account | `list(string)` | `[]` | no |
 | <a name="input_cluster_location"></a> [cluster\_location](#input\_cluster\_location) | Location (region or zone) of the GKE cluster | `string` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster hosting the operator | `string` | n/a | yes |
@@ -43,7 +43,7 @@
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_k8s_service_account_name"></a> [k8s\_service\_account\_name](#output\_k8s\_service\_account\_name) | Bound Kubernetes service account name |
 | <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of the operator's Google service account |
 <!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/application-resources/external-secrets-operator/README.md
+++ b/terraform/gcp/modules/application-resources/external-secrets-operator/README.md
@@ -1,0 +1,49 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ../gke-workload-identity | n/a |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_secret_manager_secret_iam_member.accessor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_additional_project_roles"></a> [additional\_project\_roles](#input\_additional\_project\_roles) | Additional project-level IAM roles to grant the operator's service account | `list(string)` | `[]` | no |
+| <a name="input_cluster_location"></a> [cluster\_location](#input\_cluster\_location) | Location (region or zone) of the GKE cluster | `string` | n/a | yes |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster hosting the operator | `string` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | Kubernetes namespace the operator runs in | `string` | `"external-secrets"` | no |
+| <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | Kubernetes service account name used by the operator | `string` | `"external-secrets"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to created resources that support them | `map(string)` | `{}` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name for resource naming and labeling | `string` | `"hyperswitch"` | no |
+| <a name="input_scope_to_project"></a> [scope\_to\_project](#input\_scope\_to\_project) | Whether to grant project-wide roles/secretmanager.secretAccessor. Set false and use secret\_ids for least-privilege, per-secret access instead | `bool` | `true` | no |
+| <a name="input_secret_ids"></a> [secret\_ids](#input\_secret\_ids) | List of specific Secret Manager secret IDs to grant access to (in addition to, or instead of, the project-wide role) | `list(string)` | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_k8s_service_account_name"></a> [k8s\_service\_account\_name](#output\_k8s\_service\_account\_name) | Bound Kubernetes service account name |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of the operator's Google service account |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/application-resources/external-secrets-operator/main.tf
+++ b/terraform/gcp/modules/application-resources/external-secrets-operator/main.tf
@@ -1,0 +1,52 @@
+# ============================================================================
+# External Secrets Operator (GCP equivalent of application-resources/external-secrets-operator)
+# ============================================================================
+# GSA + Workload Identity binding granted read access to Secret Manager,
+# scoped either project-wide or to a specific list of secrets - mirroring
+# the AWS module's IRSA role + scoped Secrets Manager IAM policy document.
+#
+# Usage:
+#   module "external_secrets_operator" {
+#     source = "../../modules/application-resources/external-secrets-operator"
+#
+#     project_id   = "hyperswitch-dev"
+#     environment  = "dev"
+#     project_name = "hyperswitch"
+#
+#     cluster_name     = module.gke.cluster_name
+#     cluster_location = module.gke.location
+#
+#     secret_ids = ["hyperswitch-dev-db-password"]
+#   }
+# ============================================================================
+
+module "workload_identity" {
+  source = "../gke-workload-identity"
+
+  project_id   = var.project_id
+  environment  = var.environment
+  project_name = var.project_name
+  app_name     = "eso"
+
+  cluster_name             = var.cluster_name
+  cluster_location         = var.cluster_location
+  k8s_namespace            = var.k8s_namespace
+  k8s_service_account_name = var.k8s_service_account_name
+
+  project_roles = var.scope_to_project ? concat(["roles/secretmanager.secretAccessor"], var.additional_project_roles) : var.additional_project_roles
+
+  labels = var.labels
+}
+
+# ==============================================================================
+# Per-secret access (used instead of/alongside the project-wide role above
+# when secret_ids is non-empty, for least-privilege scoping)
+# ==============================================================================
+resource "google_secret_manager_secret_iam_member" "accessor" {
+  for_each = toset(var.secret_ids)
+
+  project   = var.project_id
+  secret_id = each.value
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${module.workload_identity.service_account_email}"
+}

--- a/terraform/gcp/modules/application-resources/external-secrets-operator/outputs.tf
+++ b/terraform/gcp/modules/application-resources/external-secrets-operator/outputs.tf
@@ -1,0 +1,9 @@
+output "service_account_email" {
+  description = "Email of the operator's Google service account"
+  value       = module.workload_identity.service_account_email
+}
+
+output "k8s_service_account_name" {
+  description = "Bound Kubernetes service account name"
+  value       = module.workload_identity.k8s_service_account_name
+}

--- a/terraform/gcp/modules/application-resources/external-secrets-operator/variables.tf
+++ b/terraform/gcp/modules/application-resources/external-secrets-operator/variables.tf
@@ -1,0 +1,61 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for resource naming and labeling"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "cluster_name" {
+  description = "Name of the GKE cluster hosting the operator"
+  type        = string
+}
+
+variable "cluster_location" {
+  description = "Location (region or zone) of the GKE cluster"
+  type        = string
+}
+
+variable "k8s_namespace" {
+  description = "Kubernetes namespace the operator runs in"
+  type        = string
+  default     = "external-secrets"
+}
+
+variable "k8s_service_account_name" {
+  description = "Kubernetes service account name used by the operator"
+  type        = string
+  default     = "external-secrets"
+}
+
+variable "scope_to_project" {
+  description = "Whether to grant project-wide roles/secretmanager.secretAccessor. Set false and use secret_ids for least-privilege, per-secret access instead"
+  type        = bool
+  default     = true
+}
+
+variable "secret_ids" {
+  description = "List of specific Secret Manager secret IDs to grant access to (in addition to, or instead of, the project-wide role)"
+  type        = list(string)
+  default     = []
+}
+
+variable "additional_project_roles" {
+  description = "Additional project-level IAM roles to grant the operator's service account"
+  type        = list(string)
+  default     = []
+}
+
+variable "labels" {
+  description = "Labels to apply to created resources that support them"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/application-resources/external-secrets-operator/versions.tf
+++ b/terraform/gcp/modules/application-resources/external-secrets-operator/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/application-resources/gateway-controller/README.md
+++ b/terraform/gcp/modules/application-resources/gateway-controller/README.md
@@ -1,0 +1,51 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ../gke-workload-identity | n/a |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_compute_ssl_policy.gateway](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_ssl_policy) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_additional_project_roles"></a> [additional\_project\_roles](#input\_additional\_project\_roles) | Additional project-level IAM roles to grant the controller-adjacent service account | `list(string)` | `[]` | no |
+| <a name="input_cluster_location"></a> [cluster\_location](#input\_cluster\_location) | Location (region or zone) of the GKE cluster. Required when create\_service\_account = true | `string` | `null` | no |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster. Required when create\_service\_account = true | `string` | `null` | no |
+| <a name="input_create_service_account"></a> [create\_service\_account](#input\_create\_service\_account) | Whether to create a Workload Identity-bound service account for BackendConfig/FrontendConfig automation | `bool` | `false` | no |
+| <a name="input_create_ssl_policy"></a> [create\_ssl\_policy](#input\_create\_ssl\_policy) | Whether to create an SSL policy governing minimum TLS version/cipher suite for GKE-managed load balancers | `bool` | `true` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | Kubernetes namespace for the controller-adjacent service account | `string` | `"kube-system"` | no |
+| <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | Kubernetes service account name for the controller-adjacent service account | `string` | `"gateway-controller"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to created resources that support them | `map(string)` | `{}` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name for resource naming and labeling | `string` | `"hyperswitch"` | no |
+| <a name="input_ssl_policy_min_tls_version"></a> [ssl\_policy\_min\_tls\_version](#input\_ssl\_policy\_min\_tls\_version) | Minimum TLS version: TLS\_1\_0, TLS\_1\_1, or TLS\_1\_2 | `string` | `"TLS_1_2"` | no |
+| <a name="input_ssl_policy_profile"></a> [ssl\_policy\_profile](#input\_ssl\_policy\_profile) | SSL policy profile: COMPATIBLE, MODERN, RESTRICTED, or CUSTOM | `string` | `"MODERN"` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of the controller-adjacent service account, if created |
+| <a name="output_ssl_policy_id"></a> [ssl\_policy\_id](#output\_ssl\_policy\_id) | ID of the SSL policy, if created |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/application-resources/gateway-controller/README.md
+++ b/terraform/gcp/modules/application-resources/gateway-controller/README.md
@@ -2,32 +2,32 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ../gke-workload-identity | n/a |
 
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google_compute_ssl_policy.gateway](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_ssl_policy) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_additional_project_roles"></a> [additional\_project\_roles](#input\_additional\_project\_roles) | Additional project-level IAM roles to grant the controller-adjacent service account | `list(string)` | `[]` | no |
 | <a name="input_cluster_location"></a> [cluster\_location](#input\_cluster\_location) | Location (region or zone) of the GKE cluster. Required when create\_service\_account = true | `string` | `null` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster. Required when create\_service\_account = true | `string` | `null` | no |
@@ -45,7 +45,7 @@
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of the controller-adjacent service account, if created |
 | <a name="output_ssl_policy_id"></a> [ssl\_policy\_id](#output\_ssl\_policy\_id) | ID of the SSL policy, if created |
 <!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/application-resources/gateway-controller/locals.tf
+++ b/terraform/gcp/modules/application-resources/gateway-controller/locals.tf
@@ -1,0 +1,12 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}-gateway-controller"
+
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "application" = "gateway-controller"
+    },
+    var.labels
+  )
+}

--- a/terraform/gcp/modules/application-resources/gateway-controller/main.tf
+++ b/terraform/gcp/modules/application-resources/gateway-controller/main.tf
@@ -1,0 +1,57 @@
+# ============================================================================
+# Gateway Controller (GCP equivalent of application-resources/alb-controller)
+# ============================================================================
+# The AWS Load Balancer Controller is a Helm-installed workload that
+# provisions ALBs from Kubernetes Ingress/Gateway resources. GKE has no
+# equivalent controller to install: Gateway API and Ingress support are
+# built into GKE itself (enabled via `gateway_api_channel` on
+# composition/gke), and the Google Cloud Load Balancer controller runs as a
+# managed control-plane component, not a workload you deploy.
+#
+# What this module actually provides, then, is the supporting
+# infrastructure a Terraform-managed alb-controller module would otherwise
+# own: an SSL policy governing the minimum TLS version/cipher suite for
+# GKE-managed load balancers, and (optionally) a Workload Identity binding
+# for any BackendConfig/FrontendConfig automation that needs GCP API access.
+# The Gateway/HTTPRoute/Ingress *objects themselves* are Kubernetes-native
+# resources applied via your GitOps/kubectl flow, not Terraform - the same
+# boundary application-resources/istio draws.
+#
+# Usage:
+#   module "gateway_controller" {
+#     source = "../../modules/application-resources/gateway-controller"
+#
+#     project_id   = "hyperswitch-dev"
+#     environment  = "dev"
+#     project_name = "hyperswitch"
+#   }
+# ============================================================================
+
+resource "google_compute_ssl_policy" "gateway" {
+  count = var.create_ssl_policy ? 1 : 0
+
+  project         = var.project_id
+  name            = "${local.name_prefix}-ssl-policy"
+  profile         = var.ssl_policy_profile
+  min_tls_version = var.ssl_policy_min_tls_version
+}
+
+module "workload_identity" {
+  source = "../gke-workload-identity"
+
+  count = var.create_service_account ? 1 : 0
+
+  project_id   = var.project_id
+  environment  = var.environment
+  project_name = var.project_name
+  app_name     = "gateway-controller"
+
+  cluster_name             = var.cluster_name
+  cluster_location         = var.cluster_location
+  k8s_namespace            = var.k8s_namespace
+  k8s_service_account_name = var.k8s_service_account_name
+
+  project_roles = var.additional_project_roles
+
+  labels = local.common_labels
+}

--- a/terraform/gcp/modules/application-resources/gateway-controller/outputs.tf
+++ b/terraform/gcp/modules/application-resources/gateway-controller/outputs.tf
@@ -1,0 +1,9 @@
+output "ssl_policy_id" {
+  description = "ID of the SSL policy, if created"
+  value       = var.create_ssl_policy ? google_compute_ssl_policy.gateway[0].id : null
+}
+
+output "service_account_email" {
+  description = "Email of the controller-adjacent service account, if created"
+  value       = var.create_service_account ? module.workload_identity[0].service_account_email : null
+}

--- a/terraform/gcp/modules/application-resources/gateway-controller/variables.tf
+++ b/terraform/gcp/modules/application-resources/gateway-controller/variables.tf
@@ -1,0 +1,75 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for resource naming and labeling"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "create_ssl_policy" {
+  description = "Whether to create an SSL policy governing minimum TLS version/cipher suite for GKE-managed load balancers"
+  type        = bool
+  default     = true
+}
+
+variable "ssl_policy_profile" {
+  description = "SSL policy profile: COMPATIBLE, MODERN, RESTRICTED, or CUSTOM"
+  type        = string
+  default     = "MODERN"
+}
+
+variable "ssl_policy_min_tls_version" {
+  description = "Minimum TLS version: TLS_1_0, TLS_1_1, or TLS_1_2"
+  type        = string
+  default     = "TLS_1_2"
+}
+
+variable "create_service_account" {
+  description = "Whether to create a Workload Identity-bound service account for BackendConfig/FrontendConfig automation"
+  type        = bool
+  default     = false
+}
+
+variable "cluster_name" {
+  description = "Name of the GKE cluster. Required when create_service_account = true"
+  type        = string
+  default     = null
+}
+
+variable "cluster_location" {
+  description = "Location (region or zone) of the GKE cluster. Required when create_service_account = true"
+  type        = string
+  default     = null
+}
+
+variable "k8s_namespace" {
+  description = "Kubernetes namespace for the controller-adjacent service account"
+  type        = string
+  default     = "kube-system"
+}
+
+variable "k8s_service_account_name" {
+  description = "Kubernetes service account name for the controller-adjacent service account"
+  type        = string
+  default     = "gateway-controller"
+}
+
+variable "additional_project_roles" {
+  description = "Additional project-level IAM roles to grant the controller-adjacent service account"
+  type        = list(string)
+  default     = []
+}
+
+variable "labels" {
+  description = "Additional labels to apply to created resources that support them"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/application-resources/gateway-controller/versions.tf
+++ b/terraform/gcp/modules/application-resources/gateway-controller/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/application-resources/gke-workload-identity/README.md
+++ b/terraform/gcp/modules/application-resources/gke-workload-identity/README.md
@@ -1,0 +1,56 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_bucket"></a> [bucket](#module\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
+| <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | terraform-google-modules/kubernetes-engine/google//modules/workload-identity | 44.3.0 |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_annotate_k8s_sa"></a> [annotate\_k8s\_sa](#input\_annotate\_k8s\_sa) | Whether to annotate the Kubernetes service account with the GCP service account email | `bool` | `true` | no |
+| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Application name (e.g. hyperswitch, control-centre) | `string` | n/a | yes |
+| <a name="input_bucket_enable_versioning"></a> [bucket\_enable\_versioning](#input\_bucket\_enable\_versioning) | Enable versioning for the companion bucket | `bool` | `false` | no |
+| <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | Whether to allow bucket deletion with objects in it | `bool` | `false` | no |
+| <a name="input_bucket_location"></a> [bucket\_location](#input\_bucket\_location) | Location for the companion bucket | `string` | `"US"` | no |
+| <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Custom bucket name. If null, auto-generated as '<project>-<env>-<app>-storage' | `string` | `null` | no |
+| <a name="input_cluster_location"></a> [cluster\_location](#input\_cluster\_location) | Location (region or zone) of the GKE cluster | `string` | n/a | yes |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster hosting the workload | `string` | n/a | yes |
+| <a name="input_create_bucket"></a> [create\_bucket](#input\_create\_bucket) | Whether to create a companion GCS bucket alongside the service account | `bool` | `false` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (e.g. sandbox, dev, prod) | `string` | n/a | yes |
+| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | Kubernetes namespace of the service account to bind | `string` | n/a | yes |
+| <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | Name of the Kubernetes service account to bind via Workload Identity | `string` | n/a | yes |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to created resources that support them | `map(string)` | `{}` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name for resource naming and labeling | `string` | n/a | yes |
+| <a name="input_project_roles"></a> [project\_roles](#input\_project\_roles) | List of project-level IAM roles to grant the Google service account (e.g. ['roles/logging.logWriter']) | `list(string)` | `[]` | no |
+| <a name="input_service_account_id"></a> [service\_account\_id](#input\_service\_account\_id) | Custom Google service account ID. If null, auto-generated as '<project>-<env>-<app>-sa' | `string` | `null` | no |
+| <a name="input_use_existing_k8s_sa"></a> [use\_existing\_k8s\_sa](#input\_use\_existing\_k8s\_sa) | Whether the Kubernetes service account already exists (skip creating it) | `bool` | `false` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | Name of the companion bucket, if created |
+| <a name="output_k8s_service_account_name"></a> [k8s\_service\_account\_name](#output\_k8s\_service\_account\_name) | Name of the bound Kubernetes service account |
+| <a name="output_k8s_service_account_namespace"></a> [k8s\_service\_account\_namespace](#output\_k8s\_service\_account\_namespace) | Namespace of the bound Kubernetes service account |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of the created Google service account |
+| <a name="output_service_account_name"></a> [service\_account\_name](#output\_service\_account\_name) | Fully qualified name of the Google service account |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/application-resources/gke-workload-identity/README.md
+++ b/terraform/gcp/modules/application-resources/gke-workload-identity/README.md
@@ -2,7 +2,7 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
@@ -13,7 +13,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_bucket"></a> [bucket](#module\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
 | <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | terraform-google-modules/kubernetes-engine/google//modules/workload-identity | 44.3.0 |
 
@@ -24,7 +24,7 @@ No resources.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_annotate_k8s_sa"></a> [annotate\_k8s\_sa](#input\_annotate\_k8s\_sa) | Whether to annotate the Kubernetes service account with the GCP service account email | `bool` | `true` | no |
 | <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Application name (e.g. hyperswitch, control-centre) | `string` | n/a | yes |
 | <a name="input_bucket_enable_versioning"></a> [bucket\_enable\_versioning](#input\_bucket\_enable\_versioning) | Enable versioning for the companion bucket | `bool` | `false` | no |
@@ -47,7 +47,7 @@ No resources.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | Name of the companion bucket, if created |
 | <a name="output_k8s_service_account_name"></a> [k8s\_service\_account\_name](#output\_k8s\_service\_account\_name) | Name of the bound Kubernetes service account |
 | <a name="output_k8s_service_account_namespace"></a> [k8s\_service\_account\_namespace](#output\_k8s\_service\_account\_namespace) | Namespace of the bound Kubernetes service account |

--- a/terraform/gcp/modules/application-resources/gke-workload-identity/locals.tf
+++ b/terraform/gcp/modules/application-resources/gke-workload-identity/locals.tf
@@ -1,0 +1,15 @@
+locals {
+  name_prefix = "${var.project_name}-${var.environment}-${var.app_name}"
+
+  common_labels = merge(
+    {
+      "project"     = var.project_name
+      "environment" = var.environment
+      "application" = var.app_name
+    },
+    var.labels
+  )
+
+  gcp_sa_name = var.service_account_id != null ? var.service_account_id : "${local.name_prefix}-sa"
+  bucket_name = var.bucket_name != null ? var.bucket_name : "${local.name_prefix}-storage"
+}

--- a/terraform/gcp/modules/application-resources/gke-workload-identity/main.tf
+++ b/terraform/gcp/modules/application-resources/gke-workload-identity/main.tf
@@ -1,0 +1,68 @@
+# ============================================================================
+# GKE Workload Identity (GCP equivalent of application-resources/eks-iam)
+# ============================================================================
+# The generic/legacy variant of the shared IRSA-equivalent contract every
+# application-resources module in this tree implements: create a Google
+# service account, bind it to a Kubernetes service account via Workload
+# Identity, grant it project-level roles and/or a custom role, and
+# optionally create a companion GCS bucket + bucket IAM.
+#
+# Usage:
+#   module "app_identity" {
+#     source = "../../modules/application-resources/gke-workload-identity"
+#
+#     project_id   = "hyperswitch-dev"
+#     environment  = "dev"
+#     project_name = "hyperswitch"
+#     app_name     = "my-app"
+#
+#     cluster_name = module.gke.cluster_name
+#     k8s_namespace = "my-app"
+#     k8s_service_account_name = "my-app"
+#
+#     project_roles = ["roles/logging.logWriter"]
+#   }
+# ============================================================================
+
+module "workload_identity" {
+  source  = "terraform-google-modules/kubernetes-engine/google//modules/workload-identity"
+  version = "44.3.0"
+
+  project_id = var.project_id
+  name       = local.gcp_sa_name
+
+  use_existing_k8s_sa = var.use_existing_k8s_sa
+  k8s_sa_name         = var.k8s_service_account_name
+  namespace           = var.k8s_namespace
+  cluster_name        = var.cluster_name
+  location            = var.cluster_location
+
+  roles = var.project_roles
+
+  annotate_k8s_sa = var.annotate_k8s_sa
+}
+
+# ==============================================================================
+# Optional companion GCS bucket (mirrors eks-iam's create_s3_bucket)
+# ==============================================================================
+module "bucket" {
+  source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
+  version = "12.3.0"
+
+  count = var.create_bucket ? 1 : 0
+
+  project_id    = var.project_id
+  name          = local.bucket_name
+  location      = var.bucket_location
+  force_destroy = var.bucket_force_destroy
+
+  versioning         = var.bucket_enable_versioning
+  bucket_policy_only = true
+
+  iam_members = [{
+    role   = "roles/storage.objectAdmin"
+    member = "serviceAccount:${module.workload_identity.gcp_service_account_email}"
+  }]
+
+  labels = local.common_labels
+}

--- a/terraform/gcp/modules/application-resources/gke-workload-identity/outputs.tf
+++ b/terraform/gcp/modules/application-resources/gke-workload-identity/outputs.tf
@@ -1,0 +1,24 @@
+output "service_account_email" {
+  description = "Email of the created Google service account"
+  value       = module.workload_identity.gcp_service_account_email
+}
+
+output "service_account_name" {
+  description = "Fully qualified name of the Google service account"
+  value       = module.workload_identity.gcp_service_account_name
+}
+
+output "k8s_service_account_name" {
+  description = "Name of the bound Kubernetes service account"
+  value       = module.workload_identity.k8s_service_account_name
+}
+
+output "k8s_service_account_namespace" {
+  description = "Namespace of the bound Kubernetes service account"
+  value       = module.workload_identity.k8s_service_account_namespace
+}
+
+output "bucket_name" {
+  description = "Name of the companion bucket, if created"
+  value       = var.create_bucket ? module.bucket[0].name : null
+}

--- a/terraform/gcp/modules/application-resources/gke-workload-identity/variables.tf
+++ b/terraform/gcp/modules/application-resources/gke-workload-identity/variables.tf
@@ -1,0 +1,103 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (e.g. sandbox, dev, prod)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for resource naming and labeling"
+  type        = string
+}
+
+variable "app_name" {
+  description = "Application name (e.g. hyperswitch, control-centre)"
+  type        = string
+}
+
+variable "service_account_id" {
+  description = "Custom Google service account ID. If null, auto-generated as '<project>-<env>-<app>-sa'"
+  type        = string
+  default     = null
+}
+
+variable "cluster_name" {
+  description = "Name of the GKE cluster hosting the workload"
+  type        = string
+}
+
+variable "cluster_location" {
+  description = "Location (region or zone) of the GKE cluster"
+  type        = string
+}
+
+variable "k8s_namespace" {
+  description = "Kubernetes namespace of the service account to bind"
+  type        = string
+}
+
+variable "k8s_service_account_name" {
+  description = "Name of the Kubernetes service account to bind via Workload Identity"
+  type        = string
+}
+
+variable "use_existing_k8s_sa" {
+  description = "Whether the Kubernetes service account already exists (skip creating it)"
+  type        = bool
+  default     = false
+}
+
+variable "annotate_k8s_sa" {
+  description = "Whether to annotate the Kubernetes service account with the GCP service account email"
+  type        = bool
+  default     = true
+}
+
+variable "project_roles" {
+  description = "List of project-level IAM roles to grant the Google service account (e.g. ['roles/logging.logWriter'])"
+  type        = list(string)
+  default     = []
+}
+
+variable "labels" {
+  description = "Labels to apply to created resources that support them"
+  type        = map(string)
+  default     = {}
+}
+
+# ==============================================================================
+# Optional companion GCS bucket
+# ==============================================================================
+
+variable "create_bucket" {
+  description = "Whether to create a companion GCS bucket alongside the service account"
+  type        = bool
+  default     = false
+}
+
+variable "bucket_name" {
+  description = "Custom bucket name. If null, auto-generated as '<project>-<env>-<app>-storage'"
+  type        = string
+  default     = null
+}
+
+variable "bucket_location" {
+  description = "Location for the companion bucket"
+  type        = string
+  default     = "US"
+}
+
+variable "bucket_force_destroy" {
+  description = "Whether to allow bucket deletion with objects in it"
+  type        = bool
+  default     = false
+}
+
+variable "bucket_enable_versioning" {
+  description = "Enable versioning for the companion bucket"
+  type        = bool
+  default     = false
+}

--- a/terraform/gcp/modules/application-resources/gke-workload-identity/versions.tf
+++ b/terraform/gcp/modules/application-resources/gke-workload-identity/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/application-resources/grafana/README.md
+++ b/terraform/gcp/modules/application-resources/grafana/README.md
@@ -2,7 +2,7 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
@@ -13,7 +13,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_database"></a> [database](#module\_database) | ../../composition/cloud-sql | n/a |
 | <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ../gke-workload-identity | n/a |
 
@@ -24,7 +24,7 @@ No resources.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_additional_project_roles"></a> [additional\_project\_roles](#input\_additional\_project\_roles) | Additional project-level IAM roles to grant Grafana's service account | `list(string)` | `[]` | no |
 | <a name="input_cluster_location"></a> [cluster\_location](#input\_cluster\_location) | Location (region or zone) of the GKE cluster | `string` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster hosting Grafana | `string` | n/a | yes |
@@ -42,7 +42,7 @@ No resources.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_database_instance_connection_name"></a> [database\_instance\_connection\_name](#output\_database\_instance\_connection\_name) | Cloud SQL Auth Proxy connection name for Grafana's database, if created |
 | <a name="output_database_name"></a> [database\_name](#output\_database\_name) | Name of the Grafana database, if created |
 | <a name="output_host_domains_map"></a> [host\_domains\_map](#output\_host\_domains\_map) | Passthrough of var.host\_domains |

--- a/terraform/gcp/modules/application-resources/grafana/README.md
+++ b/terraform/gcp/modules/application-resources/grafana/README.md
@@ -1,0 +1,51 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_database"></a> [database](#module\_database) | ../../composition/cloud-sql | n/a |
+| <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ../gke-workload-identity | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_additional_project_roles"></a> [additional\_project\_roles](#input\_additional\_project\_roles) | Additional project-level IAM roles to grant Grafana's service account | `list(string)` | `[]` | no |
+| <a name="input_cluster_location"></a> [cluster\_location](#input\_cluster\_location) | Location (region or zone) of the GKE cluster | `string` | n/a | yes |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster hosting Grafana | `string` | n/a | yes |
+| <a name="input_create_database"></a> [create\_database](#input\_create\_database) | Whether to create a dedicated Cloud SQL database for Grafana | `bool` | `true` | no |
+| <a name="input_database_config"></a> [database\_config](#input\_database\_config) | Configuration for Grafana's dedicated Cloud SQL database (composition/cloud-sql) | <pre>object({<br/>    network_id          = string<br/>    instance_name       = optional(string)<br/>    database_version    = optional(string)<br/>    tier                = optional(string)<br/>    availability_type   = optional(string)<br/>    disk_size           = optional(number)<br/>    deletion_protection = optional(bool)<br/>    database_name       = optional(string)<br/>    master_username     = optional(string)<br/>    master_password     = optional(string)<br/>    encryption_key_name = optional(string)<br/>  })</pre> | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_host_domains"></a> [host\_domains](#input\_host\_domains) | Map of logical name to hostname this Grafana instance is served on, passed through as an output for wiring into composition/istio or composition/load-balancer | `map(string)` | `{}` | no |
+| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | Kubernetes namespace Grafana runs in | `string` | `"monitoring"` | no |
+| <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | Kubernetes service account name used by Grafana | `string` | `"grafana"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name for resource naming and labeling | `string` | `"hyperswitch"` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region for the dedicated Cloud SQL database | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_database_instance_connection_name"></a> [database\_instance\_connection\_name](#output\_database\_instance\_connection\_name) | Cloud SQL Auth Proxy connection name for Grafana's database, if created |
+| <a name="output_database_name"></a> [database\_name](#output\_database\_name) | Name of the Grafana database, if created |
+| <a name="output_host_domains_map"></a> [host\_domains\_map](#output\_host\_domains\_map) | Passthrough of var.host\_domains |
+| <a name="output_k8s_service_account_name"></a> [k8s\_service\_account\_name](#output\_k8s\_service\_account\_name) | Bound Kubernetes service account name |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of Grafana's Google service account |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/application-resources/grafana/locals.tf
+++ b/terraform/gcp/modules/application-resources/grafana/locals.tf
@@ -1,0 +1,10 @@
+locals {
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "application" = "grafana"
+    },
+    var.labels
+  )
+}

--- a/terraform/gcp/modules/application-resources/grafana/main.tf
+++ b/terraform/gcp/modules/application-resources/grafana/main.tf
@@ -1,0 +1,74 @@
+# ============================================================================
+# Grafana (GCP equivalent of application-resources/grafana)
+# ============================================================================
+# GSA + Workload Identity binding, plus an optional dedicated Cloud SQL
+# database via composition/cloud-sql. Unlike the AWS module - which flattens
+# ~60 database_* variables directly - this module takes a single
+# database_config object (matching application-resources/superposition's
+# style rather than grafana's, resolving the interface inconsistency
+# between the two AWS callers of the shared database module).
+#
+# Usage:
+#   module "grafana" {
+#     source = "../../modules/application-resources/grafana"
+#
+#     project_id   = "hyperswitch-dev"
+#     environment  = "dev"
+#     project_name = "hyperswitch"
+#     region       = "europe-west1"
+#
+#     cluster_name     = module.gke.cluster_name
+#     cluster_location = module.gke.location
+#
+#     database_config = {
+#       network_id = module.vpc_network.network_id
+#     }
+#
+#     host_domains = { grafana = "grafana.dev.hyperswitch.example.com" }
+#   }
+# ============================================================================
+
+module "workload_identity" {
+  source = "../gke-workload-identity"
+
+  project_id   = var.project_id
+  environment  = var.environment
+  project_name = var.project_name
+  app_name     = "grafana"
+
+  cluster_name             = var.cluster_name
+  cluster_location         = var.cluster_location
+  k8s_namespace            = var.k8s_namespace
+  k8s_service_account_name = var.k8s_service_account_name
+
+  project_roles = var.additional_project_roles
+
+  labels = local.common_labels
+}
+
+module "database" {
+  source = "../../composition/cloud-sql"
+
+  count = var.create_database ? 1 : 0
+
+  project_id   = var.project_id
+  environment  = var.environment
+  project_name = "${var.project_name}-grafana"
+  region       = var.region
+  network_id   = var.database_config.network_id
+
+  instance_name       = var.database_config.instance_name
+  database_version    = coalesce(var.database_config.database_version, "POSTGRES_15")
+  tier                = coalesce(var.database_config.tier, "db-custom-2-8192")
+  availability_type   = coalesce(var.database_config.availability_type, "REGIONAL")
+  disk_size           = coalesce(var.database_config.disk_size, 50)
+  deletion_protection = coalesce(var.database_config.deletion_protection, true)
+
+  database_name   = coalesce(var.database_config.database_name, "grafana")
+  master_username = coalesce(var.database_config.master_username, "grafana_admin")
+  master_password = var.database_config.master_password
+
+  encryption_key_name = var.database_config.encryption_key_name
+
+  labels = local.common_labels
+}

--- a/terraform/gcp/modules/application-resources/grafana/outputs.tf
+++ b/terraform/gcp/modules/application-resources/grafana/outputs.tf
@@ -1,0 +1,24 @@
+output "service_account_email" {
+  description = "Email of Grafana's Google service account"
+  value       = module.workload_identity.service_account_email
+}
+
+output "k8s_service_account_name" {
+  description = "Bound Kubernetes service account name"
+  value       = module.workload_identity.k8s_service_account_name
+}
+
+output "database_instance_connection_name" {
+  description = "Cloud SQL Auth Proxy connection name for Grafana's database, if created"
+  value       = var.create_database ? module.database[0].instance_connection_name : null
+}
+
+output "database_name" {
+  description = "Name of the Grafana database, if created"
+  value       = var.create_database ? module.database[0].database_name : null
+}
+
+output "host_domains_map" {
+  description = "Passthrough of var.host_domains"
+  value       = var.host_domains
+}

--- a/terraform/gcp/modules/application-resources/grafana/variables.tf
+++ b/terraform/gcp/modules/application-resources/grafana/variables.tf
@@ -1,0 +1,83 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for resource naming and labeling"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "region" {
+  description = "Region for the dedicated Cloud SQL database"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "Name of the GKE cluster hosting Grafana"
+  type        = string
+}
+
+variable "cluster_location" {
+  description = "Location (region or zone) of the GKE cluster"
+  type        = string
+}
+
+variable "k8s_namespace" {
+  description = "Kubernetes namespace Grafana runs in"
+  type        = string
+  default     = "monitoring"
+}
+
+variable "k8s_service_account_name" {
+  description = "Kubernetes service account name used by Grafana"
+  type        = string
+  default     = "grafana"
+}
+
+variable "additional_project_roles" {
+  description = "Additional project-level IAM roles to grant Grafana's service account"
+  type        = list(string)
+  default     = []
+}
+
+variable "create_database" {
+  description = "Whether to create a dedicated Cloud SQL database for Grafana"
+  type        = bool
+  default     = true
+}
+
+variable "database_config" {
+  description = "Configuration for Grafana's dedicated Cloud SQL database (composition/cloud-sql)"
+  type = object({
+    network_id          = string
+    instance_name       = optional(string)
+    database_version    = optional(string)
+    tier                = optional(string)
+    availability_type   = optional(string)
+    disk_size           = optional(number)
+    deletion_protection = optional(bool)
+    database_name       = optional(string)
+    master_username     = optional(string)
+    master_password     = optional(string)
+    encryption_key_name = optional(string)
+  })
+}
+
+variable "host_domains" {
+  description = "Map of logical name to hostname this Grafana instance is served on, passed through as an output for wiring into composition/istio or composition/load-balancer"
+  type        = map(string)
+  default     = {}
+}
+
+variable "labels" {
+  description = "Additional labels to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/application-resources/grafana/versions.tf
+++ b/terraform/gcp/modules/application-resources/grafana/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/application-resources/hyperswitch/README.md
+++ b/terraform/gcp/modules/application-resources/hyperswitch/README.md
@@ -2,20 +2,20 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_dashboard_themes_bucket"></a> [dashboard\_themes\_bucket](#module\_dashboard\_themes\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
 | <a name="module_file_uploads_bucket"></a> [file\_uploads\_bucket](#module\_file\_uploads\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
 | <a name="module_kms"></a> [kms](#module\_kms) | terraform-google-modules/kms/google | 4.1.2 |
@@ -24,7 +24,7 @@
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google_cloudfunctions2_function_iam_member.invoker](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudfunctions2_function_iam_member) | resource |
 | [google_kms_crypto_key_iam_member.hyperswitch](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key_iam_member) | resource |
 | [google_project_iam_member.additional_custom_roles](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
@@ -37,7 +37,7 @@
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_additional_custom_role_ids"></a> [additional\_custom\_role\_ids](#input\_additional\_custom\_role\_ids) | List of project-level custom role IDs (e.g. from application-resources/shared-iam-roles) to grant the service account | `list(string)` | `[]` | no |
 | <a name="input_additional_project_roles"></a> [additional\_project\_roles](#input\_additional\_project\_roles) | Additional project-level IAM roles to grant Hyperswitch's service account | `list(string)` | `[]` | no |
 | <a name="input_cloud_functions"></a> [cloud\_functions](#input\_cloud\_functions) | Cloud Functions configuration. Set enabled=true and list function\_names to grant invoker access | <pre>object({<br/>    enabled        = optional(bool, false)<br/>    location       = optional(string)<br/>    function_names = optional(list(string), [])<br/>  })</pre> | `null` | no |
@@ -60,7 +60,7 @@
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_cross_project_assume_enabled"></a> [cross\_project\_assume\_enabled](#output\_cross\_project\_assume\_enabled) | Whether cross-project impersonation was granted |
 | <a name="output_dashboard_themes_bucket_enabled"></a> [dashboard\_themes\_bucket\_enabled](#output\_dashboard\_themes\_bucket\_enabled) | Whether the dashboard-themes feature is enabled |
 | <a name="output_dashboard_themes_bucket_name"></a> [dashboard\_themes\_bucket\_name](#output\_dashboard\_themes\_bucket\_name) | Name of the dashboard-themes bucket (created or existing), if enabled |

--- a/terraform/gcp/modules/application-resources/hyperswitch/README.md
+++ b/terraform/gcp/modules/application-resources/hyperswitch/README.md
@@ -1,0 +1,77 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_dashboard_themes_bucket"></a> [dashboard\_themes\_bucket](#module\_dashboard\_themes\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
+| <a name="module_file_uploads_bucket"></a> [file\_uploads\_bucket](#module\_file\_uploads\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
+| <a name="module_kms"></a> [kms](#module\_kms) | terraform-google-modules/kms/google | 4.1.2 |
+| <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ../gke-workload-identity | n/a |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_cloudfunctions2_function_iam_member.invoker](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudfunctions2_function_iam_member) | resource |
+| [google_kms_crypto_key_iam_member.hyperswitch](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key_iam_member) | resource |
+| [google_project_iam_member.additional_custom_roles](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_secret_manager_secret_iam_member.secrets](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
+| [google_secret_manager_secret_iam_member.smtp](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
+| [google_service_account_iam_member.cross_project_impersonation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
+| [google_storage_bucket_iam_member.existing_dashboard_themes](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
+| [google_storage_bucket_iam_member.existing_file_uploads](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_additional_custom_role_ids"></a> [additional\_custom\_role\_ids](#input\_additional\_custom\_role\_ids) | List of project-level custom role IDs (e.g. from application-resources/shared-iam-roles) to grant the service account | `list(string)` | `[]` | no |
+| <a name="input_additional_project_roles"></a> [additional\_project\_roles](#input\_additional\_project\_roles) | Additional project-level IAM roles to grant Hyperswitch's service account | `list(string)` | `[]` | no |
+| <a name="input_cloud_functions"></a> [cloud\_functions](#input\_cloud\_functions) | Cloud Functions configuration. Set enabled=true and list function\_names to grant invoker access | <pre>object({<br/>    enabled        = optional(bool, false)<br/>    location       = optional(string)<br/>    function_names = optional(list(string), [])<br/>  })</pre> | `null` | no |
+| <a name="input_cluster_location"></a> [cluster\_location](#input\_cluster\_location) | Location (region or zone) of the GKE cluster | `string` | n/a | yes |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster hosting Hyperswitch | `string` | n/a | yes |
+| <a name="input_cross_project_assume"></a> [cross\_project\_assume](#input\_cross\_project\_assume) | Cross-project impersonation configuration. Set enabled=true and list target\_service\_accounts to grant roles/iam.serviceAccountTokenCreator on them | <pre>object({<br/>    enabled                 = optional(bool, false)<br/>    target_service_accounts = optional(list(string), [])<br/>  })</pre> | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_gcs_dashboard_themes"></a> [gcs\_dashboard\_themes](#input\_gcs\_dashboard\_themes) | GCS bucket configuration for dashboard themes. Set create=true to create a new bucket, or create=false with bucket\_name set to an existing bucket to grant access to it | <pre>object({<br/>    create             = optional(bool, false)<br/>    bucket_name        = optional(string)<br/>    location           = optional(string, "US")<br/>    force_destroy      = optional(bool, false)<br/>    versioning_enabled = optional(bool, true)<br/>  })</pre> | `null` | no |
+| <a name="input_gcs_file_uploads"></a> [gcs\_file\_uploads](#input\_gcs\_file\_uploads) | GCS bucket configuration for file uploads. Set create=true to create a new bucket, or create=false with bucket\_name set to an existing bucket to grant access to it | <pre>object({<br/>    create             = optional(bool, false)<br/>    bucket_name        = optional(string)<br/>    location           = optional(string, "US")<br/>    force_destroy      = optional(bool, false)<br/>    versioning_enabled = optional(bool, true)<br/>  })</pre> | `null` | no |
+| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | Kubernetes namespace Hyperswitch runs in | `string` | `"hyperswitch"` | no |
+| <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | Kubernetes service account name used by Hyperswitch | `string` | `"hyperswitch"` | no |
+| <a name="input_kms"></a> [kms](#input\_kms) | KMS configuration. Set create=true to create a keyring/key and grant the service account encrypt/decrypt access | <pre>object({<br/>    create          = optional(bool, false)<br/>    location        = optional(string)<br/>    keyring_name    = optional(string)<br/>    key_name        = optional(string)<br/>    rotation_period = optional(string)<br/>  })</pre> | `null` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name for resource naming and labeling | `string` | `"hyperswitch"` | no |
+| <a name="input_public_domain"></a> [public\_domain](#input\_public\_domain) | Public domain name used to access Hyperswitch. Passed through as an output for wiring into DNS/certificate config | `string` | `null` | no |
+| <a name="input_secret_ids"></a> [secret\_ids](#input\_secret\_ids) | List of Secret Manager secret IDs to grant the service account access to | `list(string)` | `[]` | no |
+| <a name="input_smtp_secret_id"></a> [smtp\_secret\_id](#input\_smtp\_secret\_id) | Secret Manager secret ID holding SMTP credentials. Null disables granting access | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_cross_project_assume_enabled"></a> [cross\_project\_assume\_enabled](#output\_cross\_project\_assume\_enabled) | Whether cross-project impersonation was granted |
+| <a name="output_dashboard_themes_bucket_enabled"></a> [dashboard\_themes\_bucket\_enabled](#output\_dashboard\_themes\_bucket\_enabled) | Whether the dashboard-themes feature is enabled |
+| <a name="output_dashboard_themes_bucket_name"></a> [dashboard\_themes\_bucket\_name](#output\_dashboard\_themes\_bucket\_name) | Name of the dashboard-themes bucket (created or existing), if enabled |
+| <a name="output_file_uploads_bucket_enabled"></a> [file\_uploads\_bucket\_enabled](#output\_file\_uploads\_bucket\_enabled) | Whether the file-uploads feature is enabled |
+| <a name="output_file_uploads_bucket_name"></a> [file\_uploads\_bucket\_name](#output\_file\_uploads\_bucket\_name) | Name of the file-uploads bucket (created or existing), if enabled |
+| <a name="output_k8s_service_account_name"></a> [k8s\_service\_account\_name](#output\_k8s\_service\_account\_name) | Bound Kubernetes service account name |
+| <a name="output_kms_enabled"></a> [kms\_enabled](#output\_kms\_enabled) | Whether a KMS key was created for this application |
+| <a name="output_kms_key_name"></a> [kms\_key\_name](#output\_kms\_key\_name) | Self-link of the KMS key, if created |
+| <a name="output_lambda_enabled"></a> [lambda\_enabled](#output\_lambda\_enabled) | Whether Cloud Functions invoker access was granted |
+| <a name="output_public_domain"></a> [public\_domain](#output\_public\_domain) | Passthrough of var.public\_domain |
+| <a name="output_secrets_manager_enabled"></a> [secrets\_manager\_enabled](#output\_secrets\_manager\_enabled) | Whether Secrets Manager access was granted |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of Hyperswitch's Google service account |
+| <a name="output_smtp_enabled"></a> [smtp\_enabled](#output\_smtp\_enabled) | Whether SMTP secret access was granted |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/application-resources/hyperswitch/gcs.tf
+++ b/terraform/gcp/modules/application-resources/hyperswitch/gcs.tf
@@ -1,0 +1,63 @@
+# ============================================================================
+# GCS Buckets (dashboard themes, file uploads)
+# ============================================================================
+module "dashboard_themes_bucket" {
+  source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
+  version = "12.3.0"
+
+  count = local.gcs_dashboard_themes_enabled && var.gcs_dashboard_themes.create ? 1 : 0
+
+  project_id    = var.project_id
+  name          = local.dashboard_themes_bucket_name
+  location      = var.gcs_dashboard_themes.location
+  force_destroy = coalesce(var.gcs_dashboard_themes.force_destroy, false)
+  versioning    = coalesce(var.gcs_dashboard_themes.versioning_enabled, true)
+
+  bucket_policy_only = true
+
+  iam_members = [{
+    role   = "roles/storage.objectViewer"
+    member = "serviceAccount:${module.workload_identity.service_account_email}"
+  }]
+
+  labels = local.common_labels
+}
+
+module "file_uploads_bucket" {
+  source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
+  version = "12.3.0"
+
+  count = local.gcs_file_uploads_enabled && var.gcs_file_uploads.create ? 1 : 0
+
+  project_id    = var.project_id
+  name          = local.file_uploads_bucket_name
+  location      = var.gcs_file_uploads.location
+  force_destroy = coalesce(var.gcs_file_uploads.force_destroy, false)
+  versioning    = coalesce(var.gcs_file_uploads.versioning_enabled, true)
+
+  bucket_policy_only = true
+
+  iam_members = [{
+    role   = "roles/storage.objectAdmin"
+    member = "serviceAccount:${module.workload_identity.service_account_email}"
+  }]
+
+  labels = local.common_labels
+}
+
+# Grant access to an existing bucket when create = false
+resource "google_storage_bucket_iam_member" "existing_dashboard_themes" {
+  count = local.gcs_dashboard_themes_enabled && !var.gcs_dashboard_themes.create ? 1 : 0
+
+  bucket = var.gcs_dashboard_themes.bucket_name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${module.workload_identity.service_account_email}"
+}
+
+resource "google_storage_bucket_iam_member" "existing_file_uploads" {
+  count = local.gcs_file_uploads_enabled && !var.gcs_file_uploads.create ? 1 : 0
+
+  bucket = var.gcs_file_uploads.bucket_name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${module.workload_identity.service_account_email}"
+}

--- a/terraform/gcp/modules/application-resources/hyperswitch/kms.tf
+++ b/terraform/gcp/modules/application-resources/hyperswitch/kms.tf
@@ -1,0 +1,27 @@
+# ============================================================================
+# KMS (CMEK for Hyperswitch application-level encryption)
+# ============================================================================
+module "kms" {
+  source  = "terraform-google-modules/kms/google"
+  version = "4.1.2"
+
+  count = local.kms_enabled ? 1 : 0
+
+  project_id = var.project_id
+  location   = coalesce(var.kms.location, "global")
+  keyring    = coalesce(var.kms.keyring_name, "${local.name_prefix}-keyring")
+  keys       = [coalesce(var.kms.key_name, "hyperswitch")]
+
+  key_protection_level = "SOFTWARE"
+  key_rotation_period  = coalesce(var.kms.rotation_period, "7776000s") # 90 days
+
+  labels = local.common_labels
+}
+
+resource "google_kms_crypto_key_iam_member" "hyperswitch" {
+  count = local.kms_enabled ? 1 : 0
+
+  crypto_key_id = module.kms[0].keys[coalesce(var.kms.key_name, "hyperswitch")]
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:${module.workload_identity.service_account_email}"
+}

--- a/terraform/gcp/modules/application-resources/hyperswitch/locals.tf
+++ b/terraform/gcp/modules/application-resources/hyperswitch/locals.tf
@@ -1,0 +1,23 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}-hyperswitch"
+
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "application" = "hyperswitch"
+    },
+    var.labels
+  )
+
+  kms_enabled                  = var.kms != null && var.kms.create
+  gcs_dashboard_themes_enabled = var.gcs_dashboard_themes != null && (var.gcs_dashboard_themes.create || var.gcs_dashboard_themes.bucket_name != null)
+  gcs_file_uploads_enabled     = var.gcs_file_uploads != null && (var.gcs_file_uploads.create || var.gcs_file_uploads.bucket_name != null)
+  smtp_enabled                 = var.smtp_secret_id != null
+  secrets_manager_enabled      = length(var.secret_ids) > 0
+  lambda_enabled               = var.cloud_functions != null && var.cloud_functions.enabled
+  cross_project_enabled        = var.cross_project_assume != null && var.cross_project_assume.enabled
+
+  dashboard_themes_bucket_name = local.gcs_dashboard_themes_enabled ? coalesce(var.gcs_dashboard_themes.bucket_name, "${local.name_prefix}-dashboard-themes") : null
+  file_uploads_bucket_name     = local.gcs_file_uploads_enabled ? coalesce(var.gcs_file_uploads.bucket_name, "${local.name_prefix}-file-uploads") : null
+}

--- a/terraform/gcp/modules/application-resources/hyperswitch/main.tf
+++ b/terraform/gcp/modules/application-resources/hyperswitch/main.tf
@@ -1,0 +1,107 @@
+# ============================================================================
+# Hyperswitch (GCP equivalent of application-resources/hyperswitch)
+# ============================================================================
+# The largest application-resources module: GSA + Workload Identity binding,
+# plus a set of optional feature toggles mirroring the AWS module's object-
+# shaped inputs and matching <feature>_enabled/<feature>_*_arn output pairs.
+#
+# Feature mapping vs. the AWS module:
+#   kms                 -> kms.tf (Cloud KMS keyring/key)
+#   s3_dashboard_themes -> gcs.tf (GCS bucket)
+#   s3_file_uploads     -> gcs.tf (GCS bucket)
+#   ses                 -> smtp_secret_id (Secret Manager; GCP has no SES analog)
+#   secrets_manager     -> secret_ids (Secret Manager secret access)
+#   lambda              -> cloud_functions (Cloud Functions invoker access)
+#   assume_role         -> cross_project_assume (service account impersonation)
+#   additional_iam_policies -> additional_project_roles / additional_custom_roles
+#
+# Usage:
+#   module "hyperswitch" {
+#     source = "../../modules/application-resources/hyperswitch"
+#
+#     project_id   = "hyperswitch-dev"
+#     environment  = "dev"
+#     project_name = "hyperswitch"
+#
+#     cluster_name     = module.gke.cluster_name
+#     cluster_location = module.gke.location
+#
+#     kms                  = { create = true }
+#     gcs_dashboard_themes = { create = true }
+#     gcs_file_uploads     = { create = true }
+#   }
+# ============================================================================
+
+module "workload_identity" {
+  source = "../gke-workload-identity"
+
+  project_id   = var.project_id
+  environment  = var.environment
+  project_name = var.project_name
+  app_name     = "hyperswitch"
+
+  cluster_name             = var.cluster_name
+  cluster_location         = var.cluster_location
+  k8s_namespace            = var.k8s_namespace
+  k8s_service_account_name = var.k8s_service_account_name
+
+  project_roles = var.additional_project_roles
+
+  labels = local.common_labels
+}
+
+# ==============================================================================
+# Secrets Manager access (replaces AWS module's secrets_manager feature)
+# ==============================================================================
+resource "google_secret_manager_secret_iam_member" "secrets" {
+  for_each = local.secrets_manager_enabled ? toset(var.secret_ids) : []
+
+  project   = var.project_id
+  secret_id = each.value
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${module.workload_identity.service_account_email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "smtp" {
+  count = local.smtp_enabled ? 1 : 0
+
+  project   = var.project_id
+  secret_id = var.smtp_secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${module.workload_identity.service_account_email}"
+}
+
+# ==============================================================================
+# Cloud Functions invoker access (replaces AWS module's lambda feature)
+# ==============================================================================
+resource "google_cloudfunctions2_function_iam_member" "invoker" {
+  for_each = local.lambda_enabled ? toset(var.cloud_functions.function_names) : []
+
+  project        = var.project_id
+  location       = var.cloud_functions.location
+  cloud_function = each.value
+  role           = "roles/cloudfunctions.invoker"
+  member         = "serviceAccount:${module.workload_identity.service_account_email}"
+}
+
+# ==============================================================================
+# Cross-project impersonation (replaces AWS module's assume_role feature)
+# ==============================================================================
+resource "google_service_account_iam_member" "cross_project_impersonation" {
+  for_each = local.cross_project_enabled ? toset(var.cross_project_assume.target_service_accounts) : []
+
+  service_account_id = each.value
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${module.workload_identity.service_account_email}"
+}
+
+# ==============================================================================
+# Additional custom IAM roles (replaces AWS module's additional_iam_policies)
+# ==============================================================================
+resource "google_project_iam_member" "additional_custom_roles" {
+  for_each = toset(var.additional_custom_role_ids)
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${module.workload_identity.service_account_email}"
+}

--- a/terraform/gcp/modules/application-resources/hyperswitch/outputs.tf
+++ b/terraform/gcp/modules/application-resources/hyperswitch/outputs.tf
@@ -1,0 +1,80 @@
+# ============================================================================
+# Service Account Outputs
+# ============================================================================
+
+output "service_account_email" {
+  description = "Email of Hyperswitch's Google service account"
+  value       = module.workload_identity.service_account_email
+}
+
+output "k8s_service_account_name" {
+  description = "Bound Kubernetes service account name"
+  value       = module.workload_identity.k8s_service_account_name
+}
+
+output "public_domain" {
+  description = "Passthrough of var.public_domain"
+  value       = var.public_domain
+}
+
+# ============================================================================
+# KMS Outputs
+# ============================================================================
+
+output "kms_enabled" {
+  description = "Whether a KMS key was created for this application"
+  value       = local.kms_enabled
+}
+
+output "kms_key_name" {
+  description = "Self-link of the KMS key, if created"
+  value       = local.kms_enabled ? module.kms[0].keys[coalesce(var.kms.key_name, "hyperswitch")] : null
+}
+
+# ============================================================================
+# GCS Bucket Outputs
+# ============================================================================
+
+output "dashboard_themes_bucket_enabled" {
+  description = "Whether the dashboard-themes feature is enabled"
+  value       = local.gcs_dashboard_themes_enabled
+}
+
+output "dashboard_themes_bucket_name" {
+  description = "Name of the dashboard-themes bucket (created or existing), if enabled"
+  value       = local.gcs_dashboard_themes_enabled ? (var.gcs_dashboard_themes.create ? module.dashboard_themes_bucket[0].name : var.gcs_dashboard_themes.bucket_name) : null
+}
+
+output "file_uploads_bucket_enabled" {
+  description = "Whether the file-uploads feature is enabled"
+  value       = local.gcs_file_uploads_enabled
+}
+
+output "file_uploads_bucket_name" {
+  description = "Name of the file-uploads bucket (created or existing), if enabled"
+  value       = local.gcs_file_uploads_enabled ? (var.gcs_file_uploads.create ? module.file_uploads_bucket[0].name : var.gcs_file_uploads.bucket_name) : null
+}
+
+# ============================================================================
+# Other Feature Outputs
+# ============================================================================
+
+output "smtp_enabled" {
+  description = "Whether SMTP secret access was granted"
+  value       = local.smtp_enabled
+}
+
+output "secrets_manager_enabled" {
+  description = "Whether Secrets Manager access was granted"
+  value       = local.secrets_manager_enabled
+}
+
+output "lambda_enabled" {
+  description = "Whether Cloud Functions invoker access was granted"
+  value       = local.lambda_enabled
+}
+
+output "cross_project_assume_enabled" {
+  description = "Whether cross-project impersonation was granted"
+  value       = local.cross_project_enabled
+}

--- a/terraform/gcp/modules/application-resources/hyperswitch/variables.tf
+++ b/terraform/gcp/modules/application-resources/hyperswitch/variables.tf
@@ -1,0 +1,157 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for resource naming and labeling"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "public_domain" {
+  description = "Public domain name used to access Hyperswitch. Passed through as an output for wiring into DNS/certificate config"
+  type        = string
+  default     = null
+}
+
+variable "cluster_name" {
+  description = "Name of the GKE cluster hosting Hyperswitch"
+  type        = string
+}
+
+variable "cluster_location" {
+  description = "Location (region or zone) of the GKE cluster"
+  type        = string
+}
+
+variable "k8s_namespace" {
+  description = "Kubernetes namespace Hyperswitch runs in"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "k8s_service_account_name" {
+  description = "Kubernetes service account name used by Hyperswitch"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "additional_project_roles" {
+  description = "Additional project-level IAM roles to grant Hyperswitch's service account"
+  type        = list(string)
+  default     = []
+}
+
+# ============================================================================
+# Feature: KMS Key
+# ============================================================================
+
+variable "kms" {
+  description = "KMS configuration. Set create=true to create a keyring/key and grant the service account encrypt/decrypt access"
+  type = object({
+    create          = optional(bool, false)
+    location        = optional(string)
+    keyring_name    = optional(string)
+    key_name        = optional(string)
+    rotation_period = optional(string)
+  })
+  default = null
+}
+
+# ============================================================================
+# Feature: GCS Buckets
+# ============================================================================
+
+variable "gcs_dashboard_themes" {
+  description = "GCS bucket configuration for dashboard themes. Set create=true to create a new bucket, or create=false with bucket_name set to an existing bucket to grant access to it"
+  type = object({
+    create             = optional(bool, false)
+    bucket_name        = optional(string)
+    location           = optional(string, "US")
+    force_destroy      = optional(bool, false)
+    versioning_enabled = optional(bool, true)
+  })
+  default = null
+}
+
+variable "gcs_file_uploads" {
+  description = "GCS bucket configuration for file uploads. Set create=true to create a new bucket, or create=false with bucket_name set to an existing bucket to grant access to it"
+  type = object({
+    create             = optional(bool, false)
+    bucket_name        = optional(string)
+    location           = optional(string, "US")
+    force_destroy      = optional(bool, false)
+    versioning_enabled = optional(bool, true)
+  })
+  default = null
+}
+
+# ============================================================================
+# Feature: SMTP credentials (replaces AWS SES; GCP has no first-party
+# transactional email service)
+# ============================================================================
+
+variable "smtp_secret_id" {
+  description = "Secret Manager secret ID holding SMTP credentials. Null disables granting access"
+  type        = string
+  default     = null
+}
+
+# ============================================================================
+# Feature: Secrets Manager
+# ============================================================================
+
+variable "secret_ids" {
+  description = "List of Secret Manager secret IDs to grant the service account access to"
+  type        = list(string)
+  default     = []
+}
+
+# ============================================================================
+# Feature: Cloud Functions (replaces AWS Lambda)
+# ============================================================================
+
+variable "cloud_functions" {
+  description = "Cloud Functions configuration. Set enabled=true and list function_names to grant invoker access"
+  type = object({
+    enabled        = optional(bool, false)
+    location       = optional(string)
+    function_names = optional(list(string), [])
+  })
+  default = null
+}
+
+# ============================================================================
+# Feature: Cross-Project Impersonation (replaces AWS cross-account assume role)
+# ============================================================================
+
+variable "cross_project_assume" {
+  description = "Cross-project impersonation configuration. Set enabled=true and list target_service_accounts to grant roles/iam.serviceAccountTokenCreator on them"
+  type = object({
+    enabled                 = optional(bool, false)
+    target_service_accounts = optional(list(string), [])
+  })
+  default = null
+}
+
+# ============================================================================
+# Feature: Additional Custom Roles (replaces AWS additional_iam_policies)
+# ============================================================================
+
+variable "additional_custom_role_ids" {
+  description = "List of project-level custom role IDs (e.g. from application-resources/shared-iam-roles) to grant the service account"
+  type        = list(string)
+  default     = []
+}
+
+variable "labels" {
+  description = "Additional labels to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/application-resources/hyperswitch/versions.tf
+++ b/terraform/gcp/modules/application-resources/hyperswitch/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/application-resources/istio/README.md
+++ b/terraform/gcp/modules/application-resources/istio/README.md
@@ -1,0 +1,64 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 3.1 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 3.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 3.1 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_firewall_rules"></a> [firewall\_rules](#module\_firewall\_rules) | ../../composition/firewall-rules | n/a |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_compute_address.gateway](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
+| [helm_release.istio_base](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.istio_gateway](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.istiod](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [google_client_config.current](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_cluster_ca_certificate"></a> [cluster\_ca\_certificate](#input\_cluster\_ca\_certificate) | Base64 encoded certificate data required to communicate with the cluster | `string` | n/a | yes |
+| <a name="input_cluster_endpoint"></a> [cluster\_endpoint](#input\_cluster\_endpoint) | Endpoint (host, without scheme) for the Kubernetes API server | `string` | n/a | yes |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster | `string` | n/a | yes |
+| <a name="input_create_firewall_rules"></a> [create\_firewall\_rules](#input\_create\_firewall\_rules) | Whether to create the firewall rule allowing ingress traffic to the gateway | `bool` | `true` | no |
+| <a name="input_create_gateway_static_ip"></a> [create\_gateway\_static\_ip](#input\_create\_gateway\_static\_ip) | Whether to reserve a static regional IP for the gateway's LoadBalancer service | `bool` | `true` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_gateway_service_annotations"></a> [gateway\_service\_annotations](#input\_gateway\_service\_annotations) | Additional annotations applied to the gateway's LoadBalancer service | `map(string)` | `{}` | no |
+| <a name="input_host_domains"></a> [host\_domains](#input\_host\_domains) | Map of logical name to hostname(s) served through this gateway, passed through as an output for wiring into DNS/routing config | `map(list(string))` | `{}` | no |
+| <a name="input_istio_base"></a> [istio\_base](#input\_istio\_base) | Configuration for the Istio base chart | <pre>object({<br/>    enabled       = bool<br/>    release_name  = optional(string)<br/>    chart_repo    = optional(string)<br/>    chart_version = optional(string)<br/>    values        = optional(list(string), [])<br/>    values_file   = optional(string, "")<br/>  })</pre> | <pre>{<br/>  "enabled": true<br/>}</pre> | no |
+| <a name="input_istio_gateway"></a> [istio\_gateway](#input\_istio\_gateway) | Configuration for the Istio gateway chart | <pre>object({<br/>    enabled       = bool<br/>    release_name  = optional(string)<br/>    chart_repo    = optional(string)<br/>    chart_version = optional(string)<br/>    values        = optional(list(string), [])<br/>    values_file   = optional(string, "")<br/>  })</pre> | <pre>{<br/>  "enabled": true<br/>}</pre> | no |
+| <a name="input_istio_namespace"></a> [istio\_namespace](#input\_istio\_namespace) | Namespace to install Istio components into | `string` | `"istio-system"` | no |
+| <a name="input_istiod"></a> [istiod](#input\_istiod) | Configuration for the istiod chart | <pre>object({<br/>    enabled       = bool<br/>    release_name  = optional(string)<br/>    chart_repo    = optional(string)<br/>    chart_version = optional(string)<br/>    values        = optional(list(string), [])<br/>    values_file   = optional(string, "")<br/>  })</pre> | <pre>{<br/>  "enabled": true<br/>}</pre> | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to created resources that support them | `map(string)` | `{}` | no |
+| <a name="input_network"></a> [network](#input\_network) | Self-link of the VPC network | `string` | n/a | yes |
+| <a name="input_network_name"></a> [network\_name](#input\_network\_name) | Name of the VPC network, required when create\_firewall\_rules = true | `string` | `null` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name for resource naming and labeling | `string` | `"hyperswitch"` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region for the gateway's static IP | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | Name of the GKE cluster Istio is installed on |
+| <a name="output_gateway_static_ip"></a> [gateway\_static\_ip](#output\_gateway\_static\_ip) | Static IP address reserved for the Istio gateway, if enabled |
+| <a name="output_host_domains_map"></a> [host\_domains\_map](#output\_host\_domains\_map) | Passthrough of var.host\_domains |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/application-resources/istio/README.md
+++ b/terraform/gcp/modules/application-resources/istio/README.md
@@ -2,7 +2,7 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 3.1 |
@@ -11,20 +11,20 @@
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 3.1 |
 
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_firewall_rules"></a> [firewall\_rules](#module\_firewall\_rules) | ../../composition/firewall-rules | n/a |
 
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google_compute_address.gateway](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
 | [helm_release.istio_base](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.istio_gateway](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
@@ -34,7 +34,7 @@
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_cluster_ca_certificate"></a> [cluster\_ca\_certificate](#input\_cluster\_ca\_certificate) | Base64 encoded certificate data required to communicate with the cluster | `string` | n/a | yes |
 | <a name="input_cluster_endpoint"></a> [cluster\_endpoint](#input\_cluster\_endpoint) | Endpoint (host, without scheme) for the Kubernetes API server | `string` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster | `string` | n/a | yes |
@@ -57,7 +57,7 @@
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | Name of the GKE cluster Istio is installed on |
 | <a name="output_gateway_static_ip"></a> [gateway\_static\_ip](#output\_gateway\_static\_ip) | Static IP address reserved for the Istio gateway, if enabled |
 | <a name="output_host_domains_map"></a> [host\_domains\_map](#output\_host\_domains\_map) | Passthrough of var.host\_domains |

--- a/terraform/gcp/modules/application-resources/istio/data.tf
+++ b/terraform/gcp/modules/application-resources/istio/data.tf
@@ -1,0 +1,1 @@
+data "google_client_config" "current" {}

--- a/terraform/gcp/modules/application-resources/istio/locals.tf
+++ b/terraform/gcp/modules/application-resources/istio/locals.tf
@@ -1,0 +1,25 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}-istio"
+
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "application" = "istio"
+    },
+    var.labels
+  )
+
+  istio_base = merge(
+    { release_name = "istio-base", chart_repo = "https://istio-release.storage.googleapis.com/charts", chart_version = null, values = [], values_file = "" },
+    var.istio_base
+  )
+  istiod = merge(
+    { release_name = "istiod", chart_repo = "https://istio-release.storage.googleapis.com/charts", chart_version = null, values = [], values_file = "" },
+    var.istiod
+  )
+  istio_gateway = merge(
+    { release_name = "istio-gateway", chart_repo = "https://istio-release.storage.googleapis.com/charts", chart_version = null, values = [], values_file = "" },
+    var.istio_gateway
+  )
+}

--- a/terraform/gcp/modules/application-resources/istio/main.tf
+++ b/terraform/gcp/modules/application-resources/istio/main.tf
@@ -1,0 +1,157 @@
+# ============================================================================
+# Istio (GCP equivalent of application-resources/istio)
+# ============================================================================
+# Same istio-release Helm charts (base/istiod/gateway) as the AWS module,
+# installed via the kubernetes/helm providers authenticated against GKE
+# instead of EKS. The istio-gateway Service is exposed as a GCP-native L4
+# LoadBalancer with a reserved static IP, rather than the AWS module's
+# ALB Ingress: GKE's Gateway API resources (the closer analogue to an ALB
+# Ingress) are Kubernetes custom resources with no first-class
+# hashicorp/kubernetes provider type, so wiring a Gateway/HTTPRoute is left
+# to your GitOps/kubectl flow - out of scope for this Terraform module, same
+# boundary the rest of this tree draws between infrastructure and
+# Kubernetes-native config.
+#
+# Usage:
+#   module "istio" {
+#     source = "../../modules/application-resources/istio"
+#
+#     project_id   = "hyperswitch-dev"
+#     environment  = "dev"
+#     project_name = "hyperswitch"
+#     region       = "europe-west1"
+#
+#     cluster_name     = module.gke.cluster_name
+#     cluster_endpoint = module.gke.endpoint
+#     cluster_ca_certificate = module.gke.ca_certificate
+#
+#     network      = module.vpc_network.network_self_link
+#     network_name = module.vpc_network.network_name
+#   }
+# ============================================================================
+
+provider "kubernetes" {
+  host                   = "https://${var.cluster_endpoint}"
+  cluster_ca_certificate = base64decode(var.cluster_ca_certificate)
+  token                  = data.google_client_config.current.access_token
+}
+
+provider "helm" {
+  kubernetes = {
+    host                   = "https://${var.cluster_endpoint}"
+    cluster_ca_certificate = base64decode(var.cluster_ca_certificate)
+    token                  = data.google_client_config.current.access_token
+  }
+}
+
+# ==============================================================================
+# Static IP for the Istio ingress gateway LoadBalancer
+# ==============================================================================
+resource "google_compute_address" "gateway" {
+  count = var.create_gateway_static_ip ? 1 : 0
+
+  project = var.project_id
+  name    = "${local.name_prefix}-gateway-ip"
+  region  = var.region
+}
+
+# ==============================================================================
+# Helm Releases
+# ==============================================================================
+resource "helm_release" "istio_base" {
+  count = local.istio_base.enabled ? 1 : 0
+
+  name             = local.istio_base.release_name
+  repository       = local.istio_base.chart_repo
+  chart            = "base"
+  namespace        = var.istio_namespace
+  version          = local.istio_base.chart_version
+  create_namespace = true
+  wait             = true
+  force_update     = true
+
+  values = concat(
+    [yamlencode({ defaultRevision = "default", base = { enableCRDTemplates = true } })],
+    local.istio_base.values_file != "" ? [file(local.istio_base.values_file)] : [],
+    local.istio_base.values
+  )
+}
+
+resource "helm_release" "istiod" {
+  count = local.istiod.enabled ? 1 : 0
+
+  name       = local.istiod.release_name
+  repository = local.istiod.chart_repo
+  chart      = "istiod"
+  namespace  = var.istio_namespace
+  version    = local.istiod.chart_version
+  wait       = true
+
+  values = concat(
+    local.istiod.values_file != "" ? [file(local.istiod.values_file)] : [],
+    local.istiod.values
+  )
+
+  depends_on = [helm_release.istio_base]
+}
+
+resource "helm_release" "istio_gateway" {
+  count = local.istio_gateway.enabled ? 1 : 0
+
+  name       = local.istio_gateway.release_name
+  repository = local.istio_gateway.chart_repo
+  chart      = "gateway"
+  namespace  = var.istio_namespace
+  version    = local.istio_gateway.chart_version
+  wait       = true
+
+  values = concat(
+    [
+      yamlencode({
+        service = {
+          type = "LoadBalancer"
+          annotations = merge(
+            var.create_gateway_static_ip ? {
+              "networking.gke.io/load-balancer-type" = "External"
+            } : {},
+            var.gateway_service_annotations
+          )
+          loadBalancerIP = var.create_gateway_static_ip ? google_compute_address.gateway[0].address : null
+        }
+      })
+    ],
+    local.istio_gateway.values_file != "" ? [file(local.istio_gateway.values_file)] : [],
+    local.istio_gateway.values
+  )
+
+  depends_on = [helm_release.istiod]
+}
+
+# ==============================================================================
+# Firewall rule allowing health checks / ingress traffic to the gateway
+# ==============================================================================
+module "firewall_rules" {
+  source = "../../composition/firewall-rules"
+
+  count = var.create_firewall_rules ? 1 : 0
+
+  project_id   = var.project_id
+  environment  = var.environment
+  project_name = var.project_name
+  network_name = var.network_name
+
+  rules = {
+    istio-gateway-ingress = {
+      rules = [
+        {
+          name        = "allow-istio-gateway-http"
+          description = "Allow HTTP/HTTPS ingress to the Istio gateway"
+          direction   = "INGRESS"
+          target_tags = ["gke-node"]
+          ranges      = ["0.0.0.0/0"]
+          allow       = [{ protocol = "tcp", ports = ["80", "443", "15021"] }]
+        },
+      ]
+    }
+  }
+}

--- a/terraform/gcp/modules/application-resources/istio/outputs.tf
+++ b/terraform/gcp/modules/application-resources/istio/outputs.tf
@@ -1,0 +1,14 @@
+output "cluster_name" {
+  description = "Name of the GKE cluster Istio is installed on"
+  value       = var.cluster_name
+}
+
+output "gateway_static_ip" {
+  description = "Static IP address reserved for the Istio gateway, if enabled"
+  value       = var.create_gateway_static_ip ? google_compute_address.gateway[0].address : null
+}
+
+output "host_domains_map" {
+  description = "Passthrough of var.host_domains"
+  value       = var.host_domains
+}

--- a/terraform/gcp/modules/application-resources/istio/variables.tf
+++ b/terraform/gcp/modules/application-resources/istio/variables.tf
@@ -1,0 +1,122 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for resource naming and labeling"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "region" {
+  description = "Region for the gateway's static IP"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "Name of the GKE cluster"
+  type        = string
+}
+
+variable "cluster_endpoint" {
+  description = "Endpoint (host, without scheme) for the Kubernetes API server"
+  type        = string
+}
+
+variable "cluster_ca_certificate" {
+  description = "Base64 encoded certificate data required to communicate with the cluster"
+  type        = string
+  sensitive   = true
+}
+
+variable "network" {
+  description = "Self-link of the VPC network"
+  type        = string
+}
+
+variable "network_name" {
+  description = "Name of the VPC network, required when create_firewall_rules = true"
+  type        = string
+  default     = null
+}
+
+variable "istio_namespace" {
+  description = "Namespace to install Istio components into"
+  type        = string
+  default     = "istio-system"
+}
+
+variable "istio_base" {
+  description = "Configuration for the Istio base chart"
+  type = object({
+    enabled       = bool
+    release_name  = optional(string)
+    chart_repo    = optional(string)
+    chart_version = optional(string)
+    values        = optional(list(string), [])
+    values_file   = optional(string, "")
+  })
+  default = { enabled = true }
+}
+
+variable "istiod" {
+  description = "Configuration for the istiod chart"
+  type = object({
+    enabled       = bool
+    release_name  = optional(string)
+    chart_repo    = optional(string)
+    chart_version = optional(string)
+    values        = optional(list(string), [])
+    values_file   = optional(string, "")
+  })
+  default = { enabled = true }
+}
+
+variable "istio_gateway" {
+  description = "Configuration for the Istio gateway chart"
+  type = object({
+    enabled       = bool
+    release_name  = optional(string)
+    chart_repo    = optional(string)
+    chart_version = optional(string)
+    values        = optional(list(string), [])
+    values_file   = optional(string, "")
+  })
+  default = { enabled = true }
+}
+
+variable "create_gateway_static_ip" {
+  description = "Whether to reserve a static regional IP for the gateway's LoadBalancer service"
+  type        = bool
+  default     = true
+}
+
+variable "gateway_service_annotations" {
+  description = "Additional annotations applied to the gateway's LoadBalancer service"
+  type        = map(string)
+  default     = {}
+}
+
+variable "create_firewall_rules" {
+  description = "Whether to create the firewall rule allowing ingress traffic to the gateway"
+  type        = bool
+  default     = true
+}
+
+variable "host_domains" {
+  description = "Map of logical name to hostname(s) served through this gateway, passed through as an output for wiring into DNS/routing config"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "labels" {
+  description = "Additional labels to apply to created resources that support them"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/application-resources/istio/versions.tf
+++ b/terraform/gcp/modules/application-resources/istio/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 3.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.1"
+    }
+  }
+}

--- a/terraform/gcp/modules/application-resources/loki/README.md
+++ b/terraform/gcp/modules/application-resources/loki/README.md
@@ -1,0 +1,58 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_chunks_bucket"></a> [chunks\_bucket](#module\_chunks\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
+| <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ../gke-workload-identity | n/a |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_pubsub_topic.bucket_notifications](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
+| [google_pubsub_topic_iam_member.gcs_publisher](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic_iam_member) | resource |
+| [google_storage_notification.chunks](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_notification) | resource |
+| [google_storage_project_service_account.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/storage_project_service_account) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_additional_project_roles"></a> [additional\_project\_roles](#input\_additional\_project\_roles) | Additional project-level IAM roles to grant Loki's service account | `list(string)` | `[]` | no |
+| <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | Whether to allow bucket deletion with objects in it | `bool` | `false` | no |
+| <a name="input_bucket_lifecycle_rules"></a> [bucket\_lifecycle\_rules](#input\_bucket\_lifecycle\_rules) | Lifecycle rules for the chunks bucket, in the shape expected by simple\_bucket | `any` | `[]` | no |
+| <a name="input_bucket_location"></a> [bucket\_location](#input\_bucket\_location) | Location for the chunks bucket | `string` | `"US"` | no |
+| <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Custom chunks bucket name. If null, auto-generated as '<env>-<project>-loki-chunks' | `string` | `null` | no |
+| <a name="input_cluster_location"></a> [cluster\_location](#input\_cluster\_location) | Location (region or zone) of the GKE cluster | `string` | n/a | yes |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster hosting Loki | `string` | n/a | yes |
+| <a name="input_enable_bucket_notifications"></a> [enable\_bucket\_notifications](#input\_enable\_bucket\_notifications) | Whether to create a Pub/Sub topic + notification for chunk bucket object-create events | `bool` | `true` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | Kubernetes namespace Loki runs in | `string` | `"observability"` | no |
+| <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | Kubernetes service account name used by Loki | `string` | `"loki"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name for resource naming and labeling | `string` | `"hyperswitch"` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_bucket_notification_topic"></a> [bucket\_notification\_topic](#output\_bucket\_notification\_topic) | Name of the Pub/Sub topic receiving bucket notifications, if enabled |
+| <a name="output_chunks_bucket_name"></a> [chunks\_bucket\_name](#output\_chunks\_bucket\_name) | Name of the chunks storage bucket |
+| <a name="output_k8s_service_account_name"></a> [k8s\_service\_account\_name](#output\_k8s\_service\_account\_name) | Bound Kubernetes service account name |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of Loki's Google service account |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/application-resources/loki/README.md
+++ b/terraform/gcp/modules/application-resources/loki/README.md
@@ -2,27 +2,27 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_chunks_bucket"></a> [chunks\_bucket](#module\_chunks\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
 | <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ../gke-workload-identity | n/a |
 
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google_pubsub_topic.bucket_notifications](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
 | [google_pubsub_topic_iam_member.gcs_publisher](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic_iam_member) | resource |
 | [google_storage_notification.chunks](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_notification) | resource |
@@ -31,7 +31,7 @@
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_additional_project_roles"></a> [additional\_project\_roles](#input\_additional\_project\_roles) | Additional project-level IAM roles to grant Loki's service account | `list(string)` | `[]` | no |
 | <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | Whether to allow bucket deletion with objects in it | `bool` | `false` | no |
 | <a name="input_bucket_lifecycle_rules"></a> [bucket\_lifecycle\_rules](#input\_bucket\_lifecycle\_rules) | Lifecycle rules for the chunks bucket, in the shape expected by simple\_bucket | `any` | `[]` | no |
@@ -50,7 +50,7 @@
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_bucket_notification_topic"></a> [bucket\_notification\_topic](#output\_bucket\_notification\_topic) | Name of the Pub/Sub topic receiving bucket notifications, if enabled |
 | <a name="output_chunks_bucket_name"></a> [chunks\_bucket\_name](#output\_chunks\_bucket\_name) | Name of the chunks storage bucket |
 | <a name="output_k8s_service_account_name"></a> [k8s\_service\_account\_name](#output\_k8s\_service\_account\_name) | Bound Kubernetes service account name |

--- a/terraform/gcp/modules/application-resources/loki/locals.tf
+++ b/terraform/gcp/modules/application-resources/loki/locals.tf
@@ -1,0 +1,14 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}-loki"
+
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "application" = "loki"
+    },
+    var.labels
+  )
+
+  bucket_name = var.bucket_name != null ? var.bucket_name : "${local.name_prefix}-chunks"
+}

--- a/terraform/gcp/modules/application-resources/loki/main.tf
+++ b/terraform/gcp/modules/application-resources/loki/main.tf
@@ -1,0 +1,98 @@
+# ============================================================================
+# Loki (GCP equivalent of application-resources/loki)
+# ============================================================================
+# GSA + Workload Identity binding, a GCS bucket for chunk storage, and a
+# Pub/Sub topic + notification wired to object-create events on that bucket
+# - the GCS+Pub/Sub equivalent of the AWS module's S3 bucket + notification
+# + dedicated IAM role/SG.
+#
+# Usage:
+#   module "loki" {
+#     source = "../../modules/application-resources/loki"
+#
+#     project_id   = "hyperswitch-dev"
+#     environment  = "dev"
+#     project_name = "hyperswitch"
+#
+#     cluster_name     = module.gke.cluster_name
+#     cluster_location = module.gke.location
+#   }
+# ============================================================================
+
+module "workload_identity" {
+  source = "../gke-workload-identity"
+
+  project_id   = var.project_id
+  environment  = var.environment
+  project_name = var.project_name
+  app_name     = "loki"
+
+  cluster_name             = var.cluster_name
+  cluster_location         = var.cluster_location
+  k8s_namespace            = var.k8s_namespace
+  k8s_service_account_name = var.k8s_service_account_name
+
+  project_roles = var.additional_project_roles
+
+  labels = local.common_labels
+}
+
+module "chunks_bucket" {
+  source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
+  version = "12.3.0"
+
+  project_id    = var.project_id
+  name          = local.bucket_name
+  location      = var.bucket_location
+  force_destroy = var.bucket_force_destroy
+
+  versioning         = false
+  bucket_policy_only = true
+
+  lifecycle_rules = var.bucket_lifecycle_rules
+
+  iam_members = [{
+    role   = "roles/storage.objectAdmin"
+    member = "serviceAccount:${module.workload_identity.service_account_email}"
+  }]
+
+  labels = local.common_labels
+}
+
+# ==============================================================================
+# Pub/Sub notification on bucket object changes (replaces the AWS module's
+# S3 -> aws_s3_bucket_notification wiring)
+# ==============================================================================
+resource "google_pubsub_topic" "bucket_notifications" {
+  count = var.enable_bucket_notifications ? 1 : 0
+
+  project = var.project_id
+  name    = "${local.name_prefix}-bucket-events"
+  labels  = local.common_labels
+}
+
+resource "google_pubsub_topic_iam_member" "gcs_publisher" {
+  count = var.enable_bucket_notifications ? 1 : 0
+
+  project = var.project_id
+  topic   = google_pubsub_topic.bucket_notifications[0].name
+  role    = "roles/pubsub.publisher"
+  member  = "serviceAccount:${data.google_storage_project_service_account.this[0].email_address}"
+}
+
+data "google_storage_project_service_account" "this" {
+  count = var.enable_bucket_notifications ? 1 : 0
+
+  project = var.project_id
+}
+
+resource "google_storage_notification" "chunks" {
+  count = var.enable_bucket_notifications ? 1 : 0
+
+  bucket         = module.chunks_bucket.name
+  payload_format = "JSON_API_V1"
+  topic          = google_pubsub_topic.bucket_notifications[0].id
+  event_types    = ["OBJECT_FINALIZE"]
+
+  depends_on = [google_pubsub_topic_iam_member.gcs_publisher]
+}

--- a/terraform/gcp/modules/application-resources/loki/outputs.tf
+++ b/terraform/gcp/modules/application-resources/loki/outputs.tf
@@ -1,0 +1,19 @@
+output "service_account_email" {
+  description = "Email of Loki's Google service account"
+  value       = module.workload_identity.service_account_email
+}
+
+output "k8s_service_account_name" {
+  description = "Bound Kubernetes service account name"
+  value       = module.workload_identity.k8s_service_account_name
+}
+
+output "chunks_bucket_name" {
+  description = "Name of the chunks storage bucket"
+  value       = module.chunks_bucket.name
+}
+
+output "bucket_notification_topic" {
+  description = "Name of the Pub/Sub topic receiving bucket notifications, if enabled"
+  value       = var.enable_bucket_notifications ? google_pubsub_topic.bucket_notifications[0].name : null
+}

--- a/terraform/gcp/modules/application-resources/loki/variables.tf
+++ b/terraform/gcp/modules/application-resources/loki/variables.tf
@@ -1,0 +1,79 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for resource naming and labeling"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "cluster_name" {
+  description = "Name of the GKE cluster hosting Loki"
+  type        = string
+}
+
+variable "cluster_location" {
+  description = "Location (region or zone) of the GKE cluster"
+  type        = string
+}
+
+variable "k8s_namespace" {
+  description = "Kubernetes namespace Loki runs in"
+  type        = string
+  default     = "observability"
+}
+
+variable "k8s_service_account_name" {
+  description = "Kubernetes service account name used by Loki"
+  type        = string
+  default     = "loki"
+}
+
+variable "additional_project_roles" {
+  description = "Additional project-level IAM roles to grant Loki's service account"
+  type        = list(string)
+  default     = []
+}
+
+variable "bucket_name" {
+  description = "Custom chunks bucket name. If null, auto-generated as '<env>-<project>-loki-chunks'"
+  type        = string
+  default     = null
+}
+
+variable "bucket_location" {
+  description = "Location for the chunks bucket"
+  type        = string
+  default     = "US"
+}
+
+variable "bucket_force_destroy" {
+  description = "Whether to allow bucket deletion with objects in it"
+  type        = bool
+  default     = false
+}
+
+variable "bucket_lifecycle_rules" {
+  description = "Lifecycle rules for the chunks bucket, in the shape expected by simple_bucket"
+  type        = any
+  default     = []
+}
+
+variable "enable_bucket_notifications" {
+  description = "Whether to create a Pub/Sub topic + notification for chunk bucket object-create events"
+  type        = bool
+  default     = true
+}
+
+variable "labels" {
+  description = "Additional labels to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/application-resources/loki/versions.tf
+++ b/terraform/gcp/modules/application-resources/loki/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/application-resources/otel-collector/README.md
+++ b/terraform/gcp/modules/application-resources/otel-collector/README.md
@@ -2,7 +2,7 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
@@ -13,7 +13,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ../gke-workload-identity | n/a |
 
 ## Resources
@@ -23,7 +23,7 @@ No resources.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_additional_project_roles"></a> [additional\_project\_roles](#input\_additional\_project\_roles) | Additional project-level IAM roles to grant the collector's service account | `list(string)` | `[]` | no |
 | <a name="input_cluster_location"></a> [cluster\_location](#input\_cluster\_location) | Location (region or zone) of the GKE cluster | `string` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster hosting the collector | `string` | n/a | yes |
@@ -37,7 +37,7 @@ No resources.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_k8s_service_account_name"></a> [k8s\_service\_account\_name](#output\_k8s\_service\_account\_name) | Bound Kubernetes service account name |
 | <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of the collector's Google service account |
 <!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/application-resources/otel-collector/README.md
+++ b/terraform/gcp/modules/application-resources/otel-collector/README.md
@@ -1,0 +1,43 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ../gke-workload-identity | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_additional_project_roles"></a> [additional\_project\_roles](#input\_additional\_project\_roles) | Additional project-level IAM roles to grant the collector's service account | `list(string)` | `[]` | no |
+| <a name="input_cluster_location"></a> [cluster\_location](#input\_cluster\_location) | Location (region or zone) of the GKE cluster | `string` | n/a | yes |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster hosting the collector | `string` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | Kubernetes namespace the collector runs in | `string` | `"observability"` | no |
+| <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | Kubernetes service account name used by the collector | `string` | `"otel-collector"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to created resources that support them | `map(string)` | `{}` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name for resource naming and labeling | `string` | `"hyperswitch"` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_k8s_service_account_name"></a> [k8s\_service\_account\_name](#output\_k8s\_service\_account\_name) | Bound Kubernetes service account name |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of the collector's Google service account |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/application-resources/otel-collector/main.tf
+++ b/terraform/gcp/modules/application-resources/otel-collector/main.tf
@@ -1,0 +1,41 @@
+# ============================================================================
+# OpenTelemetry Collector (GCP equivalent of application-resources/otel-collector)
+# ============================================================================
+# GSA + Workload Identity binding with the roles the collector needs to
+# write metrics/traces/logs to Cloud Operations, mirroring the AWS module's
+# IRSA role with CloudWatch/X-Ray-equivalent permissions.
+#
+# Usage:
+#   module "otel_collector" {
+#     source = "../../modules/application-resources/otel-collector"
+#
+#     project_id    = "hyperswitch-dev"
+#     environment   = "dev"
+#     project_name  = "hyperswitch"
+#     cluster_name  = module.gke.cluster_name
+#     cluster_location = module.gke.location
+#     k8s_namespace = "observability"
+#   }
+# ============================================================================
+
+module "workload_identity" {
+  source = "../gke-workload-identity"
+
+  project_id   = var.project_id
+  environment  = var.environment
+  project_name = var.project_name
+  app_name     = "otel-collector"
+
+  cluster_name             = var.cluster_name
+  cluster_location         = var.cluster_location
+  k8s_namespace            = var.k8s_namespace
+  k8s_service_account_name = var.k8s_service_account_name
+
+  project_roles = concat([
+    "roles/monitoring.metricWriter",
+    "roles/cloudtrace.agent",
+    "roles/logging.logWriter",
+  ], var.additional_project_roles)
+
+  labels = var.labels
+}

--- a/terraform/gcp/modules/application-resources/otel-collector/outputs.tf
+++ b/terraform/gcp/modules/application-resources/otel-collector/outputs.tf
@@ -1,0 +1,9 @@
+output "service_account_email" {
+  description = "Email of the collector's Google service account"
+  value       = module.workload_identity.service_account_email
+}
+
+output "k8s_service_account_name" {
+  description = "Bound Kubernetes service account name"
+  value       = module.workload_identity.k8s_service_account_name
+}

--- a/terraform/gcp/modules/application-resources/otel-collector/variables.tf
+++ b/terraform/gcp/modules/application-resources/otel-collector/variables.tf
@@ -1,0 +1,49 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for resource naming and labeling"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "cluster_name" {
+  description = "Name of the GKE cluster hosting the collector"
+  type        = string
+}
+
+variable "cluster_location" {
+  description = "Location (region or zone) of the GKE cluster"
+  type        = string
+}
+
+variable "k8s_namespace" {
+  description = "Kubernetes namespace the collector runs in"
+  type        = string
+  default     = "observability"
+}
+
+variable "k8s_service_account_name" {
+  description = "Kubernetes service account name used by the collector"
+  type        = string
+  default     = "otel-collector"
+}
+
+variable "additional_project_roles" {
+  description = "Additional project-level IAM roles to grant the collector's service account"
+  type        = list(string)
+  default     = []
+}
+
+variable "labels" {
+  description = "Labels to apply to created resources that support them"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/application-resources/otel-collector/versions.tf
+++ b/terraform/gcp/modules/application-resources/otel-collector/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/application-resources/ratelimiter/README.md
+++ b/terraform/gcp/modules/application-resources/ratelimiter/README.md
@@ -1,0 +1,55 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_firewall_rules"></a> [firewall\_rules](#module\_firewall\_rules) | ../../composition/firewall-rules | n/a |
+| <a name="module_memorystore"></a> [memorystore](#module\_memorystore) | ../../composition/memorystore | n/a |
+| <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ../gke-workload-identity | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_additional_project_roles"></a> [additional\_project\_roles](#input\_additional\_project\_roles) | Additional project-level IAM roles to grant the ratelimiter's service account | `list(string)` | `[]` | no |
+| <a name="input_authorized_network"></a> [authorized\_network](#input\_authorized\_network) | Self-link/ID of the VPC network to peer the Memorystore instance to (requires Private Service Access) | `string` | `null` | no |
+| <a name="input_cluster_location"></a> [cluster\_location](#input\_cluster\_location) | Location (region or zone) of the GKE cluster | `string` | n/a | yes |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster hosting the ratelimiter | `string` | n/a | yes |
+| <a name="input_create_firewall_rule"></a> [create\_firewall\_rule](#input\_create\_firewall\_rule) | Whether to create the firewall rule allowing GKE pods to reach the Memorystore instance | `bool` | `true` | no |
+| <a name="input_create_redis"></a> [create\_redis](#input\_create\_redis) | Whether to create a dedicated Memorystore instance for the ratelimiter | `bool` | `true` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_gke_pods_cidr"></a> [gke\_pods\_cidr](#input\_gke\_pods\_cidr) | CIDR range of GKE pod IPs allowed to reach the Memorystore instance | `string` | `null` | no |
+| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | Kubernetes namespace the ratelimiter runs in | `string` | `"hyperswitch"` | no |
+| <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | Kubernetes service account name used by the ratelimiter | `string` | `"ratelimiter"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_network_name"></a> [network\_name](#input\_network\_name) | Name of the VPC network, required when create\_firewall\_rule = true | `string` | `null` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name for resource naming and labeling | `string` | `"hyperswitch"` | no |
+| <a name="input_redis_memory_size_gb"></a> [redis\_memory\_size\_gb](#input\_redis\_memory\_size\_gb) | Memorystore memory size in GB | `number` | `1` | no |
+| <a name="input_redis_tier"></a> [redis\_tier](#input\_redis\_tier) | Memorystore service tier | `string` | `"STANDARD_HA"` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region for the dedicated Memorystore instance | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_k8s_service_account_name"></a> [k8s\_service\_account\_name](#output\_k8s\_service\_account\_name) | Bound Kubernetes service account name |
+| <a name="output_redis_host"></a> [redis\_host](#output\_redis\_host) | Host/IP of the dedicated Memorystore instance, if created |
+| <a name="output_redis_port"></a> [redis\_port](#output\_redis\_port) | Port of the dedicated Memorystore instance, if created |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of the ratelimiter's Google service account |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/application-resources/ratelimiter/README.md
+++ b/terraform/gcp/modules/application-resources/ratelimiter/README.md
@@ -2,7 +2,7 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
@@ -13,7 +13,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_firewall_rules"></a> [firewall\_rules](#module\_firewall\_rules) | ../../composition/firewall-rules | n/a |
 | <a name="module_memorystore"></a> [memorystore](#module\_memorystore) | ../../composition/memorystore | n/a |
 | <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ../gke-workload-identity | n/a |
@@ -25,7 +25,7 @@ No resources.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_additional_project_roles"></a> [additional\_project\_roles](#input\_additional\_project\_roles) | Additional project-level IAM roles to grant the ratelimiter's service account | `list(string)` | `[]` | no |
 | <a name="input_authorized_network"></a> [authorized\_network](#input\_authorized\_network) | Self-link/ID of the VPC network to peer the Memorystore instance to (requires Private Service Access) | `string` | `null` | no |
 | <a name="input_cluster_location"></a> [cluster\_location](#input\_cluster\_location) | Location (region or zone) of the GKE cluster | `string` | n/a | yes |
@@ -47,7 +47,7 @@ No resources.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_k8s_service_account_name"></a> [k8s\_service\_account\_name](#output\_k8s\_service\_account\_name) | Bound Kubernetes service account name |
 | <a name="output_redis_host"></a> [redis\_host](#output\_redis\_host) | Host/IP of the dedicated Memorystore instance, if created |
 | <a name="output_redis_port"></a> [redis\_port](#output\_redis\_port) | Port of the dedicated Memorystore instance, if created |

--- a/terraform/gcp/modules/application-resources/ratelimiter/locals.tf
+++ b/terraform/gcp/modules/application-resources/ratelimiter/locals.tf
@@ -1,0 +1,10 @@
+locals {
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "application" = "ratelimiter"
+    },
+    var.labels
+  )
+}

--- a/terraform/gcp/modules/application-resources/ratelimiter/main.tf
+++ b/terraform/gcp/modules/application-resources/ratelimiter/main.tf
@@ -1,0 +1,86 @@
+# ============================================================================
+# Ratelimiter (GCP equivalent of application-resources/ratelimiter)
+# ============================================================================
+# GSA + Workload Identity binding, an optional dedicated Memorystore
+# instance (composition/memorystore), and a firewall rule allowing the GKE
+# node pool to reach it - mirroring the AWS module's IRSA role +
+# composition/elasticache + LB security group rules.
+#
+# Usage:
+#   module "ratelimiter" {
+#     source = "../../modules/application-resources/ratelimiter"
+#
+#     project_id   = "hyperswitch-dev"
+#     environment  = "dev"
+#     project_name = "hyperswitch"
+#     region       = "europe-west1"
+#
+#     cluster_name     = module.gke.cluster_name
+#     cluster_location = module.gke.location
+#
+#     network             = module.vpc_network.network_self_link
+#     network_name         = module.vpc_network.network_name
+#     authorized_network   = module.vpc_network.network_id
+#   }
+# ============================================================================
+
+module "workload_identity" {
+  source = "../gke-workload-identity"
+
+  project_id   = var.project_id
+  environment  = var.environment
+  project_name = var.project_name
+  app_name     = "ratelimiter"
+
+  cluster_name             = var.cluster_name
+  cluster_location         = var.cluster_location
+  k8s_namespace            = var.k8s_namespace
+  k8s_service_account_name = var.k8s_service_account_name
+
+  project_roles = var.additional_project_roles
+
+  labels = local.common_labels
+}
+
+module "memorystore" {
+  source = "../../composition/memorystore"
+
+  count = var.create_redis ? 1 : 0
+
+  project_id   = var.project_id
+  environment  = var.environment
+  project_name = "${var.project_name}-ratelimiter"
+  region       = var.region
+
+  authorized_network = var.authorized_network
+  tier               = var.redis_tier
+  memory_size_gb     = var.redis_memory_size_gb
+
+  labels = local.common_labels
+}
+
+module "firewall_rules" {
+  source = "../../composition/firewall-rules"
+
+  count = var.create_redis && var.create_firewall_rule ? 1 : 0
+
+  project_id   = var.project_id
+  environment  = var.environment
+  project_name = var.project_name
+  network_name = var.network_name
+
+  rules = {
+    ratelimiter-to-redis = {
+      rules = [
+        {
+          name                    = "allow-ratelimiter-to-redis"
+          description             = "Allow ratelimiter workloads to reach Memorystore"
+          direction               = "INGRESS"
+          target_service_accounts = [module.workload_identity.service_account_email]
+          ranges                  = [var.gke_pods_cidr]
+          allow                   = [{ protocol = "tcp", ports = ["6379"] }]
+        },
+      ]
+    }
+  }
+}

--- a/terraform/gcp/modules/application-resources/ratelimiter/outputs.tf
+++ b/terraform/gcp/modules/application-resources/ratelimiter/outputs.tf
@@ -1,0 +1,19 @@
+output "service_account_email" {
+  description = "Email of the ratelimiter's Google service account"
+  value       = module.workload_identity.service_account_email
+}
+
+output "k8s_service_account_name" {
+  description = "Bound Kubernetes service account name"
+  value       = module.workload_identity.k8s_service_account_name
+}
+
+output "redis_host" {
+  description = "Host/IP of the dedicated Memorystore instance, if created"
+  value       = var.create_redis ? module.memorystore[0].host : null
+}
+
+output "redis_port" {
+  description = "Port of the dedicated Memorystore instance, if created"
+  value       = var.create_redis ? module.memorystore[0].port : null
+}

--- a/terraform/gcp/modules/application-resources/ratelimiter/variables.tf
+++ b/terraform/gcp/modules/application-resources/ratelimiter/variables.tf
@@ -1,0 +1,96 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for resource naming and labeling"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "region" {
+  description = "Region for the dedicated Memorystore instance"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "Name of the GKE cluster hosting the ratelimiter"
+  type        = string
+}
+
+variable "cluster_location" {
+  description = "Location (region or zone) of the GKE cluster"
+  type        = string
+}
+
+variable "k8s_namespace" {
+  description = "Kubernetes namespace the ratelimiter runs in"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "k8s_service_account_name" {
+  description = "Kubernetes service account name used by the ratelimiter"
+  type        = string
+  default     = "ratelimiter"
+}
+
+variable "additional_project_roles" {
+  description = "Additional project-level IAM roles to grant the ratelimiter's service account"
+  type        = list(string)
+  default     = []
+}
+
+variable "create_redis" {
+  description = "Whether to create a dedicated Memorystore instance for the ratelimiter"
+  type        = bool
+  default     = true
+}
+
+variable "authorized_network" {
+  description = "Self-link/ID of the VPC network to peer the Memorystore instance to (requires Private Service Access)"
+  type        = string
+  default     = null
+}
+
+variable "redis_tier" {
+  description = "Memorystore service tier"
+  type        = string
+  default     = "STANDARD_HA"
+}
+
+variable "redis_memory_size_gb" {
+  description = "Memorystore memory size in GB"
+  type        = number
+  default     = 1
+}
+
+variable "create_firewall_rule" {
+  description = "Whether to create the firewall rule allowing GKE pods to reach the Memorystore instance"
+  type        = bool
+  default     = true
+}
+
+variable "network_name" {
+  description = "Name of the VPC network, required when create_firewall_rule = true"
+  type        = string
+  default     = null
+}
+
+variable "gke_pods_cidr" {
+  description = "CIDR range of GKE pod IPs allowed to reach the Memorystore instance"
+  type        = string
+  default     = null
+}
+
+variable "labels" {
+  description = "Additional labels to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/application-resources/ratelimiter/versions.tf
+++ b/terraform/gcp/modules/application-resources/ratelimiter/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/application-resources/shared-iam-roles/README.md
+++ b/terraform/gcp/modules/application-resources/shared-iam-roles/README.md
@@ -1,0 +1,38 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_project_iam_custom_role.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where custom roles are created | `string` | n/a | yes |
+| <a name="input_roles"></a> [roles](#input\_roles) | Map of custom IAM roles to create, keyed by a DNS-safe logical name | <pre>map(object({<br/>    title       = string<br/>    description = string<br/>    permissions = list(string)<br/>    stage       = optional(string, "GA")<br/>  }))</pre> | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_role_ids"></a> [role\_ids](#output\_role\_ids) | Map of logical name to the custom role's fully qualified ID |
+| <a name="output_role_names"></a> [role\_names](#output\_role\_names) | Map of logical name to the custom role's role\_id (used in google\_project\_iam\_member.role) |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/application-resources/shared-iam-roles/README.md
+++ b/terraform/gcp/modules/application-resources/shared-iam-roles/README.md
@@ -2,14 +2,14 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
 
 ## Modules
@@ -19,20 +19,20 @@ No modules.
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google_project_iam_custom_role.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where custom roles are created | `string` | n/a | yes |
 | <a name="input_roles"></a> [roles](#input\_roles) | Map of custom IAM roles to create, keyed by a DNS-safe logical name | <pre>map(object({<br/>    title       = string<br/>    description = string<br/>    permissions = list(string)<br/>    stage       = optional(string, "GA")<br/>  }))</pre> | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_role_ids"></a> [role\_ids](#output\_role\_ids) | Map of logical name to the custom role's fully qualified ID |
 | <a name="output_role_names"></a> [role\_names](#output\_role\_names) | Map of logical name to the custom role's role\_id (used in google\_project\_iam\_member.role) |
 <!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/application-resources/shared-iam-roles/main.tf
+++ b/terraform/gcp/modules/application-resources/shared-iam-roles/main.tf
@@ -1,0 +1,35 @@
+# ============================================================================
+# Shared IAM Roles (GCP equivalent of application-resources/shared-policy)
+# ============================================================================
+# Custom IAM roles shared across multiple application-resources modules,
+# mirroring the AWS module's for_each-over-policies IAM policy factory.
+# GCP's closest equivalent to a standalone reusable IAM policy is a custom
+# role, granted to whichever service accounts need it via
+# google_project_iam_member elsewhere.
+#
+# Usage:
+#   module "shared_roles" {
+#     source = "../../modules/application-resources/shared-iam-roles"
+#
+#     project_id = "hyperswitch-dev"
+#
+#     roles = {
+#       s3-read = {
+#         title       = "Hyperswitch Storage Reader"
+#         description = "Read access to Hyperswitch storage buckets"
+#         permissions = ["storage.objects.get", "storage.objects.list"]
+#       }
+#     }
+#   }
+# ============================================================================
+
+resource "google_project_iam_custom_role" "this" {
+  for_each = var.roles
+
+  project     = var.project_id
+  role_id     = replace(each.key, "-", "_")
+  title       = each.value.title
+  description = each.value.description
+  permissions = each.value.permissions
+  stage       = try(each.value.stage, "GA")
+}

--- a/terraform/gcp/modules/application-resources/shared-iam-roles/outputs.tf
+++ b/terraform/gcp/modules/application-resources/shared-iam-roles/outputs.tf
@@ -1,0 +1,9 @@
+output "role_ids" {
+  description = "Map of logical name to the custom role's fully qualified ID"
+  value       = { for k, v in google_project_iam_custom_role.this : k => v.id }
+}
+
+output "role_names" {
+  description = "Map of logical name to the custom role's role_id (used in google_project_iam_member.role)"
+  value       = { for k, v in google_project_iam_custom_role.this : k => v.role_id }
+}

--- a/terraform/gcp/modules/application-resources/shared-iam-roles/variables.tf
+++ b/terraform/gcp/modules/application-resources/shared-iam-roles/variables.tf
@@ -1,0 +1,14 @@
+variable "project_id" {
+  description = "GCP project ID where custom roles are created"
+  type        = string
+}
+
+variable "roles" {
+  description = "Map of custom IAM roles to create, keyed by a DNS-safe logical name"
+  type = map(object({
+    title       = string
+    description = string
+    permissions = list(string)
+    stage       = optional(string, "GA")
+  }))
+}

--- a/terraform/gcp/modules/application-resources/shared-iam-roles/versions.tf
+++ b/terraform/gcp/modules/application-resources/shared-iam-roles/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/application-resources/superposition/README.md
+++ b/terraform/gcp/modules/application-resources/superposition/README.md
@@ -2,7 +2,7 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
@@ -13,7 +13,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_database"></a> [database](#module\_database) | ../../composition/cloud-sql | n/a |
 | <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ../gke-workload-identity | n/a |
 
@@ -24,7 +24,7 @@ No resources.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_additional_project_roles"></a> [additional\_project\_roles](#input\_additional\_project\_roles) | Additional project-level IAM roles to grant Superposition's service account | `list(string)` | `[]` | no |
 | <a name="input_cluster_location"></a> [cluster\_location](#input\_cluster\_location) | Location (region or zone) of the GKE cluster | `string` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster hosting Superposition | `string` | n/a | yes |
@@ -41,7 +41,7 @@ No resources.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_database_instance_connection_name"></a> [database\_instance\_connection\_name](#output\_database\_instance\_connection\_name) | Cloud SQL Auth Proxy connection name for Superposition's database, if created |
 | <a name="output_database_name"></a> [database\_name](#output\_database\_name) | Name of the Superposition database, if created |
 | <a name="output_k8s_service_account_name"></a> [k8s\_service\_account\_name](#output\_k8s\_service\_account\_name) | Bound Kubernetes service account name |

--- a/terraform/gcp/modules/application-resources/superposition/README.md
+++ b/terraform/gcp/modules/application-resources/superposition/README.md
@@ -1,0 +1,49 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_database"></a> [database](#module\_database) | ../../composition/cloud-sql | n/a |
+| <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ../gke-workload-identity | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_additional_project_roles"></a> [additional\_project\_roles](#input\_additional\_project\_roles) | Additional project-level IAM roles to grant Superposition's service account | `list(string)` | `[]` | no |
+| <a name="input_cluster_location"></a> [cluster\_location](#input\_cluster\_location) | Location (region or zone) of the GKE cluster | `string` | n/a | yes |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster hosting Superposition | `string` | n/a | yes |
+| <a name="input_create_database"></a> [create\_database](#input\_create\_database) | Whether to create a dedicated Cloud SQL database for Superposition | `bool` | `true` | no |
+| <a name="input_database_config"></a> [database\_config](#input\_database\_config) | Configuration for Superposition's dedicated Cloud SQL database (composition/cloud-sql) | <pre>object({<br/>    network_id          = string<br/>    instance_name       = optional(string)<br/>    database_version    = optional(string)<br/>    tier                = optional(string)<br/>    availability_type   = optional(string)<br/>    disk_size           = optional(number)<br/>    deletion_protection = optional(bool)<br/>    database_name       = optional(string)<br/>    master_username     = optional(string)<br/>    master_password     = optional(string)<br/>    encryption_key_name = optional(string)<br/>  })</pre> | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | Kubernetes namespace Superposition runs in | `string` | `"hyperswitch"` | no |
+| <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | Kubernetes service account name used by Superposition | `string` | `"superposition"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name for resource naming and labeling | `string` | `"hyperswitch"` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region for the dedicated Cloud SQL database | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_database_instance_connection_name"></a> [database\_instance\_connection\_name](#output\_database\_instance\_connection\_name) | Cloud SQL Auth Proxy connection name for Superposition's database, if created |
+| <a name="output_database_name"></a> [database\_name](#output\_database\_name) | Name of the Superposition database, if created |
+| <a name="output_k8s_service_account_name"></a> [k8s\_service\_account\_name](#output\_k8s\_service\_account\_name) | Bound Kubernetes service account name |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of Superposition's Google service account |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/application-resources/superposition/locals.tf
+++ b/terraform/gcp/modules/application-resources/superposition/locals.tf
@@ -1,0 +1,10 @@
+locals {
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "application" = "superposition"
+    },
+    var.labels
+  )
+}

--- a/terraform/gcp/modules/application-resources/superposition/main.tf
+++ b/terraform/gcp/modules/application-resources/superposition/main.tf
@@ -1,0 +1,71 @@
+# ============================================================================
+# Superposition (GCP equivalent of application-resources/superposition)
+# ============================================================================
+# GSA + Workload Identity binding, plus an optional dedicated Cloud SQL
+# database via composition/cloud-sql, called with the same single
+# database_config object style as application-resources/grafana (the AWS
+# side had grafana and superposition calling the same database module with
+# two different interface styles; both GCP callers now agree).
+#
+# Usage:
+#   module "superposition" {
+#     source = "../../modules/application-resources/superposition"
+#
+#     project_id   = "hyperswitch-dev"
+#     environment  = "dev"
+#     project_name = "hyperswitch"
+#     region       = "europe-west1"
+#
+#     cluster_name     = module.gke.cluster_name
+#     cluster_location = module.gke.location
+#
+#     database_config = {
+#       network_id = module.vpc_network.network_id
+#     }
+#   }
+# ============================================================================
+
+module "workload_identity" {
+  source = "../gke-workload-identity"
+
+  project_id   = var.project_id
+  environment  = var.environment
+  project_name = var.project_name
+  app_name     = "superposition"
+
+  cluster_name             = var.cluster_name
+  cluster_location         = var.cluster_location
+  k8s_namespace            = var.k8s_namespace
+  k8s_service_account_name = var.k8s_service_account_name
+
+  project_roles = var.additional_project_roles
+
+  labels = local.common_labels
+}
+
+module "database" {
+  source = "../../composition/cloud-sql"
+
+  count = var.create_database ? 1 : 0
+
+  project_id   = var.project_id
+  environment  = var.environment
+  project_name = "${var.project_name}-superposition"
+  region       = var.region
+  network_id   = var.database_config.network_id
+
+  instance_name       = var.database_config.instance_name
+  database_version    = coalesce(var.database_config.database_version, "POSTGRES_15")
+  tier                = coalesce(var.database_config.tier, "db-custom-2-8192")
+  availability_type   = coalesce(var.database_config.availability_type, "REGIONAL")
+  disk_size           = coalesce(var.database_config.disk_size, 50)
+  deletion_protection = coalesce(var.database_config.deletion_protection, true)
+
+  database_name   = coalesce(var.database_config.database_name, "superposition")
+  master_username = coalesce(var.database_config.master_username, "superposition_admin")
+  master_password = var.database_config.master_password
+
+  encryption_key_name = var.database_config.encryption_key_name
+
+  labels = local.common_labels
+}

--- a/terraform/gcp/modules/application-resources/superposition/outputs.tf
+++ b/terraform/gcp/modules/application-resources/superposition/outputs.tf
@@ -1,0 +1,19 @@
+output "service_account_email" {
+  description = "Email of Superposition's Google service account"
+  value       = module.workload_identity.service_account_email
+}
+
+output "k8s_service_account_name" {
+  description = "Bound Kubernetes service account name"
+  value       = module.workload_identity.k8s_service_account_name
+}
+
+output "database_instance_connection_name" {
+  description = "Cloud SQL Auth Proxy connection name for Superposition's database, if created"
+  value       = var.create_database ? module.database[0].instance_connection_name : null
+}
+
+output "database_name" {
+  description = "Name of the Superposition database, if created"
+  value       = var.create_database ? module.database[0].database_name : null
+}

--- a/terraform/gcp/modules/application-resources/superposition/variables.tf
+++ b/terraform/gcp/modules/application-resources/superposition/variables.tf
@@ -1,0 +1,77 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for resource naming and labeling"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "region" {
+  description = "Region for the dedicated Cloud SQL database"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "Name of the GKE cluster hosting Superposition"
+  type        = string
+}
+
+variable "cluster_location" {
+  description = "Location (region or zone) of the GKE cluster"
+  type        = string
+}
+
+variable "k8s_namespace" {
+  description = "Kubernetes namespace Superposition runs in"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "k8s_service_account_name" {
+  description = "Kubernetes service account name used by Superposition"
+  type        = string
+  default     = "superposition"
+}
+
+variable "additional_project_roles" {
+  description = "Additional project-level IAM roles to grant Superposition's service account"
+  type        = list(string)
+  default     = []
+}
+
+variable "create_database" {
+  description = "Whether to create a dedicated Cloud SQL database for Superposition"
+  type        = bool
+  default     = true
+}
+
+variable "database_config" {
+  description = "Configuration for Superposition's dedicated Cloud SQL database (composition/cloud-sql)"
+  type = object({
+    network_id          = string
+    instance_name       = optional(string)
+    database_version    = optional(string)
+    tier                = optional(string)
+    availability_type   = optional(string)
+    disk_size           = optional(number)
+    deletion_protection = optional(bool)
+    database_name       = optional(string)
+    master_username     = optional(string)
+    master_password     = optional(string)
+    encryption_key_name = optional(string)
+  })
+}
+
+variable "labels" {
+  description = "Additional labels to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/application-resources/superposition/versions.tf
+++ b/terraform/gcp/modules/application-resources/superposition/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/application-resources/vector/README.md
+++ b/terraform/gcp/modules/application-resources/vector/README.md
@@ -1,0 +1,66 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_logs_bucket"></a> [logs\_bucket](#module\_logs\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
+| <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ../gke-workload-identity | n/a |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_pubsub_subscription.log_events](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
+| [google_pubsub_subscription_iam_member.cross_region_reader](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription_iam_member) | resource |
+| [google_pubsub_subscription_iam_member.subscriber](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription_iam_member) | resource |
+| [google_pubsub_topic.log_events](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
+| [google_pubsub_topic_iam_member.gcs_publisher](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic_iam_member) | resource |
+| [google_storage_notification.logs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_notification) | resource |
+| [google_storage_project_service_account.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/storage_project_service_account) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_additional_project_roles"></a> [additional\_project\_roles](#input\_additional\_project\_roles) | Additional project-level IAM roles to grant Vector's service account | `list(string)` | `[]` | no |
+| <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | Whether to allow bucket deletion with objects in it | `bool` | `false` | no |
+| <a name="input_bucket_lifecycle_rules"></a> [bucket\_lifecycle\_rules](#input\_bucket\_lifecycle\_rules) | Lifecycle rules for the logs bucket, in the shape expected by simple\_bucket | `any` | `[]` | no |
+| <a name="input_bucket_location"></a> [bucket\_location](#input\_bucket\_location) | Location for the logs bucket | `string` | `"US"` | no |
+| <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Custom bucket name. If null, auto-generated as '<env>-<project>-vector-logs' | `string` | `null` | no |
+| <a name="input_cluster_location"></a> [cluster\_location](#input\_cluster\_location) | Location (region or zone) of the GKE cluster | `string` | n/a | yes |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster hosting Vector | `string` | n/a | yes |
+| <a name="input_create_bucket"></a> [create\_bucket](#input\_create\_bucket) | Whether to create a dedicated GCS bucket for Vector's log storage | `bool` | `true` | no |
+| <a name="input_create_queue"></a> [create\_queue](#input\_create\_queue) | Whether to create the Pub/Sub topic/subscription pair for log-event notifications | `bool` | `true` | no |
+| <a name="input_cross_region_reader_members"></a> [cross\_region\_reader\_members](#input\_cross\_region\_reader\_members) | List of IAM members (e.g. 'serviceAccount:...') in other regions/projects granted subscriber access, the equivalent of the AWS module's cross-region SQS read policy | `list(string)` | `[]` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | Kubernetes namespace Vector runs in | `string` | `"observability"` | no |
+| <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | Kubernetes service account name used by Vector | `string` | `"vector"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name for resource naming and labeling | `string` | `"hyperswitch"` | no |
+| <a name="input_subscription_ack_deadline_seconds"></a> [subscription\_ack\_deadline\_seconds](#input\_subscription\_ack\_deadline\_seconds) | Acknowledgement deadline for the pull subscription | `number` | `60` | no |
+| <a name="input_subscription_message_retention_duration"></a> [subscription\_message\_retention\_duration](#input\_subscription\_message\_retention\_duration) | How long unacknowledged messages are retained on the subscription | `string` | `"604800s"` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_k8s_service_account_name"></a> [k8s\_service\_account\_name](#output\_k8s\_service\_account\_name) | Bound Kubernetes service account name |
+| <a name="output_logs_bucket_name"></a> [logs\_bucket\_name](#output\_logs\_bucket\_name) | Name of the logs storage bucket, if created |
+| <a name="output_pubsub_subscription"></a> [pubsub\_subscription](#output\_pubsub\_subscription) | Name of the log-events pull subscription, if created |
+| <a name="output_pubsub_topic"></a> [pubsub\_topic](#output\_pubsub\_topic) | Name of the log-events Pub/Sub topic, if created |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of Vector's Google service account |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/application-resources/vector/README.md
+++ b/terraform/gcp/modules/application-resources/vector/README.md
@@ -2,27 +2,27 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_logs_bucket"></a> [logs\_bucket](#module\_logs\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
 | <a name="module_workload_identity"></a> [workload\_identity](#module\_workload\_identity) | ../gke-workload-identity | n/a |
 
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google_pubsub_subscription.log_events](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
 | [google_pubsub_subscription_iam_member.cross_region_reader](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription_iam_member) | resource |
 | [google_pubsub_subscription_iam_member.subscriber](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription_iam_member) | resource |
@@ -34,7 +34,7 @@
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_additional_project_roles"></a> [additional\_project\_roles](#input\_additional\_project\_roles) | Additional project-level IAM roles to grant Vector's service account | `list(string)` | `[]` | no |
 | <a name="input_bucket_force_destroy"></a> [bucket\_force\_destroy](#input\_bucket\_force\_destroy) | Whether to allow bucket deletion with objects in it | `bool` | `false` | no |
 | <a name="input_bucket_lifecycle_rules"></a> [bucket\_lifecycle\_rules](#input\_bucket\_lifecycle\_rules) | Lifecycle rules for the logs bucket, in the shape expected by simple\_bucket | `any` | `[]` | no |
@@ -57,7 +57,7 @@
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_k8s_service_account_name"></a> [k8s\_service\_account\_name](#output\_k8s\_service\_account\_name) | Bound Kubernetes service account name |
 | <a name="output_logs_bucket_name"></a> [logs\_bucket\_name](#output\_logs\_bucket\_name) | Name of the logs storage bucket, if created |
 | <a name="output_pubsub_subscription"></a> [pubsub\_subscription](#output\_pubsub\_subscription) | Name of the log-events pull subscription, if created |

--- a/terraform/gcp/modules/application-resources/vector/locals.tf
+++ b/terraform/gcp/modules/application-resources/vector/locals.tf
@@ -1,0 +1,14 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}-vector"
+
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "application" = "vector"
+    },
+    var.labels
+  )
+
+  bucket_name = var.bucket_name != null ? var.bucket_name : "${local.name_prefix}-logs"
+}

--- a/terraform/gcp/modules/application-resources/vector/main.tf
+++ b/terraform/gcp/modules/application-resources/vector/main.tf
@@ -1,0 +1,135 @@
+# ============================================================================
+# Vector (GCP equivalent of application-resources/vector)
+# ============================================================================
+# GSA + Workload Identity binding, a GCS log bucket, and a Pub/Sub
+# topic + pull subscription wired to object-create events on that bucket -
+# the GCS+Pub/Sub equivalent of the AWS module's S3 + SQS + cross-region SQS
+# read shape. A Pub/Sub subscription can itself be read from another region
+# without any special "cross-region" resource (Pub/Sub is a global service),
+# so cross-region reads are just IAM grants to a remote reader identity
+# rather than a second queue.
+#
+# Usage:
+#   module "vector" {
+#     source = "../../modules/application-resources/vector"
+#
+#     project_id   = "hyperswitch-dev"
+#     environment  = "dev"
+#     project_name = "hyperswitch"
+#
+#     cluster_name     = module.gke.cluster_name
+#     cluster_location = module.gke.location
+#   }
+# ============================================================================
+
+module "workload_identity" {
+  source = "../gke-workload-identity"
+
+  project_id   = var.project_id
+  environment  = var.environment
+  project_name = var.project_name
+  app_name     = "vector"
+
+  cluster_name             = var.cluster_name
+  cluster_location         = var.cluster_location
+  k8s_namespace            = var.k8s_namespace
+  k8s_service_account_name = var.k8s_service_account_name
+
+  project_roles = var.additional_project_roles
+
+  labels = local.common_labels
+}
+
+module "logs_bucket" {
+  source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
+  version = "12.3.0"
+
+  count = var.create_bucket ? 1 : 0
+
+  project_id    = var.project_id
+  name          = local.bucket_name
+  location      = var.bucket_location
+  force_destroy = var.bucket_force_destroy
+
+  versioning         = false
+  bucket_policy_only = true
+
+  lifecycle_rules = var.bucket_lifecycle_rules
+
+  iam_members = [{
+    role   = "roles/storage.objectAdmin"
+    member = "serviceAccount:${module.workload_identity.service_account_email}"
+  }]
+
+  labels = local.common_labels
+}
+
+# ==============================================================================
+# Pub/Sub (replaces the AWS module's SQS queue + policy + S3 notification)
+# ==============================================================================
+resource "google_pubsub_topic" "log_events" {
+  count = var.create_queue ? 1 : 0
+
+  project = var.project_id
+  name    = "${local.name_prefix}-log-events"
+  labels  = local.common_labels
+}
+
+data "google_storage_project_service_account" "this" {
+  count = var.create_bucket && var.create_queue ? 1 : 0
+
+  project = var.project_id
+}
+
+resource "google_pubsub_topic_iam_member" "gcs_publisher" {
+  count = var.create_bucket && var.create_queue ? 1 : 0
+
+  project = var.project_id
+  topic   = google_pubsub_topic.log_events[0].name
+  role    = "roles/pubsub.publisher"
+  member  = "serviceAccount:${data.google_storage_project_service_account.this[0].email_address}"
+}
+
+resource "google_storage_notification" "logs" {
+  count = var.create_bucket && var.create_queue ? 1 : 0
+
+  bucket         = module.logs_bucket[0].name
+  payload_format = "JSON_API_V1"
+  topic          = google_pubsub_topic.log_events[0].id
+  event_types    = ["OBJECT_FINALIZE"]
+
+  depends_on = [google_pubsub_topic_iam_member.gcs_publisher]
+}
+
+resource "google_pubsub_subscription" "log_events" {
+  count = var.create_queue ? 1 : 0
+
+  project = var.project_id
+  name    = "${local.name_prefix}-log-events-sub"
+  topic   = google_pubsub_topic.log_events[0].id
+
+  ack_deadline_seconds       = var.subscription_ack_deadline_seconds
+  message_retention_duration = var.subscription_message_retention_duration
+}
+
+resource "google_pubsub_subscription_iam_member" "subscriber" {
+  count = var.create_queue ? 1 : 0
+
+  project      = var.project_id
+  subscription = google_pubsub_subscription.log_events[0].name
+  role         = "roles/pubsub.subscriber"
+  member       = "serviceAccount:${module.workload_identity.service_account_email}"
+}
+
+# ==============================================================================
+# Cross-region read: grant a remote reader identity subscriber access, the
+# GCP equivalent of the AWS module's cross-region SQS read policy
+# ==============================================================================
+resource "google_pubsub_subscription_iam_member" "cross_region_reader" {
+  for_each = var.create_queue ? toset(var.cross_region_reader_members) : []
+
+  project      = var.project_id
+  subscription = google_pubsub_subscription.log_events[0].name
+  role         = "roles/pubsub.subscriber"
+  member       = each.value
+}

--- a/terraform/gcp/modules/application-resources/vector/outputs.tf
+++ b/terraform/gcp/modules/application-resources/vector/outputs.tf
@@ -1,0 +1,24 @@
+output "service_account_email" {
+  description = "Email of Vector's Google service account"
+  value       = module.workload_identity.service_account_email
+}
+
+output "k8s_service_account_name" {
+  description = "Bound Kubernetes service account name"
+  value       = module.workload_identity.k8s_service_account_name
+}
+
+output "logs_bucket_name" {
+  description = "Name of the logs storage bucket, if created"
+  value       = var.create_bucket ? module.logs_bucket[0].name : null
+}
+
+output "pubsub_topic" {
+  description = "Name of the log-events Pub/Sub topic, if created"
+  value       = var.create_queue ? google_pubsub_topic.log_events[0].name : null
+}
+
+output "pubsub_subscription" {
+  description = "Name of the log-events pull subscription, if created"
+  value       = var.create_queue ? google_pubsub_subscription.log_events[0].name : null
+}

--- a/terraform/gcp/modules/application-resources/vector/variables.tf
+++ b/terraform/gcp/modules/application-resources/vector/variables.tf
@@ -1,0 +1,103 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for resource naming and labeling"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "cluster_name" {
+  description = "Name of the GKE cluster hosting Vector"
+  type        = string
+}
+
+variable "cluster_location" {
+  description = "Location (region or zone) of the GKE cluster"
+  type        = string
+}
+
+variable "k8s_namespace" {
+  description = "Kubernetes namespace Vector runs in"
+  type        = string
+  default     = "observability"
+}
+
+variable "k8s_service_account_name" {
+  description = "Kubernetes service account name used by Vector"
+  type        = string
+  default     = "vector"
+}
+
+variable "additional_project_roles" {
+  description = "Additional project-level IAM roles to grant Vector's service account"
+  type        = list(string)
+  default     = []
+}
+
+variable "create_bucket" {
+  description = "Whether to create a dedicated GCS bucket for Vector's log storage"
+  type        = bool
+  default     = true
+}
+
+variable "bucket_name" {
+  description = "Custom bucket name. If null, auto-generated as '<env>-<project>-vector-logs'"
+  type        = string
+  default     = null
+}
+
+variable "bucket_location" {
+  description = "Location for the logs bucket"
+  type        = string
+  default     = "US"
+}
+
+variable "bucket_force_destroy" {
+  description = "Whether to allow bucket deletion with objects in it"
+  type        = bool
+  default     = false
+}
+
+variable "bucket_lifecycle_rules" {
+  description = "Lifecycle rules for the logs bucket, in the shape expected by simple_bucket"
+  type        = any
+  default     = []
+}
+
+variable "create_queue" {
+  description = "Whether to create the Pub/Sub topic/subscription pair for log-event notifications"
+  type        = bool
+  default     = true
+}
+
+variable "subscription_ack_deadline_seconds" {
+  description = "Acknowledgement deadline for the pull subscription"
+  type        = number
+  default     = 60
+}
+
+variable "subscription_message_retention_duration" {
+  description = "How long unacknowledged messages are retained on the subscription"
+  type        = string
+  default     = "604800s" # 7 days
+}
+
+variable "cross_region_reader_members" {
+  description = "List of IAM members (e.g. 'serviceAccount:...') in other regions/projects granted subscriber access, the equivalent of the AWS module's cross-region SQS read policy"
+  type        = list(string)
+  default     = []
+}
+
+variable "labels" {
+  description = "Additional labels to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/application-resources/vector/versions.tf
+++ b/terraform/gcp/modules/application-resources/vector/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/composition/artifact-registry/README.md
+++ b/terraform/gcp/modules/composition/artifact-registry/README.md
@@ -2,14 +2,14 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
 
 ## Modules
@@ -19,14 +19,14 @@ No modules.
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google_artifact_registry_repository.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository) | resource |
 | [google_artifact_registry_repository_iam_member.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository_iam_member) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
 | <a name="input_labels"></a> [labels](#input\_labels) | Additional labels applied to every repository | `map(string)` | `{}` | no |
 | <a name="input_location"></a> [location](#input\_location) | Location for the repositories (region, e.g. europe-west1) | `string` | n/a | yes |
@@ -37,7 +37,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_repository_ids"></a> [repository\_ids](#output\_repository\_ids) | Map of repository key to its fully qualified ID |
 | <a name="output_repository_names"></a> [repository\_names](#output\_repository\_names) | Map of repository key to its repository\_id |
 | <a name="output_repository_urls"></a> [repository\_urls](#output\_repository\_urls) | Map of repository key to its pull/push URL (<location>-docker.pkg.dev/<project>/<repo>) |

--- a/terraform/gcp/modules/composition/artifact-registry/README.md
+++ b/terraform/gcp/modules/composition/artifact-registry/README.md
@@ -1,0 +1,44 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_artifact_registry_repository.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository) | resource |
+| [google_artifact_registry_repository_iam_member.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository_iam_member) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels applied to every repository | `map(string)` | `{}` | no |
+| <a name="input_location"></a> [location](#input\_location) | Location for the repositories (region, e.g. europe-west1) | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where repositories are created | `string` | n/a | yes |
+| <a name="input_repositories"></a> [repositories](#input\_repositories) | Map of repositories to create, keyed by repository\_id | <pre>map(object({<br/>    description    = optional(string)<br/>    format         = optional(string, "DOCKER")<br/>    mode           = optional(string, "STANDARD_REPOSITORY")<br/>    kms_key_name   = optional(string)<br/>    immutable_tags = optional(bool, false)<br/>    labels         = optional(map(string), {})<br/>    cleanup_policies = optional(map(object({<br/>      action               = optional(string, "DELETE")<br/>      most_recent_versions = optional(number)<br/>      condition = optional(object({<br/>        tag_state             = optional(string, "ANY")<br/>        tag_prefixes          = optional(list(string))<br/>        version_name_prefixes = optional(list(string))<br/>        package_name_prefixes = optional(list(string))<br/>        older_than            = optional(string)<br/>      }))<br/>    })), {})<br/>  }))</pre> | `{}` | no |
+| <a name="input_repository_iam"></a> [repository\_iam](#input\_repository\_iam) | Map of repository\_id to list of {role, member} IAM bindings to grant on that repository | <pre>map(list(object({<br/>    role   = string<br/>    member = string<br/>  })))</pre> | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_repository_ids"></a> [repository\_ids](#output\_repository\_ids) | Map of repository key to its fully qualified ID |
+| <a name="output_repository_names"></a> [repository\_names](#output\_repository\_names) | Map of repository key to its repository\_id |
+| <a name="output_repository_urls"></a> [repository\_urls](#output\_repository\_urls) | Map of repository key to its pull/push URL (<location>-docker.pkg.dev/<project>/<repo>) |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/composition/artifact-registry/locals.tf
+++ b/terraform/gcp/modules/composition/artifact-registry/locals.tf
@@ -1,0 +1,20 @@
+locals {
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "managed_by"  = "terraform"
+    },
+    var.labels
+  )
+
+  repository_iam_flat = merge([
+    for repo, members in var.repository_iam : {
+      for member in members :
+      "${repo}-${member.role}-${member.member}" => {
+        repository = repo
+        role       = member.role
+        member     = member.member
+      }
+    }
+  ]...)
+}

--- a/terraform/gcp/modules/composition/artifact-registry/main.tf
+++ b/terraform/gcp/modules/composition/artifact-registry/main.tf
@@ -1,0 +1,86 @@
+# ============================================================================
+# Artifact Registry (GCP equivalent of composition/ecr)
+# ============================================================================
+# Creates one Docker-format Artifact Registry repository per entry in
+# var.repositories, mirroring the AWS ecr module's for_each-over-repos shape.
+# Repository-level IAM is granted directly (repositories are the natural
+# permission boundary on Artifact Registry, unlike ECR's account-wide policy
+# style).
+#
+# Usage:
+#   module "artifact_registry" {
+#     source = "../../modules/composition/artifact-registry"
+#
+#     project_id  = "hyperswitch-dev"
+#     environment = "dev"
+#     location    = "europe-west1"
+#
+#     repositories = {
+#       hyperswitch = {
+#         cleanup_policies = { keep-recent = { action = "KEEP", most_recent_versions = 10 } }
+#       }
+#     }
+#   }
+# ============================================================================
+
+resource "google_artifact_registry_repository" "this" {
+  for_each = var.repositories
+
+  project       = var.project_id
+  location      = var.location
+  repository_id = each.key
+  description   = try(each.value.description, "Hyperswitch ${each.key} repository")
+  format        = try(each.value.format, "DOCKER")
+  mode          = try(each.value.mode, "STANDARD_REPOSITORY")
+
+  kms_key_name = try(each.value.kms_key_name, null)
+
+  dynamic "docker_config" {
+    for_each = try(each.value.immutable_tags, false) ? [1] : []
+    content {
+      immutable_tags = true
+    }
+  }
+
+  dynamic "cleanup_policies" {
+    for_each = try(each.value.cleanup_policies, {})
+    content {
+      id     = cleanup_policies.key
+      action = try(cleanup_policies.value.action, "DELETE")
+
+      dynamic "condition" {
+        for_each = try(cleanup_policies.value.action, "DELETE") != "KEEP" ? [try(cleanup_policies.value.condition, {})] : []
+        content {
+          tag_state             = try(condition.value.tag_state, "ANY")
+          tag_prefixes          = try(condition.value.tag_prefixes, null)
+          version_name_prefixes = try(condition.value.version_name_prefixes, null)
+          package_name_prefixes = try(condition.value.package_name_prefixes, null)
+          older_than            = try(condition.value.older_than, null)
+        }
+      }
+
+      dynamic "most_recent_versions" {
+        for_each = try(cleanup_policies.value.action, "DELETE") == "KEEP" ? [try(cleanup_policies.value, {})] : []
+        content {
+          package_name_prefixes = try(most_recent_versions.value.package_name_prefixes, null)
+          keep_count            = try(most_recent_versions.value.most_recent_versions, 10)
+        }
+      }
+    }
+  }
+
+  labels = merge(local.common_labels, try(each.value.labels, {}))
+}
+
+# ==============================================================================
+# Repository IAM bindings
+# ==============================================================================
+resource "google_artifact_registry_repository_iam_member" "this" {
+  for_each = local.repository_iam_flat
+
+  project    = var.project_id
+  location   = var.location
+  repository = each.value.repository
+  role       = each.value.role
+  member     = each.value.member
+}

--- a/terraform/gcp/modules/composition/artifact-registry/outputs.tf
+++ b/terraform/gcp/modules/composition/artifact-registry/outputs.tf
@@ -1,0 +1,17 @@
+output "repository_ids" {
+  description = "Map of repository key to its fully qualified ID"
+  value       = { for k, v in google_artifact_registry_repository.this : k => v.id }
+}
+
+output "repository_names" {
+  description = "Map of repository key to its repository_id"
+  value       = { for k, v in google_artifact_registry_repository.this : k => v.repository_id }
+}
+
+output "repository_urls" {
+  description = "Map of repository key to its pull/push URL (<location>-docker.pkg.dev/<project>/<repo>)"
+  value = {
+    for k, v in google_artifact_registry_repository.this :
+    k => "${var.location}-docker.pkg.dev/${var.project_id}/${v.repository_id}"
+  }
+}

--- a/terraform/gcp/modules/composition/artifact-registry/variables.tf
+++ b/terraform/gcp/modules/composition/artifact-registry/variables.tf
@@ -1,0 +1,53 @@
+variable "project_id" {
+  description = "GCP project ID where repositories are created"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "location" {
+  description = "Location for the repositories (region, e.g. europe-west1)"
+  type        = string
+}
+
+variable "repositories" {
+  description = "Map of repositories to create, keyed by repository_id"
+  type = map(object({
+    description    = optional(string)
+    format         = optional(string, "DOCKER")
+    mode           = optional(string, "STANDARD_REPOSITORY")
+    kms_key_name   = optional(string)
+    immutable_tags = optional(bool, false)
+    labels         = optional(map(string), {})
+    cleanup_policies = optional(map(object({
+      action               = optional(string, "DELETE")
+      most_recent_versions = optional(number)
+      condition = optional(object({
+        tag_state             = optional(string, "ANY")
+        tag_prefixes          = optional(list(string))
+        version_name_prefixes = optional(list(string))
+        package_name_prefixes = optional(list(string))
+        older_than            = optional(string)
+      }))
+    })), {})
+  }))
+  default = {}
+}
+
+variable "repository_iam" {
+  description = "Map of repository_id to list of {role, member} IAM bindings to grant on that repository"
+  type = map(list(object({
+    role   = string
+    member = string
+  })))
+  default = {}
+}
+
+variable "labels" {
+  description = "Additional labels applied to every repository"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/composition/artifact-registry/versions.tf
+++ b/terraform/gcp/modules/composition/artifact-registry/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/composition/bastion-host/README.md
+++ b/terraform/gcp/modules/composition/bastion-host/README.md
@@ -2,34 +2,34 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_bastion_host"></a> [bastion\_host](#module\_bastion\_host) | terraform-google-modules/bastion-host/google | 9.0.0 |
 | <a name="module_session_log_bucket"></a> [session\_log\_bucket](#module\_session\_log\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
 
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google_logging_project_sink.session_logs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_project_sink) | resource |
 | [google_storage_bucket_iam_member.session_log_sink_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Boot disk size in GB | `number` | `20` | no |
 | <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Persistent disk type | `string` | `"pd-balanced"` | no |
 | <a name="input_enable_session_logging"></a> [enable\_session\_logging](#input\_enable\_session\_logging) | Whether to create a GCS bucket + log sink capturing bastion session/audit logs | `bool` | `true` | no |
@@ -52,7 +52,7 @@
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_instance_name"></a> [instance\_name](#output\_instance\_name) | Name of the bastion instance |
 | <a name="output_instance_self_link"></a> [instance\_self\_link](#output\_instance\_self\_link) | Self-link of the bastion instance |
 | <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of the bastion's service account |

--- a/terraform/gcp/modules/composition/bastion-host/README.md
+++ b/terraform/gcp/modules/composition/bastion-host/README.md
@@ -1,0 +1,60 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_bastion_host"></a> [bastion\_host](#module\_bastion\_host) | terraform-google-modules/bastion-host/google | 9.0.0 |
+| <a name="module_session_log_bucket"></a> [session\_log\_bucket](#module\_session\_log\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_logging_project_sink.session_logs](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_project_sink) | resource |
+| [google_storage_bucket_iam_member.session_log_sink_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Boot disk size in GB | `number` | `20` | no |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Persistent disk type | `string` | `"pd-balanced"` | no |
+| <a name="input_enable_session_logging"></a> [enable\_session\_logging](#input\_enable\_session\_logging) | Whether to create a GCS bucket + log sink capturing bastion session/audit logs | `bool` | `true` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_image"></a> [image](#input\_image) | Specific image self-link to boot from. Null uses image\_family/image\_project instead | `string` | `null` | no |
+| <a name="input_image_family"></a> [image\_family](#input\_image\_family) | Image family to boot from, used when image is null | `string` | `"debian-12"` | no |
+| <a name="input_image_project"></a> [image\_project](#input\_image\_project) | Project the boot image/family belongs to | `string` | `"debian-cloud"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_log_bucket_location"></a> [log\_bucket\_location](#input\_log\_bucket\_location) | Location for the session log bucket | `string` | `"US"` | no |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Machine type for the bastion instance | `string` | `"e2-small"` | no |
+| <a name="input_members"></a> [members](#input\_members) | List of IAM members (users/groups/service accounts) granted IAP-tunnel SSH access to the bastion | `list(string)` | `[]` | no |
+| <a name="input_network"></a> [network](#input\_network) | Self-link of the VPC network | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where the bastion is created | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name used for naming resources | `string` | `"hyperswitch"` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region for regional resources | `string` | n/a | yes |
+| <a name="input_session_log_retention_days"></a> [session\_log\_retention\_days](#input\_session\_log\_retention\_days) | Number of days to retain session log objects before deletion | `number` | `365` | no |
+| <a name="input_subnet"></a> [subnet](#input\_subnet) | Self-link of the subnetwork for the bastion (typically the management tier) | `string` | n/a | yes |
+| <a name="input_zone"></a> [zone](#input\_zone) | Zone to create the bastion instance in | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_instance_name"></a> [instance\_name](#output\_instance\_name) | Name of the bastion instance |
+| <a name="output_instance_self_link"></a> [instance\_self\_link](#output\_instance\_self\_link) | Self-link of the bastion instance |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of the bastion's service account |
+| <a name="output_session_log_bucket_name"></a> [session\_log\_bucket\_name](#output\_session\_log\_bucket\_name) | Name of the session log bucket, if enabled |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/composition/bastion-host/locals.tf
+++ b/terraform/gcp/modules/composition/bastion-host/locals.tf
@@ -1,0 +1,13 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}-bastion"
+
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "component"   = "bastion-host"
+      "managed_by"  = "terraform"
+    },
+    var.labels
+  )
+}

--- a/terraform/gcp/modules/composition/bastion-host/main.tf
+++ b/terraform/gcp/modules/composition/bastion-host/main.tf
@@ -1,0 +1,101 @@
+# ============================================================================
+# Bastion Host (GCP equivalent of composition/jump-host)
+# ============================================================================
+# IAP-tunneled bastion with no public IP, matching the AWS module's
+# SSM-Session-Manager-only jump host (no public IP, no bastion SSH key
+# distribution). Session activity is captured via Cloud Logging by default;
+# a dedicated GCS bucket + log sink give the same durable-audit-trail
+# behavior as the AWS module's S3 + CloudWatch log groups.
+#
+# Usage:
+#   module "bastion_host" {
+#     source = "../../modules/composition/bastion-host"
+#
+#     project_id  = "hyperswitch-dev"
+#     environment = "dev"
+#     region      = "europe-west1"
+#     zone        = "europe-west1-b"
+#     network     = module.vpc_network.network_self_link
+#     subnet      = module.vpc_network.subnets_by_tier["management"]
+#
+#     members = ["group:platform-team@example.com"]
+#   }
+# ============================================================================
+
+module "bastion_host" {
+  source  = "terraform-google-modules/bastion-host/google"
+  version = "9.0.0"
+
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+
+  network = var.network
+  subnet  = var.subnet
+
+  name         = "${local.name_prefix}-vm"
+  machine_type = var.machine_type
+  disk_size_gb = var.disk_size_gb
+  disk_type    = var.disk_type
+
+  image         = var.image
+  image_family  = var.image == null ? var.image_family : null
+  image_project = var.image_project
+
+  members = var.members
+
+  service_account_roles = [
+    "roles/logging.logWriter",
+    "roles/monitoring.metricWriter",
+  ]
+
+  labels = local.common_labels
+  tags   = ["bastion-host", "iap-ssh"]
+
+  shielded_vm = true
+}
+
+# ==============================================================================
+# Session logging (equivalent of the AWS module's S3 + CloudWatch log groups)
+# ==============================================================================
+module "session_log_bucket" {
+  source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
+  version = "12.3.0"
+
+  count = var.enable_session_logging ? 1 : 0
+
+  project_id    = var.project_id
+  name          = "${local.name_prefix}-session-logs"
+  location      = var.log_bucket_location
+  force_destroy = false
+
+  versioning         = true
+  bucket_policy_only = true
+
+  lifecycle_rules = [{
+    action    = { type = "Delete" }
+    condition = { age = var.session_log_retention_days }
+  }]
+
+  labels = local.common_labels
+}
+
+resource "google_logging_project_sink" "session_logs" {
+  count = var.enable_session_logging ? 1 : 0
+
+  project     = var.project_id
+  name        = "${local.name_prefix}-session-log-sink"
+  destination = "storage.googleapis.com/${module.session_log_bucket[0].name}"
+
+  filter = "resource.type=\"gce_instance\" AND resource.labels.instance_id=\"${module.bastion_host.self_link}\" AND logName:\"cloudaudit.googleapis.com\""
+
+  unique_writer_identity = true
+}
+
+resource "google_storage_bucket_iam_member" "session_log_sink_writer" {
+  count = var.enable_session_logging ? 1 : 0
+
+  bucket = module.session_log_bucket[0].name
+  role   = "roles/storage.objectCreator"
+  member = google_logging_project_sink.session_logs[0].writer_identity
+}

--- a/terraform/gcp/modules/composition/bastion-host/outputs.tf
+++ b/terraform/gcp/modules/composition/bastion-host/outputs.tf
@@ -1,0 +1,19 @@
+output "instance_name" {
+  description = "Name of the bastion instance"
+  value       = module.bastion_host.hostname
+}
+
+output "instance_self_link" {
+  description = "Self-link of the bastion instance"
+  value       = module.bastion_host.self_link
+}
+
+output "service_account_email" {
+  description = "Email of the bastion's service account"
+  value       = module.bastion_host.service_account
+}
+
+output "session_log_bucket_name" {
+  description = "Name of the session log bucket, if enabled"
+  value       = var.enable_session_logging ? module.session_log_bucket[0].name : null
+}

--- a/terraform/gcp/modules/composition/bastion-host/variables.tf
+++ b/terraform/gcp/modules/composition/bastion-host/variables.tf
@@ -1,0 +1,101 @@
+variable "project_id" {
+  description = "GCP project ID where the bastion is created"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name used for naming resources"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "region" {
+  description = "Region for regional resources"
+  type        = string
+}
+
+variable "zone" {
+  description = "Zone to create the bastion instance in"
+  type        = string
+}
+
+variable "network" {
+  description = "Self-link of the VPC network"
+  type        = string
+}
+
+variable "subnet" {
+  description = "Self-link of the subnetwork for the bastion (typically the management tier)"
+  type        = string
+}
+
+variable "machine_type" {
+  description = "Machine type for the bastion instance"
+  type        = string
+  default     = "e2-small"
+}
+
+variable "disk_size_gb" {
+  description = "Boot disk size in GB"
+  type        = number
+  default     = 20
+}
+
+variable "disk_type" {
+  description = "Persistent disk type"
+  type        = string
+  default     = "pd-balanced"
+}
+
+variable "image" {
+  description = "Specific image self-link to boot from. Null uses image_family/image_project instead"
+  type        = string
+  default     = null
+}
+
+variable "image_family" {
+  description = "Image family to boot from, used when image is null"
+  type        = string
+  default     = "debian-12"
+}
+
+variable "image_project" {
+  description = "Project the boot image/family belongs to"
+  type        = string
+  default     = "debian-cloud"
+}
+
+variable "members" {
+  description = "List of IAM members (users/groups/service accounts) granted IAP-tunnel SSH access to the bastion"
+  type        = list(string)
+  default     = []
+}
+
+variable "enable_session_logging" {
+  description = "Whether to create a GCS bucket + log sink capturing bastion session/audit logs"
+  type        = bool
+  default     = true
+}
+
+variable "log_bucket_location" {
+  description = "Location for the session log bucket"
+  type        = string
+  default     = "US"
+}
+
+variable "session_log_retention_days" {
+  description = "Number of days to retain session log objects before deletion"
+  type        = number
+  default     = 365
+}
+
+variable "labels" {
+  description = "Additional labels to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/composition/bastion-host/versions.tf
+++ b/terraform/gcp/modules/composition/bastion-host/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/composition/cassandra/README.md
+++ b/terraform/gcp/modules/composition/cassandra/README.md
@@ -2,20 +2,20 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_node_instances"></a> [node\_instances](#module\_node\_instances) | terraform-google-modules/vm/google//modules/compute_instance | 15.2.1 |
 | <a name="module_node_template"></a> [node\_template](#module\_node\_template) | terraform-google-modules/vm/google//modules/instance_template | 15.2.1 |
 | <a name="module_seed_discovery"></a> [seed\_discovery](#module\_seed\_discovery) | GoogleCloudPlatform/cloud-functions/google | 0.9.0 |
@@ -24,13 +24,13 @@
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google_compute_address.node](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Data disk size in GB per node | `number` | `500` | no |
 | <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Persistent disk type | `string` | `"pd-ssd"` | no |
 | <a name="input_enable_seed_discovery"></a> [enable\_seed\_discovery](#input\_enable\_seed\_discovery) | Whether to create the seed-discovery Cloud Function | `bool` | `true` | no |
@@ -53,7 +53,7 @@
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_node_instance_self_links"></a> [node\_instance\_self\_links](#output\_node\_instance\_self\_links) | Self-links of the Cassandra node instances |
 | <a name="output_node_internal_ips"></a> [node\_internal\_ips](#output\_node\_internal\_ips) | Static internal IP addresses assigned to Cassandra nodes |
 | <a name="output_seed_discovery_function_uri"></a> [seed\_discovery\_function\_uri](#output\_seed\_discovery\_function\_uri) | HTTPS URI of the seed-discovery function, if enabled |

--- a/terraform/gcp/modules/composition/cassandra/README.md
+++ b/terraform/gcp/modules/composition/cassandra/README.md
@@ -1,0 +1,61 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_node_instances"></a> [node\_instances](#module\_node\_instances) | terraform-google-modules/vm/google//modules/compute_instance | 15.2.1 |
+| <a name="module_node_template"></a> [node\_template](#module\_node\_template) | terraform-google-modules/vm/google//modules/instance_template | 15.2.1 |
+| <a name="module_seed_discovery"></a> [seed\_discovery](#module\_seed\_discovery) | GoogleCloudPlatform/cloud-functions/google | 0.9.0 |
+| <a name="module_service_account"></a> [service\_account](#module\_service\_account) | terraform-google-modules/service-accounts/google | 4.7.0 |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_compute_address.node](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Data disk size in GB per node | `number` | `500` | no |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Persistent disk type | `string` | `"pd-ssd"` | no |
+| <a name="input_enable_seed_discovery"></a> [enable\_seed\_discovery](#input\_enable\_seed\_discovery) | Whether to create the seed-discovery Cloud Function | `bool` | `true` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Machine type for Cassandra node instances | `string` | `"n2-standard-4"` | no |
+| <a name="input_metadata"></a> [metadata](#input\_metadata) | Additional instance metadata (e.g. startup-script parameters) | `map(string)` | `{}` | no |
+| <a name="input_network"></a> [network](#input\_network) | Self-link of the VPC network | `string` | n/a | yes |
+| <a name="input_node_count"></a> [node\_count](#input\_node\_count) | Number of Cassandra node instances | `number` | `3` | no |
+| <a name="input_node_image"></a> [node\_image](#input\_node\_image) | Self-link or family of the custom image with Cassandra pre-installed | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where instances are created | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name used for naming resources | `string` | `"hyperswitch"` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region for regional resources (addresses, instance templates, the seed-discovery function) | `string` | n/a | yes |
+| <a name="input_seed_discovery_entrypoint"></a> [seed\_discovery\_entrypoint](#input\_seed\_discovery\_entrypoint) | Entrypoint function name in the seed-discovery source | `string` | `"get_seeds"` | no |
+| <a name="input_seed_discovery_runtime"></a> [seed\_discovery\_runtime](#input\_seed\_discovery\_runtime) | Cloud Functions runtime for the seed-discovery function | `string` | `"python312"` | no |
+| <a name="input_seed_discovery_source"></a> [seed\_discovery\_source](#input\_seed\_discovery\_source) | GCS location of the seed-discovery function source zip: {bucket, object} | <pre>object({<br/>    bucket     = string<br/>    object     = string<br/>    generation = optional(string)<br/>  })</pre> | `null` | no |
+| <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | Self-link of the subnetwork (typically the data-stack tier from composition/vpc-network) | `string` | n/a | yes |
+| <a name="input_zone"></a> [zone](#input\_zone) | Zone to create instances in | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_node_instance_self_links"></a> [node\_instance\_self\_links](#output\_node\_instance\_self\_links) | Self-links of the Cassandra node instances |
+| <a name="output_node_internal_ips"></a> [node\_internal\_ips](#output\_node\_internal\_ips) | Static internal IP addresses assigned to Cassandra nodes |
+| <a name="output_seed_discovery_function_uri"></a> [seed\_discovery\_function\_uri](#output\_seed\_discovery\_function\_uri) | HTTPS URI of the seed-discovery function, if enabled |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of the shared node service account |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/composition/cassandra/locals.tf
+++ b/terraform/gcp/modules/composition/cassandra/locals.tf
@@ -1,0 +1,13 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}-cassandra"
+
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "component"   = "cassandra"
+      "managed_by"  = "terraform"
+    },
+    var.labels
+  )
+}

--- a/terraform/gcp/modules/composition/cassandra/main.tf
+++ b/terraform/gcp/modules/composition/cassandra/main.tf
@@ -1,0 +1,128 @@
+# ============================================================================
+# Cassandra on Compute Engine - GCP equivalent of composition/cassandra
+# ============================================================================
+# Provisions a Cassandra node fleet from a pre-baked custom image with
+# static internal IPs (Cassandra's seed-list config needs fixed addresses,
+# same as the AWS module's ENI approach), plus a seed-discovery HTTP
+# function so new nodes can look up the current seed list at boot time.
+#
+# The AWS module's Lambda + API Gateway pair becomes a single Cloud Run
+# function (2nd gen) with an HTTPS trigger - GCP does not need a separate
+# API Gateway resource for a simple HTTP-triggered function.
+#
+# Usage:
+#   module "cassandra" {
+#     source = "../../modules/composition/cassandra"
+#
+#     project_id  = "hyperswitch-dev"
+#     environment = "dev"
+#     zone        = "europe-west1-b"
+#     network     = module.vpc_network.network_self_link
+#     subnetwork  = module.vpc_network.subnets_by_tier["data-stack"]
+#     node_image  = "projects/hyperswitch-dev/global/images/cassandra-v1"
+#
+#     seed_discovery_source = {
+#       bucket = module.function_source_bucket.name
+#       object = "cassandra-seed-discovery.zip"
+#     }
+#   }
+# ============================================================================
+
+module "service_account" {
+  source  = "terraform-google-modules/service-accounts/google"
+  version = "4.7.0"
+
+  project_id = var.project_id
+  names      = ["${local.name_prefix}-node"]
+  project_roles = [
+    "${var.project_id}=>roles/logging.logWriter",
+    "${var.project_id}=>roles/monitoring.metricWriter",
+  ]
+}
+
+resource "google_compute_address" "node" {
+  count = var.node_count
+
+  project      = var.project_id
+  name         = "${local.name_prefix}-${count.index}"
+  region       = var.region
+  subnetwork   = var.subnetwork
+  address_type = "INTERNAL"
+}
+
+module "node_template" {
+  source  = "terraform-google-modules/vm/google//modules/instance_template"
+  version = "15.2.1"
+
+  project_id   = var.project_id
+  region       = var.region
+  name_prefix  = local.name_prefix
+  machine_type = var.machine_type
+
+  source_image = var.node_image
+  disk_size_gb = var.disk_size_gb
+  disk_type    = var.disk_type
+
+  network    = var.network
+  subnetwork = var.subnetwork
+
+  service_account = {
+    email  = module.service_account.email
+    scopes = ["cloud-platform"]
+  }
+
+  tags     = ["cassandra-node"]
+  labels   = local.common_labels
+  metadata = var.metadata
+}
+
+module "node_instances" {
+  source  = "terraform-google-modules/vm/google//modules/compute_instance"
+  version = "15.2.1"
+
+  project_id        = var.project_id
+  region            = var.region
+  zone              = var.zone
+  hostname          = local.name_prefix
+  num_instances     = var.node_count
+  instance_template = module.node_template.self_link
+  static_ips        = [for addr in google_compute_address.node : addr.address]
+  labels            = local.common_labels
+}
+
+# ==============================================================================
+# Seed Discovery Function (replaces AWS Lambda + API Gateway)
+# ==============================================================================
+module "seed_discovery" {
+  source  = "GoogleCloudPlatform/cloud-functions/google"
+  version = "0.9.0"
+
+  count = var.enable_seed_discovery ? 1 : 0
+
+  project_id        = var.project_id
+  function_name     = "${local.name_prefix}-seed-discovery"
+  function_location = var.region
+  location          = var.region
+  description       = "Returns the current Cassandra seed node IP list"
+  runtime           = var.seed_discovery_runtime
+  entrypoint        = var.seed_discovery_entrypoint
+
+  storage_source = var.seed_discovery_source
+
+  service_config = {
+    max_instance_count = 5
+    min_instance_count = 0
+    available_memory   = "256M"
+    available_cpu      = "1"
+    timeout_seconds    = 30
+    runtime_env_variables = {
+      SEED_IPS = join(",", [for addr in google_compute_address.node : addr.address])
+    }
+  }
+
+  members = {
+    invokers = ["serviceAccount:${module.service_account.email}"]
+  }
+
+  labels = local.common_labels
+}

--- a/terraform/gcp/modules/composition/cassandra/outputs.tf
+++ b/terraform/gcp/modules/composition/cassandra/outputs.tf
@@ -1,0 +1,19 @@
+output "node_internal_ips" {
+  description = "Static internal IP addresses assigned to Cassandra nodes"
+  value       = [for addr in google_compute_address.node : addr.address]
+}
+
+output "node_instance_self_links" {
+  description = "Self-links of the Cassandra node instances"
+  value       = module.node_instances.instances_self_links
+}
+
+output "service_account_email" {
+  description = "Email of the shared node service account"
+  value       = module.service_account.email
+}
+
+output "seed_discovery_function_uri" {
+  description = "HTTPS URI of the seed-discovery function, if enabled"
+  value       = var.enable_seed_discovery ? module.seed_discovery[0].function_uri : null
+}

--- a/terraform/gcp/modules/composition/cassandra/variables.tf
+++ b/terraform/gcp/modules/composition/cassandra/variables.tf
@@ -1,0 +1,104 @@
+variable "project_id" {
+  description = "GCP project ID where instances are created"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name used for naming resources"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "region" {
+  description = "Region for regional resources (addresses, instance templates, the seed-discovery function)"
+  type        = string
+}
+
+variable "zone" {
+  description = "Zone to create instances in"
+  type        = string
+}
+
+variable "network" {
+  description = "Self-link of the VPC network"
+  type        = string
+}
+
+variable "subnetwork" {
+  description = "Self-link of the subnetwork (typically the data-stack tier from composition/vpc-network)"
+  type        = string
+}
+
+variable "node_image" {
+  description = "Self-link or family of the custom image with Cassandra pre-installed"
+  type        = string
+}
+
+variable "node_count" {
+  description = "Number of Cassandra node instances"
+  type        = number
+  default     = 3
+}
+
+variable "machine_type" {
+  description = "Machine type for Cassandra node instances"
+  type        = string
+  default     = "n2-standard-4"
+}
+
+variable "disk_size_gb" {
+  description = "Data disk size in GB per node"
+  type        = number
+  default     = 500
+}
+
+variable "disk_type" {
+  description = "Persistent disk type"
+  type        = string
+  default     = "pd-ssd"
+}
+
+variable "metadata" {
+  description = "Additional instance metadata (e.g. startup-script parameters)"
+  type        = map(string)
+  default     = {}
+}
+
+variable "enable_seed_discovery" {
+  description = "Whether to create the seed-discovery Cloud Function"
+  type        = bool
+  default     = true
+}
+
+variable "seed_discovery_source" {
+  description = "GCS location of the seed-discovery function source zip: {bucket, object}"
+  type = object({
+    bucket     = string
+    object     = string
+    generation = optional(string)
+  })
+  default = null
+}
+
+variable "seed_discovery_runtime" {
+  description = "Cloud Functions runtime for the seed-discovery function"
+  type        = string
+  default     = "python312"
+}
+
+variable "seed_discovery_entrypoint" {
+  description = "Entrypoint function name in the seed-discovery source"
+  type        = string
+  default     = "get_seeds"
+}
+
+variable "labels" {
+  description = "Additional labels to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/composition/cassandra/versions.tf
+++ b/terraform/gcp/modules/composition/cassandra/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/composition/certificate-manager/README.md
+++ b/terraform/gcp/modules/composition/certificate-manager/README.md
@@ -1,0 +1,49 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_certificate_manager_certificate.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/certificate_manager_certificate) | resource |
+| [google_certificate_manager_certificate_map.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/certificate_manager_certificate_map) | resource |
+| [google_certificate_manager_certificate_map_entry.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/certificate_manager_certificate_map_entry) | resource |
+| [google_certificate_manager_dns_authorization.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/certificate_manager_dns_authorization) | resource |
+| [google_compute_managed_ssl_certificate.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_managed_ssl_certificate) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_certificates"></a> [certificates](#input\_certificates) | Map of certificate configurations. Each key represents a certificate name.<br/>Example:<br/>certificates = {<br/>  "api" = {<br/>    domain\_name               = "api.dev.hyperswitch.example.com"<br/>    subject\_alternative\_names = []<br/>    validation\_method         = "DNS"<br/>  }<br/>} | <pre>map(object({<br/>    domain_name                    = string<br/>    subject_alternative_names      = optional(list(string), [])<br/>    validation_method              = optional(string, "DNS")<br/>    create_classic_ssl_certificate = optional(bool, false)<br/>    labels                         = optional(map(string), {})<br/>  }))</pre> | `{}` | no |
+| <a name="input_create_certificate_map"></a> [create\_certificate\_map](#input\_create\_certificate\_map) | Whether to create a Certificate Manager certificate map + entry per certificate, for attaching to a target proxy via certificate\_map | `bool` | `true` | no |
+| <a name="input_dns_authorization_type"></a> [dns\_authorization\_type](#input\_dns\_authorization\_type) | DNS authorization type: FIXED\_RECORD or PER\_PROJECT\_RECORD | `string` | `"FIXED_RECORD"` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where certificates are created | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name for resource naming | `string` | `"hyperswitch"` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_certificate_ids"></a> [certificate\_ids](#output\_certificate\_ids) | Map of certificate key to its Certificate Manager certificate ID |
+| <a name="output_certificate_map_ids"></a> [certificate\_map\_ids](#output\_certificate\_map\_ids) | Map of certificate key to its certificate map ID, for attaching to a target proxy's certificate\_map |
+| <a name="output_classic_ssl_certificate_ids"></a> [classic\_ssl\_certificate\_ids](#output\_classic\_ssl\_certificate\_ids) | Map of certificate key to its classic google\_compute\_managed\_ssl\_certificate ID, for callers using the classic target-proxy ssl\_certificates attribute |
+| <a name="output_dns_authorization_records"></a> [dns\_authorization\_records](#output\_dns\_authorization\_records) | Map of domain to the DNS record {type, name, data} that must be published (e.g. via composition/cloud-dns) to complete DNS authorization - the equivalent of ACM's validation CNAME |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/composition/certificate-manager/README.md
+++ b/terraform/gcp/modules/composition/certificate-manager/README.md
@@ -2,14 +2,14 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
 
 ## Modules
@@ -19,7 +19,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google_certificate_manager_certificate.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/certificate_manager_certificate) | resource |
 | [google_certificate_manager_certificate_map.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/certificate_manager_certificate_map) | resource |
 | [google_certificate_manager_certificate_map_entry.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/certificate_manager_certificate_map_entry) | resource |
@@ -29,7 +29,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_certificates"></a> [certificates](#input\_certificates) | Map of certificate configurations. Each key represents a certificate name.<br/>Example:<br/>certificates = {<br/>  "api" = {<br/>    domain\_name               = "api.dev.hyperswitch.example.com"<br/>    subject\_alternative\_names = []<br/>    validation\_method         = "DNS"<br/>  }<br/>} | <pre>map(object({<br/>    domain_name                    = string<br/>    subject_alternative_names      = optional(list(string), [])<br/>    validation_method              = optional(string, "DNS")<br/>    create_classic_ssl_certificate = optional(bool, false)<br/>    labels                         = optional(map(string), {})<br/>  }))</pre> | `{}` | no |
 | <a name="input_create_certificate_map"></a> [create\_certificate\_map](#input\_create\_certificate\_map) | Whether to create a Certificate Manager certificate map + entry per certificate, for attaching to a target proxy via certificate\_map | `bool` | `true` | no |
 | <a name="input_dns_authorization_type"></a> [dns\_authorization\_type](#input\_dns\_authorization\_type) | DNS authorization type: FIXED\_RECORD or PER\_PROJECT\_RECORD | `string` | `"FIXED_RECORD"` | no |
@@ -41,7 +41,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_certificate_ids"></a> [certificate\_ids](#output\_certificate\_ids) | Map of certificate key to its Certificate Manager certificate ID |
 | <a name="output_certificate_map_ids"></a> [certificate\_map\_ids](#output\_certificate\_map\_ids) | Map of certificate key to its certificate map ID, for attaching to a target proxy's certificate\_map |
 | <a name="output_classic_ssl_certificate_ids"></a> [classic\_ssl\_certificate\_ids](#output\_classic\_ssl\_certificate\_ids) | Map of certificate key to its classic google\_compute\_managed\_ssl\_certificate ID, for callers using the classic target-proxy ssl\_certificates attribute |

--- a/terraform/gcp/modules/composition/certificate-manager/locals.tf
+++ b/terraform/gcp/modules/composition/certificate-manager/locals.tf
@@ -1,0 +1,19 @@
+locals {
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "component"   = "certificate-manager"
+      "managed_by"  = "terraform"
+    },
+    var.labels
+  )
+
+  # Flatten {cert_key -> domain_name + sans} into one DNS authorization per
+  # unique domain, since google_certificate_manager_dns_authorization is
+  # per-domain, not per-certificate.
+  dns_authorization_domains = distinct(flatten([
+    for key, cert in var.certificates : concat([cert.domain_name], cert.subject_alternative_names)
+    if cert.validation_method == "DNS"
+  ]))
+}

--- a/terraform/gcp/modules/composition/certificate-manager/main.tf
+++ b/terraform/gcp/modules/composition/certificate-manager/main.tf
@@ -1,0 +1,96 @@
+# ============================================================================
+# Certificate Manager (GCP equivalent of composition/acm)
+# ============================================================================
+# No official terraform-google-modules/GoogleCloudPlatform registry module
+# covers Certificate Manager, so this module wraps the raw resources
+# directly, keeping the same for_each-over-certificates shape as the AWS acm
+# module: one map entry in, one managed certificate out.
+#
+# Google-managed certificates require DNS authorization records to be
+# published (see the `dns_authorization_records` output) before validation
+# completes - the equivalent of ACM's DNS validation CNAME. Unlike ACM this
+# module does not create the DNS records itself (composition/cloud-dns owns
+# that), matching the AWS acm module's create_route53_records=false default
+# for cross-module wiring.
+#
+# A classic google_compute_managed_ssl_certificate is also created per
+# certificate for callers still using the classic (non-Certificate-Manager)
+# External HTTPS Load Balancer target-proxy attachment.
+#
+# Usage:
+#   module "certificate_manager" {
+#     source = "../../modules/composition/certificate-manager"
+#
+#     project_id  = "hyperswitch-dev"
+#     environment = "dev"
+#
+#     certificates = {
+#       api = {
+#         domain_name               = "api.dev.hyperswitch.example.com"
+#         subject_alternative_names = []
+#       }
+#     }
+#   }
+# ============================================================================
+
+resource "google_certificate_manager_dns_authorization" "this" {
+  for_each = toset(local.dns_authorization_domains)
+
+  project  = var.project_id
+  name     = replace("${var.environment}-${var.project_name}-${each.key}", ".", "-")
+  domain   = each.key
+  location = "global"
+  type     = var.dns_authorization_type
+  labels   = local.common_labels
+}
+
+resource "google_certificate_manager_certificate" "this" {
+  for_each = var.certificates
+
+  project  = var.project_id
+  name     = "${var.environment}-${var.project_name}-${each.key}-cert"
+  location = "global"
+  labels   = merge(local.common_labels, try(each.value.labels, {}))
+
+  managed {
+    domains = concat([each.value.domain_name], each.value.subject_alternative_names)
+    dns_authorizations = [
+      for domain in concat([each.value.domain_name], each.value.subject_alternative_names) :
+      google_certificate_manager_dns_authorization.this[domain].id
+      if each.value.validation_method == "DNS"
+    ]
+  }
+}
+
+resource "google_certificate_manager_certificate_map" "this" {
+  for_each = var.create_certificate_map ? var.certificates : {}
+
+  project = var.project_id
+  name    = "${var.environment}-${var.project_name}-${each.key}-map"
+  labels  = local.common_labels
+}
+
+resource "google_certificate_manager_certificate_map_entry" "this" {
+  for_each = var.create_certificate_map ? var.certificates : {}
+
+  project      = var.project_id
+  name         = "${var.environment}-${var.project_name}-${each.key}-map-entry"
+  map          = google_certificate_manager_certificate_map.this[each.key].name
+  certificates = [google_certificate_manager_certificate.this[each.key].id]
+  hostname     = each.value.domain_name
+  labels       = local.common_labels
+}
+
+# ==============================================================================
+# Classic managed SSL certificate (for classic External HTTPS LB target proxies)
+# ==============================================================================
+resource "google_compute_managed_ssl_certificate" "this" {
+  for_each = { for key, cert in var.certificates : key => cert if cert.create_classic_ssl_certificate }
+
+  project = var.project_id
+  name    = "${var.environment}-${var.project_name}-${each.key}-classic-cert"
+
+  managed {
+    domains = concat([each.value.domain_name], each.value.subject_alternative_names)
+  }
+}

--- a/terraform/gcp/modules/composition/certificate-manager/outputs.tf
+++ b/terraform/gcp/modules/composition/certificate-manager/outputs.tf
@@ -1,0 +1,26 @@
+output "dns_authorization_records" {
+  description = "Map of domain to the DNS record {type, name, data} that must be published (e.g. via composition/cloud-dns) to complete DNS authorization - the equivalent of ACM's validation CNAME"
+  value = {
+    for domain, auth in google_certificate_manager_dns_authorization.this :
+    domain => {
+      type = auth.dns_resource_record[0].type
+      name = auth.dns_resource_record[0].name
+      data = auth.dns_resource_record[0].data
+    }
+  }
+}
+
+output "certificate_ids" {
+  description = "Map of certificate key to its Certificate Manager certificate ID"
+  value       = { for k, v in google_certificate_manager_certificate.this : k => v.id }
+}
+
+output "certificate_map_ids" {
+  description = "Map of certificate key to its certificate map ID, for attaching to a target proxy's certificate_map"
+  value       = { for k, v in google_certificate_manager_certificate_map.this : k => v.id }
+}
+
+output "classic_ssl_certificate_ids" {
+  description = "Map of certificate key to its classic google_compute_managed_ssl_certificate ID, for callers using the classic target-proxy ssl_certificates attribute"
+  value       = { for k, v in google_compute_managed_ssl_certificate.this : k => v.id }
+}

--- a/terraform/gcp/modules/composition/certificate-manager/variables.tf
+++ b/terraform/gcp/modules/composition/certificate-manager/variables.tf
@@ -1,0 +1,62 @@
+variable "project_id" {
+  description = "GCP project ID where certificates are created"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for resource naming"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "dns_authorization_type" {
+  description = "DNS authorization type: FIXED_RECORD or PER_PROJECT_RECORD"
+  type        = string
+  default     = "FIXED_RECORD"
+}
+
+variable "create_certificate_map" {
+  description = "Whether to create a Certificate Manager certificate map + entry per certificate, for attaching to a target proxy via certificate_map"
+  type        = bool
+  default     = true
+}
+
+variable "certificates" {
+  description = <<EOT
+Map of certificate configurations. Each key represents a certificate name.
+Example:
+certificates = {
+  "api" = {
+    domain_name               = "api.dev.hyperswitch.example.com"
+    subject_alternative_names = []
+    validation_method         = "DNS"
+  }
+}
+EOT
+  type = map(object({
+    domain_name                    = string
+    subject_alternative_names      = optional(list(string), [])
+    validation_method              = optional(string, "DNS")
+    create_classic_ssl_certificate = optional(bool, false)
+    labels                         = optional(map(string), {})
+  }))
+  default = {}
+
+  validation {
+    condition = alltrue([
+      for cert in var.certificates : contains(["DNS"], cert.validation_method)
+    ])
+    error_message = "validation_method must be 'DNS'; Certificate Manager only supports DNS authorization for Google-managed certificates."
+  }
+}
+
+variable "labels" {
+  description = "Additional labels to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/composition/certificate-manager/versions.tf
+++ b/terraform/gcp/modules/composition/certificate-manager/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/composition/clickhouse/README.md
+++ b/terraform/gcp/modules/composition/clickhouse/README.md
@@ -1,0 +1,73 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_internal_lb"></a> [internal\_lb](#module\_internal\_lb) | terraform-google-modules/lb-internal/google | 7.1.0 |
+| <a name="module_keeper_instances"></a> [keeper\_instances](#module\_keeper\_instances) | terraform-google-modules/vm/google//modules/compute_instance | 15.2.1 |
+| <a name="module_keeper_template"></a> [keeper\_template](#module\_keeper\_template) | terraform-google-modules/vm/google//modules/instance_template | 15.2.1 |
+| <a name="module_server_group"></a> [server\_group](#module\_server\_group) | terraform-google-modules/vm/google//modules/umig | 15.2.1 |
+| <a name="module_server_template"></a> [server\_template](#module\_server\_template) | terraform-google-modules/vm/google//modules/instance_template | 15.2.1 |
+| <a name="module_service_account"></a> [service\_account](#module\_service\_account) | terraform-google-modules/service-accounts/google | 4.7.0 |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_compute_address.keeper](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
+| [google_compute_attached_disk.keeper_data](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_attached_disk) | resource |
+| [google_compute_attached_disk.server_data](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_attached_disk) | resource |
+| [google_compute_disk.keeper_data](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk) | resource |
+| [google_compute_disk.server_data](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Persistent disk type used for both boot and data disks | `string` | `"pd-ssd"` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_keeper_boot_disk_size_gb"></a> [keeper\_boot\_disk\_size\_gb](#input\_keeper\_boot\_disk\_size\_gb) | Boot disk size in GB for keeper instances | `number` | `50` | no |
+| <a name="input_keeper_count"></a> [keeper\_count](#input\_keeper\_count) | Number of ClickHouse Keeper instances (should be odd for quorum) | `number` | `3` | no |
+| <a name="input_keeper_disk_size_gb"></a> [keeper\_disk\_size\_gb](#input\_keeper\_disk\_size\_gb) | Attached data disk size in GB per keeper instance | `number` | `50` | no |
+| <a name="input_keeper_image"></a> [keeper\_image](#input\_keeper\_image) | Self-link or family of the custom image with ClickHouse Keeper pre-installed | `string` | n/a | yes |
+| <a name="input_keeper_machine_type"></a> [keeper\_machine\_type](#input\_keeper\_machine\_type) | Machine type for keeper instances | `string` | `"n2-standard-2"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_lb_subnetwork"></a> [lb\_subnetwork](#input\_lb\_subnetwork) | Self-link of the subnetwork for the internal load balancer's forwarding rule | `string` | n/a | yes |
+| <a name="input_metadata"></a> [metadata](#input\_metadata) | Additional instance metadata applied to both tiers (e.g. startup-script parameters) | `map(string)` | `{}` | no |
+| <a name="input_network"></a> [network](#input\_network) | Self-link of the VPC network | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where instances are created | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name used for naming resources | `string` | `"hyperswitch"` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region for regional resources | `string` | n/a | yes |
+| <a name="input_server_boot_disk_size_gb"></a> [server\_boot\_disk\_size\_gb](#input\_server\_boot\_disk\_size\_gb) | Boot disk size in GB for server instances | `number` | `50` | no |
+| <a name="input_server_count"></a> [server\_count](#input\_server\_count) | Number of ClickHouse server instances | `number` | `2` | no |
+| <a name="input_server_disk_size_gb"></a> [server\_disk\_size\_gb](#input\_server\_disk\_size\_gb) | Attached data disk size in GB per server instance | `number` | `1000` | no |
+| <a name="input_server_http_port"></a> [server\_http\_port](#input\_server\_http\_port) | ClickHouse HTTP interface port | `number` | `8123` | no |
+| <a name="input_server_image"></a> [server\_image](#input\_server\_image) | Self-link or family of the custom image with the ClickHouse server pre-installed | `string` | n/a | yes |
+| <a name="input_server_machine_type"></a> [server\_machine\_type](#input\_server\_machine\_type) | Machine type for server instances | `string` | `"n2-standard-8"` | no |
+| <a name="input_server_native_port"></a> [server\_native\_port](#input\_server\_native\_port) | ClickHouse native TCP protocol port | `number` | `9000` | no |
+| <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | Self-link of the subnetwork for ClickHouse nodes | `string` | n/a | yes |
+| <a name="input_zone"></a> [zone](#input\_zone) | Zone to create instances in | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_internal_lb_ip_address"></a> [internal\_lb\_ip\_address](#output\_internal\_lb\_ip\_address) | IP address of the internal load balancer in front of the server tier |
+| <a name="output_keeper_instance_self_links"></a> [keeper\_instance\_self\_links](#output\_keeper\_instance\_self\_links) | Self-links of the ClickHouse keeper instances |
+| <a name="output_keeper_internal_ips"></a> [keeper\_internal\_ips](#output\_keeper\_internal\_ips) | Static internal IP addresses assigned to keeper instances |
+| <a name="output_server_instance_self_links"></a> [server\_instance\_self\_links](#output\_server\_instance\_self\_links) | Self-links of the ClickHouse server instances |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of the shared node service account |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/composition/clickhouse/README.md
+++ b/terraform/gcp/modules/composition/clickhouse/README.md
@@ -2,20 +2,20 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_internal_lb"></a> [internal\_lb](#module\_internal\_lb) | terraform-google-modules/lb-internal/google | 7.1.0 |
 | <a name="module_keeper_instances"></a> [keeper\_instances](#module\_keeper\_instances) | terraform-google-modules/vm/google//modules/compute_instance | 15.2.1 |
 | <a name="module_keeper_template"></a> [keeper\_template](#module\_keeper\_template) | terraform-google-modules/vm/google//modules/instance_template | 15.2.1 |
@@ -26,7 +26,7 @@
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google_compute_address.keeper](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
 | [google_compute_attached_disk.keeper_data](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_attached_disk) | resource |
 | [google_compute_attached_disk.server_data](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_attached_disk) | resource |
@@ -36,7 +36,7 @@
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Persistent disk type used for both boot and data disks | `string` | `"pd-ssd"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
 | <a name="input_keeper_boot_disk_size_gb"></a> [keeper\_boot\_disk\_size\_gb](#input\_keeper\_boot\_disk\_size\_gb) | Boot disk size in GB for keeper instances | `number` | `50` | no |
@@ -64,7 +64,7 @@
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_internal_lb_ip_address"></a> [internal\_lb\_ip\_address](#output\_internal\_lb\_ip\_address) | IP address of the internal load balancer in front of the server tier |
 | <a name="output_keeper_instance_self_links"></a> [keeper\_instance\_self\_links](#output\_keeper\_instance\_self\_links) | Self-links of the ClickHouse keeper instances |
 | <a name="output_keeper_internal_ips"></a> [keeper\_internal\_ips](#output\_keeper\_internal\_ips) | Static internal IP addresses assigned to keeper instances |

--- a/terraform/gcp/modules/composition/clickhouse/locals.tf
+++ b/terraform/gcp/modules/composition/clickhouse/locals.tf
@@ -1,0 +1,13 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}-clickhouse"
+
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "component"   = "clickhouse"
+      "managed_by"  = "terraform"
+    },
+    var.labels
+  )
+}

--- a/terraform/gcp/modules/composition/clickhouse/main.tf
+++ b/terraform/gcp/modules/composition/clickhouse/main.tf
@@ -1,0 +1,208 @@
+# ============================================================================
+# ClickHouse on Compute Engine - GCP equivalent of composition/clickhouse
+# ============================================================================
+# Server + keeper tiers on pre-baked custom images with static internal IPs
+# and dedicated persistent-disk data volumes, plus an internal TCP load
+# balancer in front of the server tier (replacing the AWS module's internal
+# ALB). Keeper nodes are addressed directly by static IP (ClickHouse Keeper,
+# like Cassandra, needs a fixed peer list) so they sit behind no load
+# balancer, matching the AWS module.
+#
+# Usage:
+#   module "clickhouse" {
+#     source = "../../modules/composition/clickhouse"
+#
+#     project_id    = "hyperswitch-dev"
+#     environment   = "dev"
+#     region        = "europe-west1"
+#     zone          = "europe-west1-b"
+#     network       = module.vpc_network.network_self_link
+#     subnetwork    = module.vpc_network.subnets_by_tier["data-stack"]
+#     lb_subnetwork = module.vpc_network.subnets_by_tier["data-stack"]
+#     server_image  = "projects/hyperswitch-dev/global/images/clickhouse-server-v1"
+#     keeper_image  = "projects/hyperswitch-dev/global/images/clickhouse-keeper-v1"
+#   }
+# ============================================================================
+
+module "service_account" {
+  source  = "terraform-google-modules/service-accounts/google"
+  version = "4.7.0"
+
+  project_id = var.project_id
+  names      = ["${local.name_prefix}-node"]
+  project_roles = [
+    "${var.project_id}=>roles/logging.logWriter",
+    "${var.project_id}=>roles/monitoring.metricWriter",
+  ]
+}
+
+# ==============================================================================
+# Keeper tier (fixed IPs, no load balancer - direct peer addressing)
+# ==============================================================================
+resource "google_compute_address" "keeper" {
+  count = var.keeper_count
+
+  project      = var.project_id
+  name         = "${local.name_prefix}-keeper-${count.index}"
+  region       = var.region
+  subnetwork   = var.subnetwork
+  address_type = "INTERNAL"
+}
+
+resource "google_compute_disk" "keeper_data" {
+  count = var.keeper_count
+
+  project = var.project_id
+  name    = "${local.name_prefix}-keeper-${count.index}-data"
+  zone    = var.zone
+  type    = var.disk_type
+  size    = var.keeper_disk_size_gb
+  labels  = local.common_labels
+}
+
+module "keeper_template" {
+  source  = "terraform-google-modules/vm/google//modules/instance_template"
+  version = "15.2.1"
+
+  project_id   = var.project_id
+  region       = var.region
+  name_prefix  = "${local.name_prefix}-keeper"
+  machine_type = var.keeper_machine_type
+
+  source_image = var.keeper_image
+  disk_size_gb = var.keeper_boot_disk_size_gb
+  disk_type    = var.disk_type
+
+  network    = var.network
+  subnetwork = var.subnetwork
+
+  service_account = {
+    email  = module.service_account.email
+    scopes = ["cloud-platform"]
+  }
+
+  tags     = ["clickhouse-keeper"]
+  labels   = local.common_labels
+  metadata = var.metadata
+}
+
+module "keeper_instances" {
+  source  = "terraform-google-modules/vm/google//modules/compute_instance"
+  version = "15.2.1"
+
+  project_id        = var.project_id
+  region            = var.region
+  zone              = var.zone
+  hostname          = "${local.name_prefix}-keeper"
+  num_instances     = var.keeper_count
+  instance_template = module.keeper_template.self_link
+  static_ips        = [for addr in google_compute_address.keeper : addr.address]
+  labels            = local.common_labels
+}
+
+resource "google_compute_attached_disk" "keeper_data" {
+  count = var.keeper_count
+
+  project     = var.project_id
+  disk        = google_compute_disk.keeper_data[count.index].id
+  instance    = module.keeper_instances.instances_self_links[count.index]
+  device_name = "clickhouse-keeper-data"
+}
+
+# ==============================================================================
+# Server tier (fronted by an internal TCP load balancer)
+# ==============================================================================
+resource "google_compute_disk" "server_data" {
+  count = var.server_count
+
+  project = var.project_id
+  name    = "${local.name_prefix}-server-${count.index}-data"
+  zone    = var.zone
+  type    = var.disk_type
+  size    = var.server_disk_size_gb
+  labels  = local.common_labels
+}
+
+module "server_template" {
+  source  = "terraform-google-modules/vm/google//modules/instance_template"
+  version = "15.2.1"
+
+  project_id   = var.project_id
+  region       = var.region
+  name_prefix  = "${local.name_prefix}-server"
+  machine_type = var.server_machine_type
+
+  source_image = var.server_image
+  disk_size_gb = var.server_boot_disk_size_gb
+  disk_type    = var.disk_type
+
+  network    = var.network
+  subnetwork = var.subnetwork
+
+  service_account = {
+    email  = module.service_account.email
+    scopes = ["cloud-platform"]
+  }
+
+  tags     = ["clickhouse-server"]
+  labels   = local.common_labels
+  metadata = var.metadata
+}
+
+module "server_group" {
+  source  = "terraform-google-modules/vm/google//modules/umig"
+  version = "15.2.1"
+
+  project_id        = var.project_id
+  region            = var.region
+  zones             = [var.zone]
+  hostname          = "${local.name_prefix}-server"
+  num_instances     = var.server_count
+  instance_template = module.server_template.self_link
+  named_ports = [
+    { name = "http", port = var.server_http_port },
+    { name = "native", port = var.server_native_port },
+  ]
+}
+
+resource "google_compute_attached_disk" "server_data" {
+  count = var.server_count
+
+  project     = var.project_id
+  disk        = google_compute_disk.server_data[count.index].id
+  instance    = module.server_group.instances_self_links[count.index]
+  device_name = "clickhouse-server-data"
+}
+
+module "internal_lb" {
+  source  = "terraform-google-modules/lb-internal/google"
+  version = "7.1.0"
+
+  project    = var.project_id
+  region     = var.region
+  name       = "${local.name_prefix}-server-ilb"
+  network    = var.network
+  subnetwork = var.lb_subnetwork
+
+  ports = [tostring(var.server_native_port), tostring(var.server_http_port)]
+
+  backends = [
+    for group in module.server_group.self_links : { group = group }
+  ]
+
+  source_tags = []
+  target_tags = ["clickhouse-server"]
+
+  health_check = {
+    type                = "http"
+    port                = var.server_http_port
+    check_interval_sec  = 10
+    timeout_sec         = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    response            = null
+    proxy_header        = "NONE"
+  }
+
+  labels = local.common_labels
+}

--- a/terraform/gcp/modules/composition/clickhouse/outputs.tf
+++ b/terraform/gcp/modules/composition/clickhouse/outputs.tf
@@ -1,0 +1,24 @@
+output "keeper_internal_ips" {
+  description = "Static internal IP addresses assigned to keeper instances"
+  value       = [for addr in google_compute_address.keeper : addr.address]
+}
+
+output "server_instance_self_links" {
+  description = "Self-links of the ClickHouse server instances"
+  value       = module.server_group.instances_self_links
+}
+
+output "keeper_instance_self_links" {
+  description = "Self-links of the ClickHouse keeper instances"
+  value       = module.keeper_instances.instances_self_links
+}
+
+output "internal_lb_ip_address" {
+  description = "IP address of the internal load balancer in front of the server tier"
+  value       = module.internal_lb.ip_address
+}
+
+output "service_account_email" {
+  description = "Email of the shared node service account"
+  value       = module.service_account.email
+}

--- a/terraform/gcp/modules/composition/clickhouse/variables.tf
+++ b/terraform/gcp/modules/composition/clickhouse/variables.tf
@@ -1,0 +1,128 @@
+variable "project_id" {
+  description = "GCP project ID where instances are created"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name used for naming resources"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "region" {
+  description = "Region for regional resources"
+  type        = string
+}
+
+variable "zone" {
+  description = "Zone to create instances in"
+  type        = string
+}
+
+variable "network" {
+  description = "Self-link of the VPC network"
+  type        = string
+}
+
+variable "subnetwork" {
+  description = "Self-link of the subnetwork for ClickHouse nodes"
+  type        = string
+}
+
+variable "lb_subnetwork" {
+  description = "Self-link of the subnetwork for the internal load balancer's forwarding rule"
+  type        = string
+}
+
+variable "server_image" {
+  description = "Self-link or family of the custom image with the ClickHouse server pre-installed"
+  type        = string
+}
+
+variable "keeper_image" {
+  description = "Self-link or family of the custom image with ClickHouse Keeper pre-installed"
+  type        = string
+}
+
+variable "server_count" {
+  description = "Number of ClickHouse server instances"
+  type        = number
+  default     = 2
+}
+
+variable "keeper_count" {
+  description = "Number of ClickHouse Keeper instances (should be odd for quorum)"
+  type        = number
+  default     = 3
+}
+
+variable "server_machine_type" {
+  description = "Machine type for server instances"
+  type        = string
+  default     = "n2-standard-8"
+}
+
+variable "keeper_machine_type" {
+  description = "Machine type for keeper instances"
+  type        = string
+  default     = "n2-standard-2"
+}
+
+variable "server_boot_disk_size_gb" {
+  description = "Boot disk size in GB for server instances"
+  type        = number
+  default     = 50
+}
+
+variable "keeper_boot_disk_size_gb" {
+  description = "Boot disk size in GB for keeper instances"
+  type        = number
+  default     = 50
+}
+
+variable "server_disk_size_gb" {
+  description = "Attached data disk size in GB per server instance"
+  type        = number
+  default     = 1000
+}
+
+variable "keeper_disk_size_gb" {
+  description = "Attached data disk size in GB per keeper instance"
+  type        = number
+  default     = 50
+}
+
+variable "disk_type" {
+  description = "Persistent disk type used for both boot and data disks"
+  type        = string
+  default     = "pd-ssd"
+}
+
+variable "server_http_port" {
+  description = "ClickHouse HTTP interface port"
+  type        = number
+  default     = 8123
+}
+
+variable "server_native_port" {
+  description = "ClickHouse native TCP protocol port"
+  type        = number
+  default     = 9000
+}
+
+variable "metadata" {
+  description = "Additional instance metadata applied to both tiers (e.g. startup-script parameters)"
+  type        = map(string)
+  default     = {}
+}
+
+variable "labels" {
+  description = "Additional labels to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/composition/clickhouse/versions.tf
+++ b/terraform/gcp/modules/composition/clickhouse/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/composition/cloud-cdn/README.md
+++ b/terraform/gcp/modules/composition/cloud-cdn/README.md
@@ -1,0 +1,61 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_log_bucket"></a> [log\_bucket](#module\_log\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_compute_backend_bucket.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_backend_bucket) | resource |
+| [google_compute_global_address.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
+| [google_compute_global_forwarding_rule.http](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) | resource |
+| [google_compute_global_forwarding_rule.https](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) | resource |
+| [google_compute_managed_ssl_certificate.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_managed_ssl_certificate) | resource |
+| [google_compute_target_http_proxy.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_target_http_proxy) | resource |
+| [google_compute_target_https_proxy.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_target_https_proxy) | resource |
+| [google_compute_url_map.https_redirect](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_url_map) | resource |
+| [google_compute_url_map.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_url_map) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_backend_buckets"></a> [backend\_buckets](#input\_backend\_buckets) | Map of GCS-origin backends to create, keyed by logical name | <pre>map(object({<br/>    bucket_name       = string<br/>    enable_cdn        = optional(bool, true)<br/>    cache_mode        = optional(string, "CACHE_ALL_STATIC")<br/>    default_ttl       = optional(number, 3600)<br/>    client_ttl        = optional(number, 3600)<br/>    max_ttl           = optional(number, 86400)<br/>    negative_caching  = optional(bool, true)<br/>    serve_while_stale = optional(number, 86400)<br/>  }))</pre> | `{}` | no |
+| <a name="input_certificate_map"></a> [certificate\_map](#input\_certificate\_map) | Certificate Manager certificate map ID to attach instead of a classic managed SSL certificate (see composition/certificate-manager) | `string` | `null` | no |
+| <a name="input_enable_logging"></a> [enable\_logging](#input\_enable\_logging) | Whether to create a GCS bucket for CDN access logs | `bool` | `true` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_http_redirect_to_https"></a> [http\_redirect\_to\_https](#input\_http\_redirect\_to\_https) | Whether the HTTP listener redirects to HTTPS instead of serving the same url\_map | `bool` | `true` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_log_bucket_location"></a> [log\_bucket\_location](#input\_log\_bucket\_location) | Location for the CDN log bucket | `string` | `"US"` | no |
+| <a name="input_log_retention_days"></a> [log\_retention\_days](#input\_log\_retention\_days) | Number of days to retain CDN log objects before deletion | `number` | `90` | no |
+| <a name="input_managed_ssl_certificate_domains"></a> [managed\_ssl\_certificate\_domains](#input\_managed\_ssl\_certificate\_domains) | List of domains for the Google-managed SSL certificate, used when ssl = true and certificate\_map is null | `list(string)` | `[]` | no |
+| <a name="input_name_override"></a> [name\_override](#input\_name\_override) | Logical name for this distribution (e.g. 'assets', 'dashboard') | `string` | `"default"` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where CDN resources are created | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name used for naming resources | `string` | `"hyperswitch"` | no |
+| <a name="input_ssl"></a> [ssl](#input\_ssl) | Whether to provision an HTTPS listener | `bool` | `true` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_backend_bucket_ids"></a> [backend\_bucket\_ids](#output\_backend\_bucket\_ids) | Map of backend bucket key to its resource ID |
+| <a name="output_ip_address"></a> [ip\_address](#output\_ip\_address) | Anycast IP address serving this distribution |
+| <a name="output_log_bucket_name"></a> [log\_bucket\_name](#output\_log\_bucket\_name) | Name of the CDN log bucket, if enabled |
+| <a name="output_url_map_id"></a> [url\_map\_id](#output\_url\_map\_id) | ID of the URL map |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/composition/cloud-cdn/README.md
+++ b/terraform/gcp/modules/composition/cloud-cdn/README.md
@@ -2,26 +2,26 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_log_bucket"></a> [log\_bucket](#module\_log\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
 
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google_compute_backend_bucket.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_backend_bucket) | resource |
 | [google_compute_global_address.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
 | [google_compute_global_forwarding_rule.http](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) | resource |
@@ -35,7 +35,7 @@
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_backend_buckets"></a> [backend\_buckets](#input\_backend\_buckets) | Map of GCS-origin backends to create, keyed by logical name | <pre>map(object({<br/>    bucket_name       = string<br/>    enable_cdn        = optional(bool, true)<br/>    cache_mode        = optional(string, "CACHE_ALL_STATIC")<br/>    default_ttl       = optional(number, 3600)<br/>    client_ttl        = optional(number, 3600)<br/>    max_ttl           = optional(number, 86400)<br/>    negative_caching  = optional(bool, true)<br/>    serve_while_stale = optional(number, 86400)<br/>  }))</pre> | `{}` | no |
 | <a name="input_certificate_map"></a> [certificate\_map](#input\_certificate\_map) | Certificate Manager certificate map ID to attach instead of a classic managed SSL certificate (see composition/certificate-manager) | `string` | `null` | no |
 | <a name="input_enable_logging"></a> [enable\_logging](#input\_enable\_logging) | Whether to create a GCS bucket for CDN access logs | `bool` | `true` | no |
@@ -53,7 +53,7 @@
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_backend_bucket_ids"></a> [backend\_bucket\_ids](#output\_backend\_bucket\_ids) | Map of backend bucket key to its resource ID |
 | <a name="output_ip_address"></a> [ip\_address](#output\_ip\_address) | Anycast IP address serving this distribution |
 | <a name="output_log_bucket_name"></a> [log\_bucket\_name](#output\_log\_bucket\_name) | Name of the CDN log bucket, if enabled |

--- a/terraform/gcp/modules/composition/cloud-cdn/locals.tf
+++ b/terraform/gcp/modules/composition/cloud-cdn/locals.tf
@@ -1,0 +1,13 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}-cdn"
+
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "component"   = "cloud-cdn"
+      "managed_by"  = "terraform"
+    },
+    var.labels
+  )
+}

--- a/terraform/gcp/modules/composition/cloud-cdn/main.tf
+++ b/terraform/gcp/modules/composition/cloud-cdn/main.tf
@@ -1,0 +1,144 @@
+# ============================================================================
+# Cloud CDN (GCP equivalent of composition/cloudfront)
+# ============================================================================
+# One global external HTTP(S) load balancer per distribution with Cloud CDN
+# enabled on its backends, plus a GCS log bucket, matching the AWS module's
+# CloudFront distribution + S3 log bucket shape. Origins can be Cloud
+# Storage buckets (via `backend_buckets`) or Compute/Serverless backends
+# (via `backend_services`, reusing the same backend map shape as
+# composition/load-balancer).
+#
+# CloudFront Functions have no Cloud CDN equivalent (Cloud CDN has no
+# request/response edge-compute hook); the nearest GCP-native path for
+# request rewriting is a Cloud Run/Cloud Functions origin placed in front of
+# the real origin, which is out of scope for this module. See
+# terraform/gcp/modules/README.md.
+#
+# Usage:
+#   module "cloud_cdn" {
+#     source = "../../modules/composition/cloud-cdn"
+#
+#     project_id  = "hyperswitch-dev"
+#     environment = "dev"
+#     name_override = "assets"
+#
+#     backend_buckets = {
+#       assets = { bucket_name = module.assets_bucket.name, enable_cdn = true }
+#     }
+#     managed_ssl_certificate_domains = ["assets.dev.hyperswitch.example.com"]
+#   }
+# ============================================================================
+
+module "log_bucket" {
+  source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
+  version = "12.3.0"
+
+  count = var.enable_logging ? 1 : 0
+
+  project_id    = var.project_id
+  name          = "${local.name_prefix}-logs"
+  location      = var.log_bucket_location
+  force_destroy = false
+
+  versioning         = true
+  bucket_policy_only = true
+
+  lifecycle_rules = [{
+    action    = { type = "Delete" }
+    condition = { age = var.log_retention_days }
+  }]
+
+  labels = local.common_labels
+}
+
+resource "google_compute_backend_bucket" "this" {
+  for_each = var.backend_buckets
+
+  project     = var.project_id
+  name        = "${local.name_prefix}-${each.key}"
+  bucket_name = each.value.bucket_name
+  enable_cdn  = try(each.value.enable_cdn, true)
+
+  cdn_policy {
+    cache_mode        = try(each.value.cache_mode, "CACHE_ALL_STATIC")
+    default_ttl       = try(each.value.default_ttl, 3600)
+    client_ttl        = try(each.value.client_ttl, 3600)
+    max_ttl           = try(each.value.max_ttl, 86400)
+    negative_caching  = try(each.value.negative_caching, true)
+    serve_while_stale = try(each.value.serve_while_stale, 86400)
+  }
+}
+
+resource "google_compute_url_map" "this" {
+  project         = var.project_id
+  name            = local.name_prefix
+  default_service = values(google_compute_backend_bucket.this)[0].id
+}
+
+resource "google_compute_target_https_proxy" "this" {
+  count = var.ssl ? 1 : 0
+
+  project = var.project_id
+  name    = "${local.name_prefix}-https-proxy"
+  url_map = google_compute_url_map.this.id
+
+  ssl_certificates = var.certificate_map == null ? [google_compute_managed_ssl_certificate.this[0].id] : null
+  certificate_map  = var.certificate_map != null ? "//certificatemanager.googleapis.com/${var.certificate_map}" : null
+}
+
+resource "google_compute_managed_ssl_certificate" "this" {
+  count = var.ssl && var.certificate_map == null ? 1 : 0
+
+  project = var.project_id
+  name    = "${local.name_prefix}-cert"
+
+  managed {
+    domains = var.managed_ssl_certificate_domains
+  }
+}
+
+resource "google_compute_global_address" "this" {
+  project = var.project_id
+  name    = "${local.name_prefix}-ip"
+}
+
+resource "google_compute_global_forwarding_rule" "https" {
+  count = var.ssl ? 1 : 0
+
+  project    = var.project_id
+  name       = "${local.name_prefix}-https"
+  target     = google_compute_target_https_proxy.this[0].id
+  port_range = "443"
+  ip_address = google_compute_global_address.this.address
+}
+
+resource "google_compute_target_http_proxy" "this" {
+  count = var.http_redirect_to_https || !var.ssl ? 1 : 0
+
+  project = var.project_id
+  name    = "${local.name_prefix}-http-proxy"
+  url_map = var.ssl ? google_compute_url_map.https_redirect[0].id : google_compute_url_map.this.id
+}
+
+resource "google_compute_url_map" "https_redirect" {
+  count = var.ssl && var.http_redirect_to_https ? 1 : 0
+
+  project = var.project_id
+  name    = "${local.name_prefix}-https-redirect"
+
+  default_url_redirect {
+    https_redirect         = true
+    strip_query            = false
+    redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+  }
+}
+
+resource "google_compute_global_forwarding_rule" "http" {
+  count = var.http_redirect_to_https || !var.ssl ? 1 : 0
+
+  project    = var.project_id
+  name       = "${local.name_prefix}-http"
+  target     = google_compute_target_http_proxy.this[0].id
+  port_range = "80"
+  ip_address = google_compute_global_address.this.address
+}

--- a/terraform/gcp/modules/composition/cloud-cdn/outputs.tf
+++ b/terraform/gcp/modules/composition/cloud-cdn/outputs.tf
@@ -1,0 +1,19 @@
+output "ip_address" {
+  description = "Anycast IP address serving this distribution"
+  value       = google_compute_global_address.this.address
+}
+
+output "url_map_id" {
+  description = "ID of the URL map"
+  value       = google_compute_url_map.this.id
+}
+
+output "backend_bucket_ids" {
+  description = "Map of backend bucket key to its resource ID"
+  value       = { for k, v in google_compute_backend_bucket.this : k => v.id }
+}
+
+output "log_bucket_name" {
+  description = "Name of the CDN log bucket, if enabled"
+  value       = var.enable_logging ? module.log_bucket[0].name : null
+}

--- a/terraform/gcp/modules/composition/cloud-cdn/variables.tf
+++ b/terraform/gcp/modules/composition/cloud-cdn/variables.tf
@@ -1,0 +1,84 @@
+variable "project_id" {
+  description = "GCP project ID where CDN resources are created"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name used for naming resources"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "name_override" {
+  description = "Logical name for this distribution (e.g. 'assets', 'dashboard')"
+  type        = string
+  default     = "default"
+}
+
+variable "backend_buckets" {
+  description = "Map of GCS-origin backends to create, keyed by logical name"
+  type = map(object({
+    bucket_name       = string
+    enable_cdn        = optional(bool, true)
+    cache_mode        = optional(string, "CACHE_ALL_STATIC")
+    default_ttl       = optional(number, 3600)
+    client_ttl        = optional(number, 3600)
+    max_ttl           = optional(number, 86400)
+    negative_caching  = optional(bool, true)
+    serve_while_stale = optional(number, 86400)
+  }))
+  default = {}
+}
+
+variable "ssl" {
+  description = "Whether to provision an HTTPS listener"
+  type        = bool
+  default     = true
+}
+
+variable "http_redirect_to_https" {
+  description = "Whether the HTTP listener redirects to HTTPS instead of serving the same url_map"
+  type        = bool
+  default     = true
+}
+
+variable "managed_ssl_certificate_domains" {
+  description = "List of domains for the Google-managed SSL certificate, used when ssl = true and certificate_map is null"
+  type        = list(string)
+  default     = []
+}
+
+variable "certificate_map" {
+  description = "Certificate Manager certificate map ID to attach instead of a classic managed SSL certificate (see composition/certificate-manager)"
+  type        = string
+  default     = null
+}
+
+variable "enable_logging" {
+  description = "Whether to create a GCS bucket for CDN access logs"
+  type        = bool
+  default     = true
+}
+
+variable "log_bucket_location" {
+  description = "Location for the CDN log bucket"
+  type        = string
+  default     = "US"
+}
+
+variable "log_retention_days" {
+  description = "Number of days to retain CDN log objects before deletion"
+  type        = number
+  default     = 90
+}
+
+variable "labels" {
+  description = "Additional labels to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/composition/cloud-cdn/versions.tf
+++ b/terraform/gcp/modules/composition/cloud-cdn/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/composition/cloud-dns/README.md
+++ b/terraform/gcp/modules/composition/cloud-dns/README.md
@@ -2,7 +2,7 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
@@ -13,7 +13,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_cloud_dns"></a> [cloud\_dns](#module\_cloud\_dns) | terraform-google-modules/cloud-dns/google | 7.1.0 |
 
 ## Resources
@@ -23,7 +23,7 @@ No resources.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_domain"></a> [domain](#input\_domain) | The DNS domain of this zone, e.g. 'dev.hyperswitch.example.com.' (trailing dot required) | `string` | n/a | yes |
 | <a name="input_enable_dnssec"></a> [enable\_dnssec](#input\_enable\_dnssec) | Whether to enable DNSSEC. Only applicable to public zones | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
@@ -38,7 +38,7 @@ No resources.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_domain"></a> [domain](#output\_domain) | Domain of the zone |
 | <a name="output_name_servers"></a> [name\_servers](#output\_name\_servers) | Name servers assigned to the zone (only meaningful for public zones) |
 | <a name="output_type"></a> [type](#output\_type) | Type of the zone |

--- a/terraform/gcp/modules/composition/cloud-dns/README.md
+++ b/terraform/gcp/modules/composition/cloud-dns/README.md
@@ -1,0 +1,46 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_cloud_dns"></a> [cloud\_dns](#module\_cloud\_dns) | terraform-google-modules/cloud-dns/google | 7.1.0 |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_domain"></a> [domain](#input\_domain) | The DNS domain of this zone, e.g. 'dev.hyperswitch.example.com.' (trailing dot required) | `string` | n/a | yes |
+| <a name="input_enable_dnssec"></a> [enable\_dnssec](#input\_enable\_dnssec) | Whether to enable DNSSEC. Only applicable to public zones | `bool` | `false` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to the zone | `map(string)` | `{}` | no |
+| <a name="input_private_visibility_config_networks"></a> [private\_visibility\_config\_networks](#input\_private\_visibility\_config\_networks) | List of VPC network self-links this zone is visible from. Required when type = private | `list(string)` | `[]` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where the zone is created | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name used for labeling resources | `string` | `"hyperswitch"` | no |
+| <a name="input_recordsets"></a> [recordsets](#input\_recordsets) | List of DNS recordsets to create in this zone, in the shape expected by terraform-google-modules/cloud-dns | `any` | `[]` | no |
+| <a name="input_type"></a> [type](#input\_type) | Zone type: public or private | `string` | `"private"` | no |
+| <a name="input_zone_name"></a> [zone\_name](#input\_zone\_name) | Name of the Cloud DNS managed zone (DNS-safe identifier, not the domain itself) | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_domain"></a> [domain](#output\_domain) | Domain of the zone |
+| <a name="output_name_servers"></a> [name\_servers](#output\_name\_servers) | Name servers assigned to the zone (only meaningful for public zones) |
+| <a name="output_type"></a> [type](#output\_type) | Type of the zone |
+| <a name="output_zone_name"></a> [zone\_name](#output\_zone\_name) | Name of the managed zone |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/composition/cloud-dns/locals.tf
+++ b/terraform/gcp/modules/composition/cloud-dns/locals.tf
@@ -1,0 +1,10 @@
+locals {
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "managed_by"  = "terraform"
+    },
+    var.labels
+  )
+}

--- a/terraform/gcp/modules/composition/cloud-dns/main.tf
+++ b/terraform/gcp/modules/composition/cloud-dns/main.tf
@@ -1,0 +1,44 @@
+# ============================================================================
+# Cloud DNS (GCP equivalent of composition/route53)
+# ============================================================================
+# One managed zone (public or private) per module call plus its recordsets,
+# matching the AWS module's zone+records shape. Instantiate this module once
+# per zone from the live layer, same as composition/route53.
+#
+# Usage:
+#   module "cloud_dns_public" {
+#     source = "../../modules/composition/cloud-dns"
+#
+#     project_id  = "hyperswitch-dev"
+#     environment = "dev"
+#     zone_name   = "hyperswitch-dev-public"
+#     domain      = "dev.hyperswitch.example.com."
+#     type        = "public"
+#
+#     recordsets = [
+#       { name = "api", type = "A", ttl = 300, records = ["203.0.113.10"] },
+#     ]
+#   }
+# ============================================================================
+
+module "cloud_dns" {
+  source  = "terraform-google-modules/cloud-dns/google"
+  version = "7.1.0"
+
+  project_id = var.project_id
+  name       = var.zone_name
+  domain     = var.domain
+  type       = var.type
+
+  private_visibility_config_networks = var.private_visibility_config_networks
+
+  dnssec_config = var.enable_dnssec ? {
+    kind          = "dns#managedZoneDnsSecConfig"
+    non_existence = "nsec3"
+    state         = "on"
+  } : null
+
+  recordsets = var.recordsets
+
+  labels = local.common_labels
+}

--- a/terraform/gcp/modules/composition/cloud-dns/outputs.tf
+++ b/terraform/gcp/modules/composition/cloud-dns/outputs.tf
@@ -1,0 +1,19 @@
+output "zone_name" {
+  description = "Name of the managed zone"
+  value       = module.cloud_dns.name
+}
+
+output "domain" {
+  description = "Domain of the zone"
+  value       = module.cloud_dns.domain
+}
+
+output "name_servers" {
+  description = "Name servers assigned to the zone (only meaningful for public zones)"
+  value       = module.cloud_dns.name_servers
+}
+
+output "type" {
+  description = "Type of the zone"
+  value       = module.cloud_dns.type
+}

--- a/terraform/gcp/modules/composition/cloud-dns/variables.tf
+++ b/terraform/gcp/modules/composition/cloud-dns/variables.tf
@@ -1,0 +1,60 @@
+variable "project_id" {
+  description = "GCP project ID where the zone is created"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name used for labeling resources"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "zone_name" {
+  description = "Name of the Cloud DNS managed zone (DNS-safe identifier, not the domain itself)"
+  type        = string
+}
+
+variable "domain" {
+  description = "The DNS domain of this zone, e.g. 'dev.hyperswitch.example.com.' (trailing dot required)"
+  type        = string
+}
+
+variable "type" {
+  description = "Zone type: public or private"
+  type        = string
+  default     = "private"
+
+  validation {
+    condition     = contains(["public", "private"], var.type)
+    error_message = "type must be either 'public' or 'private'."
+  }
+}
+
+variable "private_visibility_config_networks" {
+  description = "List of VPC network self-links this zone is visible from. Required when type = private"
+  type        = list(string)
+  default     = []
+}
+
+variable "enable_dnssec" {
+  description = "Whether to enable DNSSEC. Only applicable to public zones"
+  type        = bool
+  default     = false
+}
+
+variable "recordsets" {
+  description = "List of DNS recordsets to create in this zone, in the shape expected by terraform-google-modules/cloud-dns"
+  type        = any
+  default     = []
+}
+
+variable "labels" {
+  description = "Additional labels to apply to the zone"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/composition/cloud-dns/versions.tf
+++ b/terraform/gcp/modules/composition/cloud-dns/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/composition/cloud-monitoring/README.md
+++ b/terraform/gcp/modules/composition/cloud-monitoring/README.md
@@ -1,0 +1,52 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_log_sinks"></a> [log\_sinks](#module\_log\_sinks) | terraform-google-modules/log-export/google | 11.1.0 |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_logging_metric.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_metric) | resource |
+| [google_monitoring_alert_policy.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
+| [google_monitoring_dashboard.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_dashboard) | resource |
+| [google_monitoring_notification_channel.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_notification_channel) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_alert_policies"></a> [alert\_policies](#input\_alert\_policies) | Map of alert policies to create, keyed by logical name. notification\_channel\_keys reference keys in var.notification\_channels | <pre>map(object({<br/>    combiner = string # AND, OR, AND_WITH_MATCHING_RESOURCE<br/>    conditions = list(object({<br/>      display_name       = string<br/>      filter             = string<br/>      comparison         = string # COMPARISON_GT, COMPARISON_LT, ...<br/>      threshold_value    = number<br/>      duration           = string<br/>      alignment_period   = optional(string, "60s")<br/>      per_series_aligner = optional(string, "ALIGN_MEAN")<br/>    }))<br/>    notification_channel_keys = optional(list(string), [])<br/>    documentation             = optional(string)<br/>    labels                    = optional(map(string), {})<br/>  }))</pre> | `{}` | no |
+| <a name="input_dashboards"></a> [dashboards](#input\_dashboards) | Map of dashboard definitions (as native Terraform objects, JSON-encoded internally) keyed by logical name | `map(any)` | `{}` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_log_metrics"></a> [log\_metrics](#input\_log\_metrics) | Map of log-based metrics to create, keyed by logical name | <pre>map(object({<br/>    filter      = string<br/>    description = optional(string)<br/>    metric_kind = optional(string, "DELTA")<br/>    value_type  = optional(string, "INT64")<br/>    unit        = optional(string, "1")<br/>  }))</pre> | `{}` | no |
+| <a name="input_log_sinks"></a> [log\_sinks](#input\_log\_sinks) | Map of project-level log sinks to create, keyed by logical name | <pre>map(object({<br/>    destination_uri = string # e.g. "storage.googleapis.com/<bucket>" or "pubsub.googleapis.com/projects/<p>/topics/<t>"<br/>    filter          = string<br/>  }))</pre> | `{}` | no |
+| <a name="input_notification_channels"></a> [notification\_channels](#input\_notification\_channels) | Map of notification channels to create, keyed by logical name | <pre>map(object({<br/>    type        = string # e.g. "email", "pubsub", "slack", "pagerduty"<br/>    labels      = map(string)<br/>    description = optional(string)<br/>    enabled     = optional(bool, true)<br/>  }))</pre> | `{}` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where monitoring resources are created | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name used for naming resources | `string` | `"hyperswitch"` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_alert_policy_ids"></a> [alert\_policy\_ids](#output\_alert\_policy\_ids) | Map of alert policy key to its resource ID |
+| <a name="output_dashboard_ids"></a> [dashboard\_ids](#output\_dashboard\_ids) | Map of dashboard key to its resource ID |
+| <a name="output_log_metric_ids"></a> [log\_metric\_ids](#output\_log\_metric\_ids) | Map of log-based metric key to its resource ID |
+| <a name="output_log_sink_writer_identities"></a> [log\_sink\_writer\_identities](#output\_log\_sink\_writer\_identities) | Map of log sink key to its writer service-account identity, for granting it write access to the destination |
+| <a name="output_notification_channel_ids"></a> [notification\_channel\_ids](#output\_notification\_channel\_ids) | Map of notification channel key to its resource ID |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/composition/cloud-monitoring/README.md
+++ b/terraform/gcp/modules/composition/cloud-monitoring/README.md
@@ -2,26 +2,26 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_log_sinks"></a> [log\_sinks](#module\_log\_sinks) | terraform-google-modules/log-export/google | 11.1.0 |
 
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google_logging_metric.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/logging_metric) | resource |
 | [google_monitoring_alert_policy.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
 | [google_monitoring_dashboard.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_dashboard) | resource |
@@ -30,7 +30,7 @@
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_alert_policies"></a> [alert\_policies](#input\_alert\_policies) | Map of alert policies to create, keyed by logical name. notification\_channel\_keys reference keys in var.notification\_channels | <pre>map(object({<br/>    combiner = string # AND, OR, AND_WITH_MATCHING_RESOURCE<br/>    conditions = list(object({<br/>      display_name       = string<br/>      filter             = string<br/>      comparison         = string # COMPARISON_GT, COMPARISON_LT, ...<br/>      threshold_value    = number<br/>      duration           = string<br/>      alignment_period   = optional(string, "60s")<br/>      per_series_aligner = optional(string, "ALIGN_MEAN")<br/>    }))<br/>    notification_channel_keys = optional(list(string), [])<br/>    documentation             = optional(string)<br/>    labels                    = optional(map(string), {})<br/>  }))</pre> | `{}` | no |
 | <a name="input_dashboards"></a> [dashboards](#input\_dashboards) | Map of dashboard definitions (as native Terraform objects, JSON-encoded internally) keyed by logical name | `map(any)` | `{}` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
@@ -43,7 +43,7 @@
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_alert_policy_ids"></a> [alert\_policy\_ids](#output\_alert\_policy\_ids) | Map of alert policy key to its resource ID |
 | <a name="output_dashboard_ids"></a> [dashboard\_ids](#output\_dashboard\_ids) | Map of dashboard key to its resource ID |
 | <a name="output_log_metric_ids"></a> [log\_metric\_ids](#output\_log\_metric\_ids) | Map of log-based metric key to its resource ID |

--- a/terraform/gcp/modules/composition/cloud-monitoring/locals.tf
+++ b/terraform/gcp/modules/composition/cloud-monitoring/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}"
+}

--- a/terraform/gcp/modules/composition/cloud-monitoring/main.tf
+++ b/terraform/gcp/modules/composition/cloud-monitoring/main.tf
@@ -1,0 +1,128 @@
+# ============================================================================
+# Cloud Monitoring (GCP equivalent of composition/cloudwatch)
+# ============================================================================
+# Notification channels, alert policies, log-based metrics, and dashboards -
+# mirroring the AWS module's SNS-action metric/composite/anomaly alarms +
+# log groups + dashboard shape. Cloud Monitoring's `combiner` field on an
+# alert policy plays the role of a CloudWatch composite alarm: a policy
+# whose conditions reference other policies' underlying metrics.
+#
+# Log sinks (the equivalent of the AWS module's CloudWatch Logs export
+# destinations) are built on terraform-google-modules/log-export, one call
+# per destination.
+#
+# Usage:
+#   module "cloud_monitoring" {
+#     source = "../../modules/composition/cloud-monitoring"
+#
+#     project_id  = "hyperswitch-dev"
+#     environment = "dev"
+#
+#     notification_channels = {
+#       platform-pagerduty = { type = "pubsub", labels = { topic = module.pubsub.topic_id } }
+#     }
+#
+#     alert_policies = {
+#       high-cpu = {
+#         display_name = "High CPU"
+#         combiner     = "OR"
+#         conditions = [{
+#           display_name = "CPU > 80%"
+#           filter       = "resource.type=\"gce_instance\" AND metric.type=\"compute.googleapis.com/instance/cpu/utilization\""
+#           comparison   = "COMPARISON_GT"
+#           threshold_value = 0.8
+#           duration     = "300s"
+#         }]
+#         notification_channel_keys = ["platform-pagerduty"]
+#       }
+#     }
+#   }
+# ============================================================================
+
+resource "google_monitoring_notification_channel" "this" {
+  for_each = var.notification_channels
+
+  project      = var.project_id
+  display_name = "${local.name_prefix}-${each.key}"
+  type         = each.value.type
+  labels       = each.value.labels
+  description  = try(each.value.description, null)
+  enabled      = try(each.value.enabled, true)
+}
+
+resource "google_monitoring_alert_policy" "this" {
+  for_each = var.alert_policies
+
+  project      = var.project_id
+  display_name = "${local.name_prefix}-${each.key}"
+  combiner     = each.value.combiner
+
+  dynamic "conditions" {
+    for_each = each.value.conditions
+    content {
+      display_name = conditions.value.display_name
+
+      condition_threshold {
+        filter          = conditions.value.filter
+        comparison      = conditions.value.comparison
+        threshold_value = conditions.value.threshold_value
+        duration        = conditions.value.duration
+        aggregations {
+          alignment_period   = try(conditions.value.alignment_period, "60s")
+          per_series_aligner = try(conditions.value.per_series_aligner, "ALIGN_MEAN")
+        }
+      }
+    }
+  }
+
+  notification_channels = [
+    for key in each.value.notification_channel_keys :
+    google_monitoring_notification_channel.this[key].id
+  ]
+
+  documentation {
+    content   = try(each.value.documentation, "Managed by Terraform (composition/cloud-monitoring)")
+    mime_type = "text/markdown"
+  }
+
+  user_labels = try(each.value.labels, {})
+}
+
+resource "google_logging_metric" "this" {
+  for_each = var.log_metrics
+
+  project     = var.project_id
+  name        = "${local.name_prefix}-${each.key}"
+  filter      = each.value.filter
+  description = try(each.value.description, null)
+
+  metric_descriptor {
+    metric_kind = try(each.value.metric_kind, "DELTA")
+    value_type  = try(each.value.value_type, "INT64")
+    unit        = try(each.value.unit, "1")
+  }
+}
+
+resource "google_monitoring_dashboard" "this" {
+  for_each = var.dashboards
+
+  project        = var.project_id
+  dashboard_json = jsonencode(each.value)
+}
+
+# ==============================================================================
+# Log sinks
+# ==============================================================================
+module "log_sinks" {
+  source  = "terraform-google-modules/log-export/google"
+  version = "11.1.0"
+
+  for_each = var.log_sinks
+
+  destination_uri        = each.value.destination_uri
+  filter                 = each.value.filter
+  log_sink_name          = "${local.name_prefix}-${each.key}"
+  parent_resource_type   = "project"
+  parent_resource_id     = var.project_id
+  unique_writer_identity = true
+}

--- a/terraform/gcp/modules/composition/cloud-monitoring/outputs.tf
+++ b/terraform/gcp/modules/composition/cloud-monitoring/outputs.tf
@@ -1,0 +1,24 @@
+output "notification_channel_ids" {
+  description = "Map of notification channel key to its resource ID"
+  value       = { for k, v in google_monitoring_notification_channel.this : k => v.id }
+}
+
+output "alert_policy_ids" {
+  description = "Map of alert policy key to its resource ID"
+  value       = { for k, v in google_monitoring_alert_policy.this : k => v.id }
+}
+
+output "log_metric_ids" {
+  description = "Map of log-based metric key to its resource ID"
+  value       = { for k, v in google_logging_metric.this : k => v.id }
+}
+
+output "dashboard_ids" {
+  description = "Map of dashboard key to its resource ID"
+  value       = { for k, v in google_monitoring_dashboard.this : k => v.id }
+}
+
+output "log_sink_writer_identities" {
+  description = "Map of log sink key to its writer service-account identity, for granting it write access to the destination"
+  value       = { for k, v in module.log_sinks : k => v.writer_identity }
+}

--- a/terraform/gcp/modules/composition/cloud-monitoring/variables.tf
+++ b/terraform/gcp/modules/composition/cloud-monitoring/variables.tf
@@ -1,0 +1,73 @@
+variable "project_id" {
+  description = "GCP project ID where monitoring resources are created"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name used for naming resources"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "notification_channels" {
+  description = "Map of notification channels to create, keyed by logical name"
+  type = map(object({
+    type        = string # e.g. "email", "pubsub", "slack", "pagerduty"
+    labels      = map(string)
+    description = optional(string)
+    enabled     = optional(bool, true)
+  }))
+  default = {}
+}
+
+variable "alert_policies" {
+  description = "Map of alert policies to create, keyed by logical name. notification_channel_keys reference keys in var.notification_channels"
+  type = map(object({
+    combiner = string # AND, OR, AND_WITH_MATCHING_RESOURCE
+    conditions = list(object({
+      display_name       = string
+      filter             = string
+      comparison         = string # COMPARISON_GT, COMPARISON_LT, ...
+      threshold_value    = number
+      duration           = string
+      alignment_period   = optional(string, "60s")
+      per_series_aligner = optional(string, "ALIGN_MEAN")
+    }))
+    notification_channel_keys = optional(list(string), [])
+    documentation             = optional(string)
+    labels                    = optional(map(string), {})
+  }))
+  default = {}
+}
+
+variable "log_metrics" {
+  description = "Map of log-based metrics to create, keyed by logical name"
+  type = map(object({
+    filter      = string
+    description = optional(string)
+    metric_kind = optional(string, "DELTA")
+    value_type  = optional(string, "INT64")
+    unit        = optional(string, "1")
+  }))
+  default = {}
+}
+
+variable "dashboards" {
+  description = "Map of dashboard definitions (as native Terraform objects, JSON-encoded internally) keyed by logical name"
+  type        = map(any)
+  default     = {}
+}
+
+variable "log_sinks" {
+  description = "Map of project-level log sinks to create, keyed by logical name"
+  type = map(object({
+    destination_uri = string # e.g. "storage.googleapis.com/<bucket>" or "pubsub.googleapis.com/projects/<p>/topics/<t>"
+    filter          = string
+  }))
+  default = {}
+}

--- a/terraform/gcp/modules/composition/cloud-monitoring/versions.tf
+++ b/terraform/gcp/modules/composition/cloud-monitoring/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/composition/cloud-sql/README.md
+++ b/terraform/gcp/modules/composition/cloud-sql/README.md
@@ -1,0 +1,70 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_cloud_sql"></a> [cloud\_sql](#module\_cloud\_sql) | terraform-google-modules/sql-db/google//modules/postgresql | 28.1.0 |
+| <a name="module_kms"></a> [kms](#module\_kms) | terraform-google-modules/kms/google | 4.1.2 |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_availability_type"></a> [availability\_type](#input\_availability\_type) | Availability type: ZONAL or REGIONAL (REGIONAL enables HA, the Multi-AZ equivalent) | `string` | `"REGIONAL"` | no |
+| <a name="input_backup_start_time"></a> [backup\_start\_time](#input\_backup\_start\_time) | HH:MM start time for the daily automated backup window (UTC) | `string` | `"02:00"` | no |
+| <a name="input_database_flags"></a> [database\_flags](#input\_database\_flags) | List of database flags to set on the instance | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_database_name"></a> [database\_name](#input\_database\_name) | Name of the default database to create | `string` | `"hyperswitch"` | no |
+| <a name="input_database_version"></a> [database\_version](#input\_database\_version) | PostgreSQL engine version | `string` | `"POSTGRES_15"` | no |
+| <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether to enable deletion protection on the instance | `bool` | `true` | no |
+| <a name="input_disk_autoresize"></a> [disk\_autoresize](#input\_disk\_autoresize) | Whether to enable disk autoresize | `bool` | `true` | no |
+| <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | Disk size in GB | `number` | `100` | no |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Disk type: PD\_SSD or PD\_HDD | `string` | `"PD_SSD"` | no |
+| <a name="input_edition"></a> [edition](#input\_edition) | Edition of the instance: ENTERPRISE or ENTERPRISE\_PLUS | `string` | `"ENTERPRISE"` | no |
+| <a name="input_enable_point_in_time_recovery"></a> [enable\_point\_in\_time\_recovery](#input\_enable\_point\_in\_time\_recovery) | Whether to enable point-in-time recovery (WAL archiving) | `bool` | `true` | no |
+| <a name="input_encryption_key_name"></a> [encryption\_key\_name](#input\_encryption\_key\_name) | Self-link of an existing KMS CryptoKey for disk encryption. Takes precedence over var.kms.create | `string` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_instance_name"></a> [instance\_name](#input\_instance\_name) | Name of the Cloud SQL instance. Defaults to '<environment>-<project\_name>-sql-pg' | `string` | `null` | no |
+| <a name="input_kms"></a> [kms](#input\_kms) | CMEK configuration. Set create=true to have this module create a KMS keyring/key for disk encryption | <pre>object({<br/>    create          = optional(bool, false)<br/>    keyring_name    = optional(string)<br/>    key_name        = optional(string, "cloud-sql")<br/>    rotation_period = optional(string)<br/>  })</pre> | `null` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_master_password"></a> [master\_password](#input\_master\_password) | Password for the default database user. Leave null to auto-generate a random password | `string` | `null` | no |
+| <a name="input_master_username"></a> [master\_username](#input\_master\_username) | Name of the default database user to create | `string` | `"hyperswitch_admin"` | no |
+| <a name="input_module_depends_on"></a> [module\_depends\_on](#input\_module\_depends\_on) | List of resources this module should depend on (e.g. the Private Service Access connection from composition/vpc-network) | `list(any)` | `[]` | no |
+| <a name="input_network_id"></a> [network\_id](#input\_network\_id) | Self-link/ID of the VPC network to attach the instance to (requires Private Service Access to already be configured, see composition/vpc-network) | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where the instance is created | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name for labeling and naming resources | `string` | `"hyperswitch"` | no |
+| <a name="input_random_instance_name"></a> [random\_instance\_name](#input\_random\_instance\_name) | Whether to append a random suffix to the instance name | `bool` | `false` | no |
+| <a name="input_read_replicas"></a> [read\_replicas](#input\_read\_replicas) | List of read replicas to create, in the shape expected by terraform-google-modules/sql-db//modules/postgresql. Cross-region entries are the closest GCP equivalent to an Aurora Global Cluster secondary region. | `any` | `[]` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region for the primary Cloud SQL instance | `string` | n/a | yes |
+| <a name="input_retained_backups"></a> [retained\_backups](#input\_retained\_backups) | Number of automated backups to retain | `number` | `30` | no |
+| <a name="input_tier"></a> [tier](#input\_tier) | Machine tier for the instance (e.g. db-custom-4-16384) | `string` | `"db-custom-2-8192"` | no |
+| <a name="input_transaction_log_retention_days"></a> [transaction\_log\_retention\_days](#input\_transaction\_log\_retention\_days) | Number of days of transaction logs to retain for point-in-time recovery | `string` | `"7"` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_database_name"></a> [database\_name](#output\_database\_name) | Name of the default database |
+| <a name="output_generated_user_password"></a> [generated\_user\_password](#output\_generated\_user\_password) | Auto-generated password for the default user, if master\_password was not set |
+| <a name="output_instance_connection_name"></a> [instance\_connection\_name](#output\_instance\_connection\_name) | Connection name for the Cloud SQL Auth Proxy (project:region:instance) |
+| <a name="output_instance_name"></a> [instance\_name](#output\_instance\_name) | Name of the primary Cloud SQL instance |
+| <a name="output_instance_self_link"></a> [instance\_self\_link](#output\_instance\_self\_link) | Self-link of the primary instance |
+| <a name="output_kms_key_name"></a> [kms\_key\_name](#output\_kms\_key\_name) | Self-link of the KMS key used for disk encryption, if any |
+| <a name="output_master_username"></a> [master\_username](#output\_master\_username) | Name of the default database user |
+| <a name="output_private_ip_address"></a> [private\_ip\_address](#output\_private\_ip\_address) | Private IP address of the primary instance |
+| <a name="output_read_replica_instance_names"></a> [read\_replica\_instance\_names](#output\_read\_replica\_instance\_names) | Names of the created read replicas |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/composition/cloud-sql/README.md
+++ b/terraform/gcp/modules/composition/cloud-sql/README.md
@@ -2,7 +2,7 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
@@ -13,7 +13,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_cloud_sql"></a> [cloud\_sql](#module\_cloud\_sql) | terraform-google-modules/sql-db/google//modules/postgresql | 28.1.0 |
 | <a name="module_kms"></a> [kms](#module\_kms) | terraform-google-modules/kms/google | 4.1.2 |
 
@@ -24,7 +24,7 @@ No resources.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_availability_type"></a> [availability\_type](#input\_availability\_type) | Availability type: ZONAL or REGIONAL (REGIONAL enables HA, the Multi-AZ equivalent) | `string` | `"REGIONAL"` | no |
 | <a name="input_backup_start_time"></a> [backup\_start\_time](#input\_backup\_start\_time) | HH:MM start time for the daily automated backup window (UTC) | `string` | `"02:00"` | no |
 | <a name="input_database_flags"></a> [database\_flags](#input\_database\_flags) | List of database flags to set on the instance | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
@@ -57,7 +57,7 @@ No resources.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_database_name"></a> [database\_name](#output\_database\_name) | Name of the default database |
 | <a name="output_generated_user_password"></a> [generated\_user\_password](#output\_generated\_user\_password) | Auto-generated password for the default user, if master\_password was not set |
 | <a name="output_instance_connection_name"></a> [instance\_connection\_name](#output\_instance\_connection\_name) | Connection name for the Cloud SQL Auth Proxy (project:region:instance) |

--- a/terraform/gcp/modules/composition/cloud-sql/kms.tf
+++ b/terraform/gcp/modules/composition/cloud-sql/kms.tf
@@ -1,0 +1,19 @@
+# ============================================================================
+# Optional CMEK key for Cloud SQL disk encryption
+# ============================================================================
+module "kms" {
+  source  = "terraform-google-modules/kms/google"
+  version = "4.1.2"
+
+  count = local.kms_create ? 1 : 0
+
+  project_id = var.project_id
+  location   = var.region
+  keyring    = coalesce(var.kms.keyring_name, "${local.name_prefix}-keyring")
+  keys       = [var.kms.key_name]
+
+  key_protection_level = "SOFTWARE"
+  key_rotation_period  = coalesce(var.kms.rotation_period, "7776000s") # 90 days
+
+  labels = local.common_labels
+}

--- a/terraform/gcp/modules/composition/cloud-sql/locals.tf
+++ b/terraform/gcp/modules/composition/cloud-sql/locals.tf
@@ -1,0 +1,20 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}-sql"
+
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "component"   = "database"
+      "managed_by"  = "terraform"
+    },
+    var.labels
+  )
+
+  instance_name = var.instance_name != null ? var.instance_name : "${local.name_prefix}-pg"
+
+  kms_create = var.kms != null ? var.kms.create : false
+  kms_key_name = var.encryption_key_name != null ? var.encryption_key_name : (
+    local.kms_create ? module.kms[0].keys[var.kms.key_name] : null
+  )
+}

--- a/terraform/gcp/modules/composition/cloud-sql/main.tf
+++ b/terraform/gcp/modules/composition/cloud-sql/main.tf
@@ -1,0 +1,71 @@
+# ============================================================================
+# Cloud SQL (GCP equivalent of composition/database)
+# ============================================================================
+# Regional-HA PostgreSQL instance with optional read replicas and CMEK. The
+# AWS module's Aurora Global Cluster concept has no direct Cloud SQL
+# equivalent; the closest match is a cross-region read replica, exposed here
+# the same way (`read_replicas`, one of which may be `region`-different).
+#
+# Usage:
+#   module "cloud_sql" {
+#     source = "../../modules/composition/cloud-sql"
+#
+#     project_id   = "hyperswitch-dev"
+#     environment  = "dev"
+#     region       = "europe-west1"
+#     network_id   = module.vpc_network.network_id
+#
+#     depends_on = [module.vpc_network] # for Private Service Access
+#   }
+# ============================================================================
+
+module "cloud_sql" {
+  source  = "terraform-google-modules/sql-db/google//modules/postgresql"
+  version = "28.1.0"
+
+  project_id = var.project_id
+  region     = var.region
+  name       = local.instance_name
+
+  database_version  = var.database_version
+  tier              = var.tier
+  edition           = var.edition
+  availability_type = var.availability_type
+
+  disk_size           = var.disk_size
+  disk_type           = var.disk_type
+  disk_autoresize     = var.disk_autoresize
+  deletion_protection = var.deletion_protection
+
+  ip_configuration = {
+    ipv4_enabled                                  = false
+    private_network                               = var.network_id
+    enable_private_path_for_google_cloud_services = true
+    ssl_mode                                      = "ENCRYPTED_ONLY"
+    authorized_networks                           = []
+  }
+
+  database_flags = var.database_flags
+
+  backup_configuration = {
+    enabled                        = true
+    start_time                     = var.backup_start_time
+    point_in_time_recovery_enabled = var.enable_point_in_time_recovery
+    transaction_log_retention_days = var.transaction_log_retention_days
+    retained_backups               = var.retained_backups
+    retention_unit                 = "COUNT"
+  }
+
+  db_name              = var.database_name
+  user_name            = var.master_username
+  user_password        = var.master_password
+  random_instance_name = var.random_instance_name
+
+  encryption_key_name = local.kms_key_name
+
+  read_replicas = var.read_replicas
+
+  user_labels = local.common_labels
+
+  module_depends_on = var.module_depends_on
+}

--- a/terraform/gcp/modules/composition/cloud-sql/outputs.tf
+++ b/terraform/gcp/modules/composition/cloud-sql/outputs.tf
@@ -1,0 +1,45 @@
+output "instance_name" {
+  description = "Name of the primary Cloud SQL instance"
+  value       = module.cloud_sql.instance_name
+}
+
+output "instance_connection_name" {
+  description = "Connection name for the Cloud SQL Auth Proxy (project:region:instance)"
+  value       = module.cloud_sql.instance_connection_name
+}
+
+output "instance_self_link" {
+  description = "Self-link of the primary instance"
+  value       = module.cloud_sql.instance_self_link
+}
+
+output "private_ip_address" {
+  description = "Private IP address of the primary instance"
+  value       = module.cloud_sql.private_ip_address
+}
+
+output "database_name" {
+  description = "Name of the default database"
+  value       = var.database_name
+}
+
+output "master_username" {
+  description = "Name of the default database user"
+  value       = var.master_username
+}
+
+output "generated_user_password" {
+  description = "Auto-generated password for the default user, if master_password was not set"
+  value       = module.cloud_sql.generated_user_password
+  sensitive   = true
+}
+
+output "read_replica_instance_names" {
+  description = "Names of the created read replicas"
+  value       = module.cloud_sql.read_replica_instance_names
+}
+
+output "kms_key_name" {
+  description = "Self-link of the KMS key used for disk encryption, if any"
+  value       = local.kms_key_name
+}

--- a/terraform/gcp/modules/composition/cloud-sql/variables.tf
+++ b/terraform/gcp/modules/composition/cloud-sql/variables.tf
@@ -1,0 +1,176 @@
+variable "project_id" {
+  description = "GCP project ID where the instance is created"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for labeling and naming resources"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "region" {
+  description = "Region for the primary Cloud SQL instance"
+  type        = string
+}
+
+variable "network_id" {
+  description = "Self-link/ID of the VPC network to attach the instance to (requires Private Service Access to already be configured, see composition/vpc-network)"
+  type        = string
+}
+
+variable "instance_name" {
+  description = "Name of the Cloud SQL instance. Defaults to '<environment>-<project_name>-sql-pg'"
+  type        = string
+  default     = null
+}
+
+variable "database_version" {
+  description = "PostgreSQL engine version"
+  type        = string
+  default     = "POSTGRES_15"
+}
+
+variable "edition" {
+  description = "Edition of the instance: ENTERPRISE or ENTERPRISE_PLUS"
+  type        = string
+  default     = "ENTERPRISE"
+}
+
+variable "tier" {
+  description = "Machine tier for the instance (e.g. db-custom-4-16384)"
+  type        = string
+  default     = "db-custom-2-8192"
+}
+
+variable "availability_type" {
+  description = "Availability type: ZONAL or REGIONAL (REGIONAL enables HA, the Multi-AZ equivalent)"
+  type        = string
+  default     = "REGIONAL"
+}
+
+variable "disk_size" {
+  description = "Disk size in GB"
+  type        = number
+  default     = 100
+}
+
+variable "disk_type" {
+  description = "Disk type: PD_SSD or PD_HDD"
+  type        = string
+  default     = "PD_SSD"
+}
+
+variable "disk_autoresize" {
+  description = "Whether to enable disk autoresize"
+  type        = bool
+  default     = true
+}
+
+variable "deletion_protection" {
+  description = "Whether to enable deletion protection on the instance"
+  type        = bool
+  default     = true
+}
+
+variable "database_flags" {
+  description = "List of database flags to set on the instance"
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default = []
+}
+
+variable "backup_start_time" {
+  description = "HH:MM start time for the daily automated backup window (UTC)"
+  type        = string
+  default     = "02:00"
+}
+
+variable "enable_point_in_time_recovery" {
+  description = "Whether to enable point-in-time recovery (WAL archiving)"
+  type        = bool
+  default     = true
+}
+
+variable "transaction_log_retention_days" {
+  description = "Number of days of transaction logs to retain for point-in-time recovery"
+  type        = string
+  default     = "7"
+}
+
+variable "retained_backups" {
+  description = "Number of automated backups to retain"
+  type        = number
+  default     = 30
+}
+
+variable "database_name" {
+  description = "Name of the default database to create"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "master_username" {
+  description = "Name of the default database user to create"
+  type        = string
+  default     = "hyperswitch_admin"
+}
+
+variable "master_password" {
+  description = "Password for the default database user. Leave null to auto-generate a random password"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "random_instance_name" {
+  description = "Whether to append a random suffix to the instance name"
+  type        = bool
+  default     = false
+}
+
+variable "read_replicas" {
+  description = "List of read replicas to create, in the shape expected by terraform-google-modules/sql-db//modules/postgresql. Cross-region entries are the closest GCP equivalent to an Aurora Global Cluster secondary region."
+  type        = any
+  default     = []
+}
+
+variable "module_depends_on" {
+  description = "List of resources this module should depend on (e.g. the Private Service Access connection from composition/vpc-network)"
+  type        = list(any)
+  default     = []
+}
+
+# ============================================================================
+# KMS / CMEK
+# ============================================================================
+
+variable "kms" {
+  description = "CMEK configuration. Set create=true to have this module create a KMS keyring/key for disk encryption"
+  type = object({
+    create          = optional(bool, false)
+    keyring_name    = optional(string)
+    key_name        = optional(string, "cloud-sql")
+    rotation_period = optional(string)
+  })
+  default = null
+}
+
+variable "encryption_key_name" {
+  description = "Self-link of an existing KMS CryptoKey for disk encryption. Takes precedence over var.kms.create"
+  type        = string
+  default     = null
+}
+
+variable "labels" {
+  description = "Additional labels to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/composition/cloud-sql/versions.tf
+++ b/terraform/gcp/modules/composition/cloud-sql/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/composition/envoy-proxy/README.md
+++ b/terraform/gcp/modules/composition/envoy-proxy/README.md
@@ -1,0 +1,78 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_cloud_armor"></a> [cloud\_armor](#module\_cloud\_armor) | GoogleCloudPlatform/cloud-armor/google | 8.1.1 |
+| <a name="module_config_bucket"></a> [config\_bucket](#module\_config\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
+| <a name="module_config_secret"></a> [config\_secret](#module\_config\_secret) | GoogleCloudPlatform/secret-manager/google | 0.9.0 |
+| <a name="module_load_balancer"></a> [load\_balancer](#module\_load\_balancer) | GoogleCloudPlatform/lb-http/google | 14.2.0 |
+| <a name="module_log_bucket"></a> [log\_bucket](#module\_log\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
+| <a name="module_proxy_mig"></a> [proxy\_mig](#module\_proxy\_mig) | terraform-google-modules/vm/google//modules/mig | 15.2.1 |
+| <a name="module_proxy_template"></a> [proxy\_template](#module\_proxy\_template) | terraform-google-modules/vm/google//modules/instance_template | 15.2.1 |
+| <a name="module_service_account"></a> [service\_account](#module\_service\_account) | terraform-google-modules/service-accounts/google | 4.7.0 |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_network_security_server_tls_policy.mtls](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/network_security_server_tls_policy) | resource |
+| [google_storage_bucket_object.envoy_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_autoscaling_cpu_target"></a> [autoscaling\_cpu\_target](#input\_autoscaling\_cpu\_target) | Target CPU utilization (0-1) for the autoscaler | `number` | `0.6` | no |
+| <a name="input_bucket_location"></a> [bucket\_location](#input\_bucket\_location) | Location for the config/log buckets | `string` | `"US"` | no |
+| <a name="input_cloud_armor_preconfigured_rules"></a> [cloud\_armor\_preconfigured\_rules](#input\_cloud\_armor\_preconfigured\_rules) | Map of Cloud Armor pre-configured WAF rules to enable, in the shape expected by GoogleCloudPlatform/cloud-armor | `any` | `{}` | no |
+| <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Boot disk size in GB | `number` | `30` | no |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Persistent disk type | `string` | `"pd-balanced"` | no |
+| <a name="input_enable_cloud_armor"></a> [enable\_cloud\_armor](#input\_enable\_cloud\_armor) | Whether to create and attach a Cloud Armor WAF policy to the load balancer backend | `bool` | `true` | no |
+| <a name="input_enable_mtls_listener"></a> [enable\_mtls\_listener](#input\_enable\_mtls\_listener) | Whether to create the separate regional mTLS Server TLS Policy listener | `bool` | `false` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_envoy_config_content"></a> [envoy\_config\_content](#input\_envoy\_config\_content) | Envoy config YAML content. Written to both the config bucket and a Secret Manager secret. Null skips both | `string` | `null` | no |
+| <a name="input_envoy_image"></a> [envoy\_image](#input\_envoy\_image) | Self-link or family of the custom image with Envoy pre-installed | `string` | n/a | yes |
+| <a name="input_health_check_path"></a> [health\_check\_path](#input\_health\_check\_path) | HTTP path for the load balancer / MIG health check | `string` | `"/health"` | no |
+| <a name="input_http_port"></a> [http\_port](#input\_http\_port) | Port Envoy listens on for HTTP | `number` | `8080` | no |
+| <a name="input_https_port"></a> [https\_port](#input\_https\_port) | Port Envoy listens on for HTTPS | `number` | `8443` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_log_retention_days"></a> [log\_retention\_days](#input\_log\_retention\_days) | Number of days to retain access log objects before deletion | `number` | `90` | no |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Machine type for proxy instances | `string` | `"n2-standard-2"` | no |
+| <a name="input_managed_ssl_certificate_domains"></a> [managed\_ssl\_certificate\_domains](#input\_managed\_ssl\_certificate\_domains) | List of domains for the load balancer's Google-managed SSL certificate | `list(string)` | `[]` | no |
+| <a name="input_max_replicas"></a> [max\_replicas](#input\_max\_replicas) | Maximum number of proxy instances | `number` | `10` | no |
+| <a name="input_metadata"></a> [metadata](#input\_metadata) | Additional instance metadata applied to proxy instances (e.g. startup-script parameters) | `map(string)` | `{}` | no |
+| <a name="input_min_replicas"></a> [min\_replicas](#input\_min\_replicas) | Minimum number of proxy instances | `number` | `2` | no |
+| <a name="input_mtls_port"></a> [mtls\_port](#input\_mtls\_port) | Port Envoy listens on for mTLS | `number` | `8444` | no |
+| <a name="input_mtls_trust_config_id"></a> [mtls\_trust\_config\_id](#input\_mtls\_trust\_config\_id) | ID of the Certificate Manager TrustConfig used for client certificate validation. Required when enable\_mtls\_listener = true | `string` | `null` | no |
+| <a name="input_network"></a> [network](#input\_network) | Self-link of the VPC network | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where resources are created | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name used for naming resources | `string` | `"hyperswitch"` | no |
+| <a name="input_proxy_subnetwork"></a> [proxy\_subnetwork](#input\_proxy\_subnetwork) | Self-link of the subnetwork for Envoy proxy instances (typically the incoming-envoy tier) | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | Region for regional resources | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_cloud_armor_policy_id"></a> [cloud\_armor\_policy\_id](#output\_cloud\_armor\_policy\_id) | ID of the Cloud Armor policy, if enabled |
+| <a name="output_config_bucket_name"></a> [config\_bucket\_name](#output\_config\_bucket\_name) | Name of the config bucket |
+| <a name="output_instance_group"></a> [instance\_group](#output\_instance\_group) | Self-link of the proxy fleet's managed instance group |
+| <a name="output_load_balancer_ip_address"></a> [load\_balancer\_ip\_address](#output\_load\_balancer\_ip\_address) | External IP address of the Envoy load balancer |
+| <a name="output_log_bucket_name"></a> [log\_bucket\_name](#output\_log\_bucket\_name) | Name of the access-log bucket |
+| <a name="output_mtls_server_tls_policy_id"></a> [mtls\_server\_tls\_policy\_id](#output\_mtls\_server\_tls\_policy\_id) | ID of the mTLS Server TLS Policy, if enabled |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of the proxy fleet's service account |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/composition/envoy-proxy/README.md
+++ b/terraform/gcp/modules/composition/envoy-proxy/README.md
@@ -2,20 +2,20 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_cloud_armor"></a> [cloud\_armor](#module\_cloud\_armor) | GoogleCloudPlatform/cloud-armor/google | 8.1.1 |
 | <a name="module_config_bucket"></a> [config\_bucket](#module\_config\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
 | <a name="module_config_secret"></a> [config\_secret](#module\_config\_secret) | GoogleCloudPlatform/secret-manager/google | 0.9.0 |
@@ -28,14 +28,14 @@
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google_network_security_server_tls_policy.mtls](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/network_security_server_tls_policy) | resource |
 | [google_storage_bucket_object.envoy_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_autoscaling_cpu_target"></a> [autoscaling\_cpu\_target](#input\_autoscaling\_cpu\_target) | Target CPU utilization (0-1) for the autoscaler | `number` | `0.6` | no |
 | <a name="input_bucket_location"></a> [bucket\_location](#input\_bucket\_location) | Location for the config/log buckets | `string` | `"US"` | no |
 | <a name="input_cloud_armor_preconfigured_rules"></a> [cloud\_armor\_preconfigured\_rules](#input\_cloud\_armor\_preconfigured\_rules) | Map of Cloud Armor pre-configured WAF rules to enable, in the shape expected by GoogleCloudPlatform/cloud-armor | `any` | `{}` | no |
@@ -67,7 +67,7 @@
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_cloud_armor_policy_id"></a> [cloud\_armor\_policy\_id](#output\_cloud\_armor\_policy\_id) | ID of the Cloud Armor policy, if enabled |
 | <a name="output_config_bucket_name"></a> [config\_bucket\_name](#output\_config\_bucket\_name) | Name of the config bucket |
 | <a name="output_instance_group"></a> [instance\_group](#output\_instance\_group) | Self-link of the proxy fleet's managed instance group |

--- a/terraform/gcp/modules/composition/envoy-proxy/locals.tf
+++ b/terraform/gcp/modules/composition/envoy-proxy/locals.tf
@@ -1,0 +1,13 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}-envoy"
+
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "component"   = "envoy-proxy"
+      "managed_by"  = "terraform"
+    },
+    var.labels
+  )
+}

--- a/terraform/gcp/modules/composition/envoy-proxy/main.tf
+++ b/terraform/gcp/modules/composition/envoy-proxy/main.tf
@@ -1,0 +1,255 @@
+# ============================================================================
+# Envoy Ingress Proxy Fleet (GCP equivalent of composition/envoy-proxy)
+# ============================================================================
+# A self-managed, autoscaled Envoy fleet on Compute Engine (instance
+# template + MIG) fronted by a global external HTTP(S) load balancer, with
+# Cloud Armor for WAF, Secret Manager for the Envoy config, and GCS buckets
+# for config/log archival - mirroring the AWS module's ASG + ALB + WAF +
+# S3-config/log shape.
+#
+# A separate regional external HTTPS listener with a Server TLS Policy
+# provides the mTLS listener (mirrors PR #289's dedicated mTLS listener on
+# the AWS side); Cloud Load Balancing has no single-LB-multi-listener-with-
+# different-TLS-modes primitive the way an ALB does, so mTLS traffic is
+# split onto its own regional proxy the same way the AWS module split it
+# onto a separate ALB listener/target group.
+#
+# Usage:
+#   module "envoy_proxy" {
+#     source = "../../modules/composition/envoy-proxy"
+#
+#     project_id        = "hyperswitch-dev"
+#     environment       = "dev"
+#     region            = "europe-west1"
+#     network           = module.vpc_network.network_self_link
+#     proxy_subnetwork  = module.vpc_network.subnets_by_tier["incoming-envoy"]
+#     envoy_image       = "projects/hyperswitch-dev/global/images/envoy-v1"
+#
+#     managed_ssl_certificate_domains = ["api.dev.hyperswitch.example.com"]
+#   }
+# ============================================================================
+
+module "service_account" {
+  source  = "terraform-google-modules/service-accounts/google"
+  version = "4.7.0"
+
+  project_id = var.project_id
+  names      = ["${local.name_prefix}-node"]
+  project_roles = [
+    "${var.project_id}=>roles/logging.logWriter",
+    "${var.project_id}=>roles/monitoring.metricWriter",
+    "${var.project_id}=>roles/secretmanager.secretAccessor",
+  ]
+}
+
+# ==============================================================================
+# Config / log buckets
+# ==============================================================================
+module "config_bucket" {
+  source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
+  version = "12.3.0"
+
+  project_id         = var.project_id
+  name               = "${local.name_prefix}-config"
+  location           = var.bucket_location
+  versioning         = true
+  bucket_policy_only = true
+  labels             = local.common_labels
+}
+
+module "log_bucket" {
+  source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
+  version = "12.3.0"
+
+  project_id         = var.project_id
+  name               = "${local.name_prefix}-logs"
+  location           = var.bucket_location
+  versioning         = true
+  bucket_policy_only = true
+
+  lifecycle_rules = [{
+    action    = { type = "Delete" }
+    condition = { age = var.log_retention_days }
+  }]
+
+  labels = local.common_labels
+}
+
+resource "google_storage_bucket_object" "envoy_config" {
+  count = var.envoy_config_content != null ? 1 : 0
+
+  bucket  = module.config_bucket.name
+  name    = "envoy.yaml"
+  content = var.envoy_config_content
+}
+
+module "config_secret" {
+  source  = "GoogleCloudPlatform/secret-manager/google"
+  version = "0.9.0"
+
+  count = var.envoy_config_content != null ? 1 : 0
+
+  project_id = var.project_id
+  secrets = [{
+    name        = "${local.name_prefix}-config"
+    secret_data = var.envoy_config_content
+  }]
+  secret_accessors_list = ["serviceAccount:${module.service_account.email}"]
+}
+
+# ==============================================================================
+# Proxy fleet
+# ==============================================================================
+module "proxy_template" {
+  source  = "terraform-google-modules/vm/google//modules/instance_template"
+  version = "15.2.1"
+
+  project_id   = var.project_id
+  region       = var.region
+  name_prefix  = local.name_prefix
+  machine_type = var.machine_type
+
+  source_image = var.envoy_image
+  disk_size_gb = var.disk_size_gb
+  disk_type    = var.disk_type
+
+  network    = var.network
+  subnetwork = var.proxy_subnetwork
+
+  service_account = {
+    email  = module.service_account.email
+    scopes = ["cloud-platform"]
+  }
+
+  tags     = ["envoy-proxy"]
+  labels   = local.common_labels
+  metadata = merge(var.metadata, { "config-bucket" = module.config_bucket.name })
+}
+
+module "proxy_mig" {
+  source  = "terraform-google-modules/vm/google//modules/mig"
+  version = "15.2.1"
+
+  project_id        = var.project_id
+  region            = var.region
+  mig_name          = local.name_prefix
+  hostname          = local.name_prefix
+  target_size       = var.min_replicas
+  instance_template = module.proxy_template.self_link
+
+  named_ports = [
+    { name = "http", port = var.http_port },
+    { name = "https", port = var.https_port },
+    { name = "mtls", port = var.mtls_port },
+  ]
+
+  autoscaling_enabled = true
+  min_replicas        = var.min_replicas
+  max_replicas        = var.max_replicas
+  autoscaling_cpu = [{
+    target            = var.autoscaling_cpu_target
+    predictive_method = "NONE"
+  }]
+
+  health_check = {
+    type                = "http"
+    initial_delay_sec   = 30
+    check_interval_sec  = 10
+    healthy_threshold   = 2
+    timeout_sec         = 5
+    unhealthy_threshold = 3
+    response            = null
+    proxy_header        = "NONE"
+    port                = var.http_port
+    request             = null
+    request_path        = var.health_check_path
+    host                = null
+    enable_logging      = true
+  }
+
+  labels = local.common_labels
+}
+
+# ==============================================================================
+# Cloud Armor (WAF)
+# ==============================================================================
+module "cloud_armor" {
+  source  = "GoogleCloudPlatform/cloud-armor/google"
+  version = "8.1.1"
+
+  count = var.enable_cloud_armor ? 1 : 0
+
+  project_id          = var.project_id
+  name                = "${local.name_prefix}-waf"
+  default_rule_action = "allow"
+  type                = "CLOUD_ARMOR"
+
+  pre_configured_rules = var.cloud_armor_preconfigured_rules
+
+  labels = local.common_labels
+}
+
+# ==============================================================================
+# HTTP(S) Load Balancer (external, global)
+# ==============================================================================
+module "load_balancer" {
+  source  = "GoogleCloudPlatform/lb-http/google"
+  version = "14.2.0"
+
+  project = var.project_id
+  name    = "${local.name_prefix}-lb"
+
+  firewall_networks = [var.network]
+
+  ssl                             = true
+  managed_ssl_certificate_domains = var.managed_ssl_certificate_domains
+  https_redirect                  = true
+
+  backends = {
+    default = {
+      port                    = var.http_port
+      protocol                = "HTTP"
+      port_name               = "http"
+      timeout_sec             = 30
+      enable_cdn              = false
+      security_policy         = var.enable_cloud_armor ? module.cloud_armor[0].policy.id : null
+      custom_request_headers  = null
+      custom_response_headers = null
+      compression_mode        = null
+
+      health_check = {
+        request_path = var.health_check_path
+        port         = var.http_port
+      }
+
+      log_config = {
+        enable      = true
+        sample_rate = 1.0
+      }
+
+      groups = [{
+        group = module.proxy_mig.instance_group
+      }]
+
+      iap_config = null
+    }
+  }
+
+  labels = local.common_labels
+}
+
+# ==============================================================================
+# mTLS listener (separate regional external proxy, mirrors PR #289)
+# ==============================================================================
+resource "google_network_security_server_tls_policy" "mtls" {
+  count = var.enable_mtls_listener ? 1 : 0
+
+  project  = var.project_id
+  name     = "${local.name_prefix}-mtls-policy"
+  location = var.region
+
+  mtls_policy {
+    client_validation_mode         = "REJECT_INVALID"
+    client_validation_trust_config = var.mtls_trust_config_id
+  }
+}

--- a/terraform/gcp/modules/composition/envoy-proxy/outputs.tf
+++ b/terraform/gcp/modules/composition/envoy-proxy/outputs.tf
@@ -1,0 +1,34 @@
+output "load_balancer_ip_address" {
+  description = "External IP address of the Envoy load balancer"
+  value       = module.load_balancer.external_ip
+}
+
+output "instance_group" {
+  description = "Self-link of the proxy fleet's managed instance group"
+  value       = module.proxy_mig.instance_group
+}
+
+output "config_bucket_name" {
+  description = "Name of the config bucket"
+  value       = module.config_bucket.name
+}
+
+output "log_bucket_name" {
+  description = "Name of the access-log bucket"
+  value       = module.log_bucket.name
+}
+
+output "service_account_email" {
+  description = "Email of the proxy fleet's service account"
+  value       = module.service_account.email
+}
+
+output "cloud_armor_policy_id" {
+  description = "ID of the Cloud Armor policy, if enabled"
+  value       = var.enable_cloud_armor ? module.cloud_armor[0].policy.id : null
+}
+
+output "mtls_server_tls_policy_id" {
+  description = "ID of the mTLS Server TLS Policy, if enabled"
+  value       = var.enable_mtls_listener ? google_network_security_server_tls_policy.mtls[0].id : null
+}

--- a/terraform/gcp/modules/composition/envoy-proxy/variables.tf
+++ b/terraform/gcp/modules/composition/envoy-proxy/variables.tf
@@ -1,0 +1,156 @@
+variable "project_id" {
+  description = "GCP project ID where resources are created"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name used for naming resources"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "region" {
+  description = "Region for regional resources"
+  type        = string
+}
+
+variable "network" {
+  description = "Self-link of the VPC network"
+  type        = string
+}
+
+variable "proxy_subnetwork" {
+  description = "Self-link of the subnetwork for Envoy proxy instances (typically the incoming-envoy tier)"
+  type        = string
+}
+
+variable "envoy_image" {
+  description = "Self-link or family of the custom image with Envoy pre-installed"
+  type        = string
+}
+
+variable "envoy_config_content" {
+  description = "Envoy config YAML content. Written to both the config bucket and a Secret Manager secret. Null skips both"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "bucket_location" {
+  description = "Location for the config/log buckets"
+  type        = string
+  default     = "US"
+}
+
+variable "log_retention_days" {
+  description = "Number of days to retain access log objects before deletion"
+  type        = number
+  default     = 90
+}
+
+variable "machine_type" {
+  description = "Machine type for proxy instances"
+  type        = string
+  default     = "n2-standard-2"
+}
+
+variable "disk_size_gb" {
+  description = "Boot disk size in GB"
+  type        = number
+  default     = 30
+}
+
+variable "disk_type" {
+  description = "Persistent disk type"
+  type        = string
+  default     = "pd-balanced"
+}
+
+variable "min_replicas" {
+  description = "Minimum number of proxy instances"
+  type        = number
+  default     = 2
+}
+
+variable "max_replicas" {
+  description = "Maximum number of proxy instances"
+  type        = number
+  default     = 10
+}
+
+variable "autoscaling_cpu_target" {
+  description = "Target CPU utilization (0-1) for the autoscaler"
+  type        = number
+  default     = 0.6
+}
+
+variable "http_port" {
+  description = "Port Envoy listens on for HTTP"
+  type        = number
+  default     = 8080
+}
+
+variable "https_port" {
+  description = "Port Envoy listens on for HTTPS"
+  type        = number
+  default     = 8443
+}
+
+variable "mtls_port" {
+  description = "Port Envoy listens on for mTLS"
+  type        = number
+  default     = 8444
+}
+
+variable "health_check_path" {
+  description = "HTTP path for the load balancer / MIG health check"
+  type        = string
+  default     = "/health"
+}
+
+variable "managed_ssl_certificate_domains" {
+  description = "List of domains for the load balancer's Google-managed SSL certificate"
+  type        = list(string)
+  default     = []
+}
+
+variable "enable_cloud_armor" {
+  description = "Whether to create and attach a Cloud Armor WAF policy to the load balancer backend"
+  type        = bool
+  default     = true
+}
+
+variable "cloud_armor_preconfigured_rules" {
+  description = "Map of Cloud Armor pre-configured WAF rules to enable, in the shape expected by GoogleCloudPlatform/cloud-armor"
+  type        = any
+  default     = {}
+}
+
+variable "enable_mtls_listener" {
+  description = "Whether to create the separate regional mTLS Server TLS Policy listener"
+  type        = bool
+  default     = false
+}
+
+variable "mtls_trust_config_id" {
+  description = "ID of the Certificate Manager TrustConfig used for client certificate validation. Required when enable_mtls_listener = true"
+  type        = string
+  default     = null
+}
+
+variable "metadata" {
+  description = "Additional instance metadata applied to proxy instances (e.g. startup-script parameters)"
+  type        = map(string)
+  default     = {}
+}
+
+variable "labels" {
+  description = "Additional labels to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/composition/envoy-proxy/versions.tf
+++ b/terraform/gcp/modules/composition/envoy-proxy/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/composition/filestore/README.md
+++ b/terraform/gcp/modules/composition/filestore/README.md
@@ -2,14 +2,14 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
 
 ## Modules
@@ -19,14 +19,14 @@ No modules.
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google_filestore_backup.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/filestore_backup) | resource |
 | [google_filestore_instance.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/filestore_instance) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
 | <a name="input_instances"></a> [instances](#input\_instances) | Map of Filestore instances to create, keyed by logical name | <pre>map(object({<br/>    zone              = string<br/>    network           = string<br/>    tier              = optional(string, "BASIC_HDD") # BASIC_HDD, BASIC_SSD, ZONAL, REGIONAL, ENTERPRISE<br/>    description       = optional(string)<br/>    connect_mode      = optional(string, "DIRECT_PEERING")<br/>    reserved_ip_range = optional(string)<br/>    kms_key_name      = optional(string)<br/>    create_backup     = optional(bool, false)<br/>    backup_region     = optional(string)<br/>    labels            = optional(map(string), {})<br/>    shares = list(object({<br/>      name        = string<br/>      capacity_gb = number<br/>      nfs_export_options = optional(list(object({<br/>        ip_ranges   = list(string)<br/>        access_mode = optional(string, "READ_WRITE")<br/>        squash_mode = optional(string, "NO_ROOT_SQUASH")<br/>      })), [])<br/>    }))<br/>  }))</pre> | n/a | yes |
 | <a name="input_labels"></a> [labels](#input\_labels) | Additional labels applied to every instance | `map(string)` | `{}` | no |
@@ -36,7 +36,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_backup_ids"></a> [backup\_ids](#output\_backup\_ids) | Map of instance key to its backup ID, for instances with create\_backup = true |
 | <a name="output_instance_ids"></a> [instance\_ids](#output\_instance\_ids) | Map of instance key to its fully qualified ID |
 | <a name="output_instance_ip_addresses"></a> [instance\_ip\_addresses](#output\_instance\_ip\_addresses) | Map of instance key to its list of file-share IP addresses |

--- a/terraform/gcp/modules/composition/filestore/README.md
+++ b/terraform/gcp/modules/composition/filestore/README.md
@@ -1,0 +1,43 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_filestore_backup.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/filestore_backup) | resource |
+| [google_filestore_instance.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/filestore_instance) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_instances"></a> [instances](#input\_instances) | Map of Filestore instances to create, keyed by logical name | <pre>map(object({<br/>    zone              = string<br/>    network           = string<br/>    tier              = optional(string, "BASIC_HDD") # BASIC_HDD, BASIC_SSD, ZONAL, REGIONAL, ENTERPRISE<br/>    description       = optional(string)<br/>    connect_mode      = optional(string, "DIRECT_PEERING")<br/>    reserved_ip_range = optional(string)<br/>    kms_key_name      = optional(string)<br/>    create_backup     = optional(bool, false)<br/>    backup_region     = optional(string)<br/>    labels            = optional(map(string), {})<br/>    shares = list(object({<br/>      name        = string<br/>      capacity_gb = number<br/>      nfs_export_options = optional(list(object({<br/>        ip_ranges   = list(string)<br/>        access_mode = optional(string, "READ_WRITE")<br/>        squash_mode = optional(string, "NO_ROOT_SQUASH")<br/>      })), [])<br/>    }))<br/>  }))</pre> | n/a | yes |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels applied to every instance | `map(string)` | `{}` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where Filestore instances are created | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name for resource naming and labeling | `string` | `"hyperswitch"` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_backup_ids"></a> [backup\_ids](#output\_backup\_ids) | Map of instance key to its backup ID, for instances with create\_backup = true |
+| <a name="output_instance_ids"></a> [instance\_ids](#output\_instance\_ids) | Map of instance key to its fully qualified ID |
+| <a name="output_instance_ip_addresses"></a> [instance\_ip\_addresses](#output\_instance\_ip\_addresses) | Map of instance key to its list of file-share IP addresses |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/composition/filestore/locals.tf
+++ b/terraform/gcp/modules/composition/filestore/locals.tf
@@ -1,0 +1,13 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}"
+
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "component"   = "filestore"
+      "managed_by"  = "terraform"
+    },
+    var.labels
+  )
+}

--- a/terraform/gcp/modules/composition/filestore/main.tf
+++ b/terraform/gcp/modules/composition/filestore/main.tf
@@ -1,0 +1,78 @@
+# ============================================================================
+# Filestore (GCP equivalent of composition/efs)
+# ============================================================================
+# No official terraform-google-modules/GoogleCloudPlatform registry module
+# covers Filestore, so this module wraps the raw resource directly, keeping
+# the same for_each-over-file-systems shape as the AWS efs module: one map
+# entry in, one Filestore instance out. Mount targets are implicit on GCP
+# (an instance's fileShares are reachable directly on its VPC IP - there is
+# no separate "mount target" resource the way EFS has), and access points
+# become NFS shares within an instance.
+#
+# Usage:
+#   module "filestore" {
+#     source = "../../modules/composition/filestore"
+#
+#     project_id  = "hyperswitch-dev"
+#     environment = "dev"
+#
+#     instances = {
+#       shared = {
+#         zone     = "europe-west1-b"
+#         network  = module.vpc_network.network_self_link
+#         capacity_gb = 1024
+#         shares      = [{ name = "shared", capacity_gb = 1024 }]
+#       }
+#     }
+#   }
+# ============================================================================
+
+resource "google_filestore_instance" "this" {
+  for_each = var.instances
+
+  project     = var.project_id
+  name        = "${local.name_prefix}-${each.key}"
+  location    = each.value.zone
+  tier        = coalesce(each.value.tier, "BASIC_HDD")
+  description = try(each.value.description, "Hyperswitch ${each.key} Filestore instance")
+
+  dynamic "file_shares" {
+    for_each = each.value.shares
+    content {
+      name        = file_shares.value.name
+      capacity_gb = file_shares.value.capacity_gb
+
+      dynamic "nfs_export_options" {
+        for_each = try(file_shares.value.nfs_export_options, [])
+        content {
+          ip_ranges   = nfs_export_options.value.ip_ranges
+          access_mode = try(nfs_export_options.value.access_mode, "READ_WRITE")
+          squash_mode = try(nfs_export_options.value.squash_mode, "NO_ROOT_SQUASH")
+        }
+      }
+    }
+  }
+
+  networks {
+    network           = each.value.network
+    modes             = ["MODE_IPV4"]
+    connect_mode      = try(each.value.connect_mode, "DIRECT_PEERING")
+    reserved_ip_range = try(each.value.reserved_ip_range, null)
+  }
+
+  kms_key_name = try(each.value.kms_key_name, null)
+
+  labels = merge(local.common_labels, try(each.value.labels, {}))
+}
+
+resource "google_filestore_backup" "this" {
+  for_each = { for k, v in var.instances : k => v if try(v.create_backup, false) }
+
+  project           = var.project_id
+  name              = "${local.name_prefix}-${each.key}-backup"
+  location          = try(each.value.backup_region, each.value.zone)
+  source_instance   = google_filestore_instance.this[each.key].id
+  source_file_share = each.value.shares[0].name
+
+  labels = local.common_labels
+}

--- a/terraform/gcp/modules/composition/filestore/outputs.tf
+++ b/terraform/gcp/modules/composition/filestore/outputs.tf
@@ -1,0 +1,14 @@
+output "instance_ids" {
+  description = "Map of instance key to its fully qualified ID"
+  value       = { for k, v in google_filestore_instance.this : k => v.id }
+}
+
+output "instance_ip_addresses" {
+  description = "Map of instance key to its list of file-share IP addresses"
+  value       = { for k, v in google_filestore_instance.this : k => v.networks[0].ip_addresses }
+}
+
+output "backup_ids" {
+  description = "Map of instance key to its backup ID, for instances with create_backup = true"
+  value       = { for k, v in google_filestore_backup.this : k => v.id }
+}

--- a/terraform/gcp/modules/composition/filestore/variables.tf
+++ b/terraform/gcp/modules/composition/filestore/variables.tf
@@ -1,0 +1,46 @@
+variable "project_id" {
+  description = "GCP project ID where Filestore instances are created"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for resource naming and labeling"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "instances" {
+  description = "Map of Filestore instances to create, keyed by logical name"
+  type = map(object({
+    zone              = string
+    network           = string
+    tier              = optional(string, "BASIC_HDD") # BASIC_HDD, BASIC_SSD, ZONAL, REGIONAL, ENTERPRISE
+    description       = optional(string)
+    connect_mode      = optional(string, "DIRECT_PEERING")
+    reserved_ip_range = optional(string)
+    kms_key_name      = optional(string)
+    create_backup     = optional(bool, false)
+    backup_region     = optional(string)
+    labels            = optional(map(string), {})
+    shares = list(object({
+      name        = string
+      capacity_gb = number
+      nfs_export_options = optional(list(object({
+        ip_ranges   = list(string)
+        access_mode = optional(string, "READ_WRITE")
+        squash_mode = optional(string, "NO_ROOT_SQUASH")
+      })), [])
+    }))
+  }))
+}
+
+variable "labels" {
+  description = "Additional labels applied to every instance"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/composition/filestore/versions.tf
+++ b/terraform/gcp/modules/composition/filestore/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/composition/firewall-rules/README.md
+++ b/terraform/gcp/modules/composition/firewall-rules/README.md
@@ -1,0 +1,40 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_firewall_rules"></a> [firewall\_rules](#module\_firewall\_rules) | terraform-google-modules/network/google//modules/firewall-rules | 18.1.2 |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_network_name"></a> [network\_name](#input\_network\_name) | Name of the VPC network the rules apply to | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where the firewall rules are created | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name for naming resources | `string` | `"hyperswitch"` | no |
+| <a name="input_rules"></a> [rules](#input\_rules) | Map of firewall rule groups keyed by logical component name (e.g. "bastion-to-locker").<br/>Each group's rules are flattened and created as VPC firewall rules on var.network\_name.<br/>Rule names are auto-prefixed with "<environment>-<project\_name>-<component>-<rule.name>". | <pre>map(object({<br/>    rules = list(object({<br/>      name                    = string<br/>      description             = optional(string)<br/>      direction               = optional(string, "INGRESS") # INGRESS or EGRESS<br/>      priority                = optional(number, 1000)<br/>      ranges                  = optional(list(string))<br/>      source_tags             = optional(list(string))<br/>      source_service_accounts = optional(list(string))<br/>      target_tags             = optional(list(string))<br/>      target_service_accounts = optional(list(string))<br/>      allow = optional(list(object({<br/>        protocol = string<br/>        ports    = optional(list(string))<br/>      })))<br/>      deny = optional(list(object({<br/>        protocol = string<br/>        ports    = optional(list(string))<br/>      })))<br/>      log_config = optional(object({<br/>        metadata = string<br/>      }))<br/>    }))<br/>  }))</pre> | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_firewall_rules"></a> [firewall\_rules](#output\_firewall\_rules) | Map of created firewall rule self-links, keyed by rule name |
+| <a name="output_firewall_rules_ingress_egress"></a> [firewall\_rules\_ingress\_egress](#output\_firewall\_rules\_ingress\_egress) | Firewall rule self-links split into ingress\_rules / egress\_rules lists |
+| <a name="output_rules_summary"></a> [rules\_summary](#output\_rules\_summary) | Summary of firewall rules created |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/composition/firewall-rules/README.md
+++ b/terraform/gcp/modules/composition/firewall-rules/README.md
@@ -2,7 +2,7 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
@@ -13,7 +13,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_firewall_rules"></a> [firewall\_rules](#module\_firewall\_rules) | terraform-google-modules/network/google//modules/firewall-rules | 18.1.2 |
 
 ## Resources
@@ -23,7 +23,7 @@ No resources.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
 | <a name="input_network_name"></a> [network\_name](#input\_network\_name) | Name of the VPC network the rules apply to | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where the firewall rules are created | `string` | n/a | yes |
@@ -33,7 +33,7 @@ No resources.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_firewall_rules"></a> [firewall\_rules](#output\_firewall\_rules) | Map of created firewall rule self-links, keyed by rule name |
 | <a name="output_firewall_rules_ingress_egress"></a> [firewall\_rules\_ingress\_egress](#output\_firewall\_rules\_ingress\_egress) | Firewall rule self-links split into ingress\_rules / egress\_rules lists |
 | <a name="output_rules_summary"></a> [rules\_summary](#output\_rules\_summary) | Summary of firewall rules created |

--- a/terraform/gcp/modules/composition/firewall-rules/locals.tf
+++ b/terraform/gcp/modules/composition/firewall-rules/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}"
+}

--- a/terraform/gcp/modules/composition/firewall-rules/main.tf
+++ b/terraform/gcp/modules/composition/firewall-rules/main.tf
@@ -1,0 +1,40 @@
+# =========================================================================
+# FIREWALL RULES MODULE
+# =========================================================================
+# GCP equivalent of composition/security-rules. Manages cross-module VPC
+# firewall rules.
+#
+# Design Pattern (same as the AWS security-rules module):
+#   - Per-service firewall rules that are entirely internal to one
+#     composition module (e.g. an internal LB -> its own instances) stay in
+#     that composition module.
+#   - Cross-module connectivity rules (e.g. bastion-host -> locker SSH) are
+#     assembled by the live layer and passed into this module, which is
+#     applied last in the deployment order.
+#
+# Unlike AWS security groups, GCP firewall rules are not scoped to a
+# resource - they are network-wide and matched via direction, target/source
+# tags, or target/source service accounts. So there is no per-"sg_id"
+# grouping on GCP; instead rules are grouped by logical component name
+# purely for input organization, then flattened into the list the
+# `firewall-rules` submodule expects.
+# =========================================================================
+
+locals {
+  rules_flat = merge([
+    for component, group in var.rules : {
+      for rule in group.rules :
+      "${component}-${rule.name}" => merge(rule, { name = "${local.name_prefix}-${component}-${rule.name}" })
+    }
+  ]...)
+}
+
+module "firewall_rules" {
+  source  = "terraform-google-modules/network/google//modules/firewall-rules"
+  version = "18.1.2"
+
+  project_id   = var.project_id
+  network_name = var.network_name
+
+  rules = values(local.rules_flat)
+}

--- a/terraform/gcp/modules/composition/firewall-rules/outputs.tf
+++ b/terraform/gcp/modules/composition/firewall-rules/outputs.tf
@@ -1,0 +1,24 @@
+# =========================================================================
+# FIREWALL RULES OUTPUTS
+# =========================================================================
+
+output "firewall_rules" {
+  description = "Map of created firewall rule self-links, keyed by rule name"
+  value       = module.firewall_rules.firewall_rules
+}
+
+output "firewall_rules_ingress_egress" {
+  description = "Firewall rule self-links split into ingress_rules / egress_rules lists"
+  value       = module.firewall_rules.firewall_rules_ingress_egress
+}
+
+output "rules_summary" {
+  description = "Summary of firewall rules created"
+  value = {
+    total_rules = length(local.rules_flat)
+    by_component = {
+      for component, group in var.rules :
+      component => length(group.rules)
+    }
+  }
+}

--- a/terraform/gcp/modules/composition/firewall-rules/variables.tf
+++ b/terraform/gcp/modules/composition/firewall-rules/variables.tf
@@ -1,0 +1,53 @@
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for naming resources"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "project_id" {
+  description = "GCP project ID where the firewall rules are created"
+  type        = string
+}
+
+variable "network_name" {
+  description = "Name of the VPC network the rules apply to"
+  type        = string
+}
+
+variable "rules" {
+  description = <<-EOT
+    Map of firewall rule groups keyed by logical component name (e.g. "bastion-to-locker").
+    Each group's rules are flattened and created as VPC firewall rules on var.network_name.
+    Rule names are auto-prefixed with "<environment>-<project_name>-<component>-<rule.name>".
+  EOT
+  type = map(object({
+    rules = list(object({
+      name                    = string
+      description             = optional(string)
+      direction               = optional(string, "INGRESS") # INGRESS or EGRESS
+      priority                = optional(number, 1000)
+      ranges                  = optional(list(string))
+      source_tags             = optional(list(string))
+      source_service_accounts = optional(list(string))
+      target_tags             = optional(list(string))
+      target_service_accounts = optional(list(string))
+      allow = optional(list(object({
+        protocol = string
+        ports    = optional(list(string))
+      })))
+      deny = optional(list(object({
+        protocol = string
+        ports    = optional(list(string))
+      })))
+      log_config = optional(object({
+        metadata = string
+      }))
+    }))
+  }))
+  default = {}
+}

--- a/terraform/gcp/modules/composition/firewall-rules/versions.tf
+++ b/terraform/gcp/modules/composition/firewall-rules/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/composition/gcs-backend/README.md
+++ b/terraform/gcp/modules/composition/gcs-backend/README.md
@@ -2,7 +2,7 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
@@ -13,7 +13,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_state_bucket"></a> [state\_bucket](#module\_state\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
 
 ## Resources
@@ -23,7 +23,7 @@ No resources.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_allow_destroy"></a> [allow\_destroy](#input\_allow\_destroy) | Allow destruction of the bucket even if it contains objects (should be false for prod) | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | Self link of the KMS CryptoKey used to encrypt the bucket (null uses Google-managed encryption) | `string` | `null` | no |
@@ -40,7 +40,7 @@ No resources.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_backend_config"></a> [backend\_config](#output\_backend\_config) | Backend configuration object for use in other Terraform deployments |
 | <a name="output_backend_config_formatted"></a> [backend\_config\_formatted](#output\_backend\_config\_formatted) | Formatted backend configuration for copy-paste into backend.tf files |
 | <a name="output_state_bucket_location"></a> [state\_bucket\_location](#output\_state\_bucket\_location) | The location of the state bucket |

--- a/terraform/gcp/modules/composition/gcs-backend/README.md
+++ b/terraform/gcp/modules/composition/gcs-backend/README.md
@@ -1,0 +1,49 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_state_bucket"></a> [state\_bucket](#module\_state\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_allow_destroy"></a> [allow\_destroy](#input\_allow\_destroy) | Allow destruction of the bucket even if it contains objects (should be false for prod) | `bool` | `false` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | Self link of the KMS CryptoKey used to encrypt the bucket (null uses Google-managed encryption) | `string` | `null` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_lifecycle_rules"></a> [lifecycle\_rules](#input\_lifecycle\_rules) | List of lifecycle rules for the state bucket | <pre>list(object({<br/>    action = object({<br/>      type          = string<br/>      storage_class = optional(string)<br/>    })<br/>    condition = object({<br/>      age                   = optional(number)<br/>      created_before        = optional(string)<br/>      with_state            = optional(string)<br/>      num_newer_versions    = optional(number)<br/>      matches_storage_class = optional(string)<br/>    })<br/>  }))</pre> | `[]` | no |
+| <a name="input_location"></a> [location](#input\_location) | GCS bucket location (region or multi-region, e.g. europe-west1 or EU) | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where the state bucket is created | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name for labeling and naming resources | `string` | `"hyperswitch"` | no |
+| <a name="input_retention_period_seconds"></a> [retention\_period\_seconds](#input\_retention\_period\_seconds) | Minimum retention period (seconds) objects must be retained. Null disables the retention policy | `number` | `null` | no |
+| <a name="input_retention_policy_locked"></a> [retention\_policy\_locked](#input\_retention\_policy\_locked) | Whether the retention policy is locked (irreversible). Only used when retention\_period\_seconds is set | `bool` | `false` | no |
+| <a name="input_state_bucket_name"></a> [state\_bucket\_name](#input\_state\_bucket\_name) | Name of the GCS bucket for Terraform state (must be globally unique) | `string` | n/a | yes |
+| <a name="input_storage_class"></a> [storage\_class](#input\_storage\_class) | Storage class for the state bucket | `string` | `"STANDARD"` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_backend_config"></a> [backend\_config](#output\_backend\_config) | Backend configuration object for use in other Terraform deployments |
+| <a name="output_backend_config_formatted"></a> [backend\_config\_formatted](#output\_backend\_config\_formatted) | Formatted backend configuration for copy-paste into backend.tf files |
+| <a name="output_state_bucket_location"></a> [state\_bucket\_location](#output\_state\_bucket\_location) | The location of the state bucket |
+| <a name="output_state_bucket_name"></a> [state\_bucket\_name](#output\_state\_bucket\_name) | The name of the state bucket |
+| <a name="output_state_bucket_url"></a> [state\_bucket\_url](#output\_state\_bucket\_url) | The gsutil URI of the state bucket (gs://<name>) |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/composition/gcs-backend/locals.tf
+++ b/terraform/gcp/modules/composition/gcs-backend/locals.tf
@@ -1,0 +1,13 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}-backend"
+
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "component"   = "terraform-backend"
+      "managed_by"  = "terraform"
+    },
+    var.labels
+  )
+}

--- a/terraform/gcp/modules/composition/gcs-backend/main.tf
+++ b/terraform/gcp/modules/composition/gcs-backend/main.tf
@@ -1,0 +1,56 @@
+# ============================================================================
+# Terraform Backend Infrastructure (GCS)
+# ============================================================================
+# This module creates the backend infrastructure for Terraform on GCP:
+#   - GCS bucket for state storage (versioned, uniform bucket-level access,
+#     optional CMEK, optional retention policy)
+#
+# Unlike the AWS equivalent (composition/terraform-backend), no lock table is
+# created: the GCS backend uses native object-generation locking, so a
+# DynamoDB-style companion resource has no GCP equivalent and is intentionally
+# omitted. See terraform/gcp/modules/README.md for the full mapping notes.
+#
+# Usage:
+#   module "terraform_backend" {
+#     source = "../../modules/composition/gcs-backend"
+#
+#     environment       = "dev"
+#     project_name      = "hyperswitch"
+#     project_id        = "hyperswitch-dev"
+#     state_bucket_name = "hyperswitch-dev-terraform-state"
+#   }
+# ============================================================================
+
+module "state_bucket" {
+  source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
+  version = "12.3.0"
+
+  project_id    = var.project_id
+  name          = var.state_bucket_name
+  location      = var.location
+  storage_class = var.storage_class
+  force_destroy = var.allow_destroy
+
+  versioning               = true
+  bucket_policy_only       = true
+  public_access_prevention = "enforced"
+
+  encryption = var.kms_key_id != null ? {
+    default_kms_key_name = var.kms_key_id
+  } : null
+
+  retention_policy = var.retention_period_seconds != null ? {
+    is_locked        = var.retention_policy_locked
+    retention_period = var.retention_period_seconds
+  } : null
+
+  lifecycle_rules = var.lifecycle_rules
+
+  labels = merge(
+    local.common_labels,
+    {
+      "name"    = var.state_bucket_name
+      "purpose" = "terraform-state"
+    }
+  )
+}

--- a/terraform/gcp/modules/composition/gcs-backend/outputs.tf
+++ b/terraform/gcp/modules/composition/gcs-backend/outputs.tf
@@ -1,0 +1,41 @@
+# ============================================================================
+# GCS Bucket Outputs
+# ============================================================================
+
+output "state_bucket_name" {
+  description = "The name of the state bucket"
+  value       = module.state_bucket.name
+}
+
+output "state_bucket_url" {
+  description = "The gsutil URI of the state bucket (gs://<name>)"
+  value       = module.state_bucket.url
+}
+
+output "state_bucket_location" {
+  description = "The location of the state bucket"
+  value       = var.location
+}
+
+# ============================================================================
+# Backend Configuration
+# ============================================================================
+
+output "backend_config" {
+  description = "Backend configuration object for use in other Terraform deployments"
+  value = {
+    bucket = module.state_bucket.name
+  }
+}
+
+output "backend_config_formatted" {
+  description = "Formatted backend configuration for copy-paste into backend.tf files"
+  value       = <<-EOT
+    terraform {
+      backend "gcs" {
+        bucket = "${module.state_bucket.name}"
+        prefix = "<environment>/<region>/<service>"
+      }
+    }
+  EOT
+}

--- a/terraform/gcp/modules/composition/gcs-backend/variables.tf
+++ b/terraform/gcp/modules/composition/gcs-backend/variables.tf
@@ -1,0 +1,92 @@
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "integ", "prod", "sandbox"], var.environment)
+    error_message = "Environment must be one of: dev, integ, prod, sandbox"
+  }
+}
+
+variable "project_name" {
+  description = "Project name for labeling and naming resources"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "project_id" {
+  description = "GCP project ID where the state bucket is created"
+  type        = string
+}
+
+variable "location" {
+  description = "GCS bucket location (region or multi-region, e.g. europe-west1 or EU)"
+  type        = string
+}
+
+# ============================================================================
+# Bucket Configuration
+# ============================================================================
+
+variable "state_bucket_name" {
+  description = "Name of the GCS bucket for Terraform state (must be globally unique)"
+  type        = string
+}
+
+variable "storage_class" {
+  description = "Storage class for the state bucket"
+  type        = string
+  default     = "STANDARD"
+}
+
+variable "allow_destroy" {
+  description = "Allow destruction of the bucket even if it contains objects (should be false for prod)"
+  type        = bool
+  default     = false
+}
+
+variable "kms_key_id" {
+  description = "Self link of the KMS CryptoKey used to encrypt the bucket (null uses Google-managed encryption)"
+  type        = string
+  default     = null
+}
+
+variable "retention_period_seconds" {
+  description = "Minimum retention period (seconds) objects must be retained. Null disables the retention policy"
+  type        = number
+  default     = null
+}
+
+variable "retention_policy_locked" {
+  description = "Whether the retention policy is locked (irreversible). Only used when retention_period_seconds is set"
+  type        = bool
+  default     = false
+}
+
+variable "lifecycle_rules" {
+  description = "List of lifecycle rules for the state bucket"
+  type = list(object({
+    action = object({
+      type          = string
+      storage_class = optional(string)
+    })
+    condition = object({
+      age                   = optional(number)
+      created_before        = optional(string)
+      with_state            = optional(string)
+      num_newer_versions    = optional(number)
+      matches_storage_class = optional(string)
+    })
+  }))
+  default = [] # No lifecycle rules by default - keep all state history
+}
+
+# ============================================================================
+# Labeling
+# ============================================================================
+
+variable "labels" {
+  description = "Additional labels to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/composition/gcs-backend/versions.tf
+++ b/terraform/gcp/modules/composition/gcs-backend/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/composition/gke-kubernetes-resources/README.md
+++ b/terraform/gcp/modules/composition/gke-kubernetes-resources/README.md
@@ -2,7 +2,7 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 3.1 |
@@ -11,7 +11,7 @@
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 3.1 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 3.0 |
@@ -24,7 +24,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [helm_release.hyperswitch_stack](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubernetes_cluster_role_v1.cicd](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_v1) | resource |
 | [kubernetes_cluster_role_v1.custom_roles](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_v1) | resource |
@@ -40,7 +40,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_cluster_ca_certificate"></a> [cluster\_ca\_certificate](#input\_cluster\_ca\_certificate) | Base64 encoded certificate data required to communicate with the cluster | `string` | n/a | yes |
 | <a name="input_cluster_endpoint"></a> [cluster\_endpoint](#input\_cluster\_endpoint) | Endpoint (host, without scheme) for the Kubernetes API server | `string` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster | `string` | n/a | yes |
@@ -68,7 +68,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_default_storage_class_name"></a> [default\_storage\_class\_name](#output\_default\_storage\_class\_name) | Name of the default storage class, if created |
 | <a name="output_hyperswitch_namespace"></a> [hyperswitch\_namespace](#output\_hyperswitch\_namespace) | Namespace the Hyperswitch Helm release was deployed into, if enabled |
 | <a name="output_hyperswitch_release_status"></a> [hyperswitch\_release\_status](#output\_hyperswitch\_release\_status) | Status of the Hyperswitch Helm release, if enabled |

--- a/terraform/gcp/modules/composition/gke-kubernetes-resources/README.md
+++ b/terraform/gcp/modules/composition/gke-kubernetes-resources/README.md
@@ -1,0 +1,76 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 3.1 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 3.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 3.1 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 3.0 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [helm_release.hyperswitch_stack](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [kubernetes_cluster_role_v1.cicd](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_v1) | resource |
+| [kubernetes_cluster_role_v1.custom_roles](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_v1) | resource |
+| [kubernetes_cluster_role_v1.developer](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_v1) | resource |
+| [kubernetes_cluster_role_v1.readonly](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_v1) | resource |
+| [kubernetes_namespace_v1.hyperswitch](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
+| [kubernetes_secret_v1.registry_pull_secret](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
+| [kubernetes_storage_class_v1.custom](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/storage_class_v1) | resource |
+| [kubernetes_storage_class_v1.pd_balanced](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/storage_class_v1) | resource |
+| [terraform_data.cluster_ready](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
+| [google_client_config.current](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_cluster_ca_certificate"></a> [cluster\_ca\_certificate](#input\_cluster\_ca\_certificate) | Base64 encoded certificate data required to communicate with the cluster | `string` | n/a | yes |
+| <a name="input_cluster_endpoint"></a> [cluster\_endpoint](#input\_cluster\_endpoint) | Endpoint (host, without scheme) for the Kubernetes API server | `string` | n/a | yes |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster | `string` | n/a | yes |
+| <a name="input_create_default_rbac_roles"></a> [create\_default\_rbac\_roles](#input\_create\_default\_rbac\_roles) | Whether to create default RBAC roles (developer, readonly, cicd) | `bool` | `true` | no |
+| <a name="input_create_default_storage_class"></a> [create\_default\_storage\_class](#input\_create\_default\_storage\_class) | Whether to create the default pd-balanced storage class | `bool` | `true` | no |
+| <a name="input_create_registry_pull_secret"></a> [create\_registry\_pull\_secret](#input\_create\_registry\_pull\_secret) | Whether to create a docker registry pull secret. Not normally needed for Artifact Registry, which authenticates via Workload Identity | `bool` | `false` | no |
+| <a name="input_custom_rbac_roles"></a> [custom\_rbac\_roles](#input\_custom\_rbac\_roles) | Additional custom RBAC roles to create | <pre>map(object({<br/>    rules = list(object({<br/>      api_groups     = list(string)<br/>      resources      = list(string)<br/>      verbs          = list(string)<br/>      resource_names = optional(list(string), [])<br/>    }))<br/>  }))</pre> | `{}` | no |
+| <a name="input_custom_storage_classes"></a> [custom\_storage\_classes](#input\_custom\_storage\_classes) | Map of additional custom storage classes to create | <pre>map(object({<br/>    storage_provisioner    = string<br/>    volume_binding_mode    = optional(string, "Immediate")<br/>    reclaim_policy         = optional(string, "Retain")<br/>    allow_volume_expansion = optional(bool, false)<br/>    parameters             = optional(map(string), {})<br/>    annotations            = optional(map(string), {})<br/>  }))</pre> | `{}` | no |
+| <a name="input_default_storage_class_name"></a> [default\_storage\_class\_name](#input\_default\_storage\_class\_name) | Name of the default storage class | `string` | `"pd-balanced"` | no |
+| <a name="input_enable_helm_deployments"></a> [enable\_helm\_deployments](#input\_enable\_helm\_deployments) | Enable Helm deployments managed by Terraform. Set to false if using ArgoCD instead | `bool` | `false` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_hyperswitch_chart_version"></a> [hyperswitch\_chart\_version](#input\_hyperswitch\_chart\_version) | Helm chart version for Hyperswitch (null for latest) | `string` | `null` | no |
+| <a name="input_hyperswitch_helm_chart"></a> [hyperswitch\_helm\_chart](#input\_hyperswitch\_helm\_chart) | Helm chart name for Hyperswitch | `string` | `"hyperswitch-stack"` | no |
+| <a name="input_hyperswitch_helm_repository"></a> [hyperswitch\_helm\_repository](#input\_hyperswitch\_helm\_repository) | Helm repository URL for Hyperswitch chart | `string` | `"https://juspay.github.io/hyperswitch-helm"` | no |
+| <a name="input_hyperswitch_helm_timeout"></a> [hyperswitch\_helm\_timeout](#input\_hyperswitch\_helm\_timeout) | Timeout in seconds for Helm deployment | `number` | `900` | no |
+| <a name="input_hyperswitch_namespace"></a> [hyperswitch\_namespace](#input\_hyperswitch\_namespace) | Kubernetes namespace for Hyperswitch deployment | `string` | `"hyperswitch"` | no |
+| <a name="input_hyperswitch_release_name"></a> [hyperswitch\_release\_name](#input\_hyperswitch\_release\_name) | Helm release name for Hyperswitch stack | `string` | `"hyperswitch-stack"` | no |
+| <a name="input_hyperswitch_values_file"></a> [hyperswitch\_values\_file](#input\_hyperswitch\_values\_file) | Path to custom Helm values file for Hyperswitch (null for defaults) | `string` | `null` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to created resources that support them | `map(string)` | `{}` | no |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Name of the project | `string` | n/a | yes |
+| <a name="input_registry_pull_secret_password"></a> [registry\_pull\_secret\_password](#input\_registry\_pull\_secret\_password) | Password/token for the optional pull secret | `string` | `null` | no |
+| <a name="input_registry_pull_secret_server"></a> [registry\_pull\_secret\_server](#input\_registry\_pull\_secret\_server) | Registry server for the optional pull secret | `string` | `null` | no |
+| <a name="input_registry_pull_secret_username"></a> [registry\_pull\_secret\_username](#input\_registry\_pull\_secret\_username) | Username for the optional pull secret | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_default_storage_class_name"></a> [default\_storage\_class\_name](#output\_default\_storage\_class\_name) | Name of the default storage class, if created |
+| <a name="output_hyperswitch_namespace"></a> [hyperswitch\_namespace](#output\_hyperswitch\_namespace) | Namespace the Hyperswitch Helm release was deployed into, if enabled |
+| <a name="output_hyperswitch_release_status"></a> [hyperswitch\_release\_status](#output\_hyperswitch\_release\_status) | Status of the Hyperswitch Helm release, if enabled |
+| <a name="output_rbac_role_names"></a> [rbac\_role\_names](#output\_rbac\_role\_names) | Names of created default RBAC cluster roles |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/composition/gke-kubernetes-resources/data.tf
+++ b/terraform/gcp/modules/composition/gke-kubernetes-resources/data.tf
@@ -1,0 +1,1 @@
+data "google_client_config" "current" {}

--- a/terraform/gcp/modules/composition/gke-kubernetes-resources/main.tf
+++ b/terraform/gcp/modules/composition/gke-kubernetes-resources/main.tf
@@ -1,0 +1,331 @@
+# =============================================================================
+# GKE Kubernetes Resources Module (GCP equivalent of composition/eks-kubernetes-resources)
+# =============================================================================
+# Manages Kubernetes resources that require an operational GKE cluster. Like
+# its AWS counterpart, this must be applied *after* composition/gke, passing
+# through the cluster's connection details, since the kubernetes/helm
+# providers need a live endpoint to plan against.
+#
+# Divergences from the AWS module, both intentional:
+#   - No self-hosted cluster-autoscaler Deployment/ECR-image-sync machinery:
+#     GKE's autoscaler is a control-plane feature enabled directly on
+#     composition/gke (cluster_autoscaling / node pool min/max counts), not
+#     something deployed as a workload here.
+#   - No ECR-style registry pull secret: Artifact Registry access from GKE
+#     is granted via Workload Identity on the node/GSA (roles/artifactregistry.reader),
+#     so no docker imagePullSecret is normally required. An optional secret
+#     is still supported for non-GCP registries.
+#
+# Usage:
+#   module "gke_kubernetes_resources" {
+#     source = "../../modules/composition/gke-kubernetes-resources"
+#
+#     cluster_name     = module.gke.cluster_name
+#     cluster_endpoint = module.gke.endpoint
+#     cluster_ca_certificate = module.gke.ca_certificate
+#     ...
+#   }
+# =============================================================================
+
+resource "terraform_data" "cluster_ready" {
+  triggers_replace = [
+    var.cluster_name,
+    var.cluster_endpoint,
+    var.cluster_ca_certificate,
+  ]
+
+  lifecycle {
+    precondition {
+      condition     = var.cluster_endpoint != null && var.cluster_endpoint != ""
+      error_message = "cluster_endpoint must be provided and non-empty. The GKE cluster must exist before creating Kubernetes resources."
+    }
+    precondition {
+      condition     = var.cluster_ca_certificate != null && var.cluster_ca_certificate != ""
+      error_message = "cluster_ca_certificate must be provided. The GKE cluster must exist before creating Kubernetes resources."
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Kubernetes / Helm Provider Configuration
+# -----------------------------------------------------------------------------
+provider "kubernetes" {
+  host                   = "https://${var.cluster_endpoint}"
+  cluster_ca_certificate = base64decode(var.cluster_ca_certificate)
+  token                  = data.google_client_config.current.access_token
+}
+
+provider "helm" {
+  kubernetes = {
+    host                   = "https://${var.cluster_endpoint}"
+    cluster_ca_certificate = base64decode(var.cluster_ca_certificate)
+    token                  = data.google_client_config.current.access_token
+  }
+}
+
+# =============================================================================
+# RBAC Resources
+# =============================================================================
+
+resource "kubernetes_cluster_role_v1" "developer" {
+  count = var.create_default_rbac_roles ? 1 : 0
+
+  metadata {
+    name = "cluster-developer"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["pods", "pods/log", "pods/exec", "pods/portforward", "services", "endpoints", "persistentvolumeclaims", "configmaps", "secrets"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+
+  rule {
+    api_groups = ["apps"]
+    resources  = ["deployments", "daemonsets", "statefulsets", "replicasets"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+
+  rule {
+    api_groups = ["batch"]
+    resources  = ["jobs", "cronjobs"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+
+  rule {
+    api_groups = ["networking.k8s.io"]
+    resources  = ["ingresses", "networkpolicies"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["namespaces", "nodes"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["rbac.authorization.k8s.io"]
+    resources  = ["roles", "rolebindings", "clusterroles", "clusterrolebindings"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  depends_on = [terraform_data.cluster_ready]
+}
+
+resource "kubernetes_cluster_role_v1" "readonly" {
+  count = var.create_default_rbac_roles ? 1 : 0
+
+  metadata {
+    name = "cluster-readonly"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["pods", "pods/log", "services", "endpoints", "persistentvolumeclaims", "configmaps", "secrets", "namespaces", "nodes"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["apps"]
+    resources  = ["deployments", "daemonsets", "statefulsets", "replicasets"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["batch"]
+    resources  = ["jobs", "cronjobs"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["networking.k8s.io"]
+    resources  = ["ingresses", "networkpolicies"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["rbac.authorization.k8s.io"]
+    resources  = ["roles", "rolebindings", "clusterroles", "clusterrolebindings"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  depends_on = [terraform_data.cluster_ready]
+}
+
+resource "kubernetes_cluster_role_v1" "cicd" {
+  count = var.create_default_rbac_roles ? 1 : 0
+
+  metadata {
+    name = "cluster-cicd"
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["pods", "pods/log", "services", "endpoints", "persistentvolumeclaims", "configmaps", "secrets"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+
+  rule {
+    api_groups = ["apps"]
+    resources  = ["deployments", "daemonsets", "statefulsets", "replicasets"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+
+  rule {
+    api_groups = ["batch"]
+    resources  = ["jobs", "cronjobs"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+
+  rule {
+    api_groups = ["networking.k8s.io"]
+    resources  = ["ingresses"]
+    verbs      = ["get", "list", "watch", "create", "update", "patch", "delete"]
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["namespaces"]
+    verbs      = ["get", "list", "watch", "create"]
+  }
+
+  depends_on = [terraform_data.cluster_ready]
+}
+
+resource "kubernetes_cluster_role_v1" "custom_roles" {
+  for_each = var.custom_rbac_roles
+
+  metadata {
+    name = "cluster-${each.key}"
+  }
+
+  dynamic "rule" {
+    for_each = each.value.rules
+    content {
+      api_groups     = rule.value.api_groups
+      resources      = rule.value.resources
+      verbs          = rule.value.verbs
+      resource_names = try(rule.value.resource_names, [])
+    }
+  }
+
+  depends_on = [terraform_data.cluster_ready]
+}
+
+# =============================================================================
+# Storage Class Resources
+# =============================================================================
+
+resource "kubernetes_storage_class_v1" "pd_balanced" {
+  count = var.create_default_storage_class ? 1 : 0
+
+  metadata {
+    name = var.default_storage_class_name
+    annotations = {
+      "storageclass.kubernetes.io/is-default-class" = "true"
+    }
+  }
+
+  storage_provisioner    = "pd.csi.storage.gke.io"
+  volume_binding_mode    = "WaitForFirstConsumer"
+  allow_volume_expansion = true
+
+  parameters = {
+    type = "pd-balanced"
+  }
+
+  depends_on = [terraform_data.cluster_ready]
+}
+
+resource "kubernetes_storage_class_v1" "custom" {
+  for_each = var.custom_storage_classes
+
+  metadata {
+    name        = each.key
+    annotations = each.value.annotations
+  }
+
+  storage_provisioner    = each.value.storage_provisioner
+  volume_binding_mode    = each.value.volume_binding_mode
+  reclaim_policy         = each.value.reclaim_policy
+  allow_volume_expansion = each.value.allow_volume_expansion
+  parameters             = each.value.parameters
+
+  depends_on = [terraform_data.cluster_ready]
+}
+
+# =============================================================================
+# Kubernetes Namespace Resources
+# =============================================================================
+
+resource "kubernetes_namespace_v1" "hyperswitch" {
+  count = var.enable_helm_deployments ? 1 : 0
+
+  metadata {
+    name = var.hyperswitch_namespace
+
+    labels = {
+      name        = var.hyperswitch_namespace
+      environment = var.environment
+    }
+  }
+
+  depends_on = [terraform_data.cluster_ready]
+}
+
+# -----------------------------------------------------------------------------
+# Optional registry pull secret (only needed for non-Artifact-Registry images;
+# Artifact Registry access is normally granted via Workload Identity instead)
+# -----------------------------------------------------------------------------
+resource "kubernetes_secret_v1" "registry_pull_secret" {
+  count = var.enable_helm_deployments && var.create_registry_pull_secret ? 1 : 0
+
+  metadata {
+    name      = "registry-pull-secret"
+    namespace = kubernetes_namespace_v1.hyperswitch[0].metadata[0].name
+  }
+
+  type = "kubernetes.io/dockerconfigjson"
+
+  data = {
+    ".dockerconfigjson" = jsonencode({
+      auths = {
+        (var.registry_pull_secret_server) = {
+          username = var.registry_pull_secret_username
+          password = var.registry_pull_secret_password
+          auth     = base64encode("${var.registry_pull_secret_username}:${var.registry_pull_secret_password}")
+        }
+      }
+    })
+  }
+
+  depends_on = [kubernetes_namespace_v1.hyperswitch]
+}
+
+# -----------------------------------------------------------------------------
+# Hyperswitch Helm Release
+# -----------------------------------------------------------------------------
+resource "helm_release" "hyperswitch_stack" {
+  count = var.enable_helm_deployments ? 1 : 0
+
+  name       = var.hyperswitch_release_name
+  repository = var.hyperswitch_helm_repository
+  chart      = var.hyperswitch_helm_chart
+  namespace  = kubernetes_namespace_v1.hyperswitch[0].metadata[0].name
+  version    = var.hyperswitch_chart_version
+
+  values = var.hyperswitch_values_file != null ? [
+    file(var.hyperswitch_values_file)
+  ] : []
+
+  wait          = true
+  wait_for_jobs = true
+  timeout       = var.hyperswitch_helm_timeout
+
+  depends_on = [
+    terraform_data.cluster_ready,
+    kubernetes_namespace_v1.hyperswitch,
+    kubernetes_storage_class_v1.pd_balanced,
+  ]
+}

--- a/terraform/gcp/modules/composition/gke-kubernetes-resources/outputs.tf
+++ b/terraform/gcp/modules/composition/gke-kubernetes-resources/outputs.tf
@@ -1,0 +1,23 @@
+output "rbac_role_names" {
+  description = "Names of created default RBAC cluster roles"
+  value = compact([
+    try(kubernetes_cluster_role_v1.developer[0].metadata[0].name, ""),
+    try(kubernetes_cluster_role_v1.readonly[0].metadata[0].name, ""),
+    try(kubernetes_cluster_role_v1.cicd[0].metadata[0].name, ""),
+  ])
+}
+
+output "default_storage_class_name" {
+  description = "Name of the default storage class, if created"
+  value       = var.create_default_storage_class ? kubernetes_storage_class_v1.pd_balanced[0].metadata[0].name : null
+}
+
+output "hyperswitch_namespace" {
+  description = "Namespace the Hyperswitch Helm release was deployed into, if enabled"
+  value       = var.enable_helm_deployments ? kubernetes_namespace_v1.hyperswitch[0].metadata[0].name : null
+}
+
+output "hyperswitch_release_status" {
+  description = "Status of the Hyperswitch Helm release, if enabled"
+  value       = var.enable_helm_deployments ? helm_release.hyperswitch_stack[0].status : null
+}

--- a/terraform/gcp/modules/composition/gke-kubernetes-resources/variables.tf
+++ b/terraform/gcp/modules/composition/gke-kubernetes-resources/variables.tf
@@ -1,0 +1,166 @@
+# -----------------------------------------------------------------------------
+# Required Cluster Information (from composition/gke outputs)
+# -----------------------------------------------------------------------------
+variable "cluster_name" {
+  description = "Name of the GKE cluster"
+  type        = string
+}
+
+variable "cluster_endpoint" {
+  description = "Endpoint (host, without scheme) for the Kubernetes API server"
+  type        = string
+}
+
+variable "cluster_ca_certificate" {
+  description = "Base64 encoded certificate data required to communicate with the cluster"
+  type        = string
+  sensitive   = true
+}
+
+# -----------------------------------------------------------------------------
+# Environment Configuration
+# -----------------------------------------------------------------------------
+variable "project_name" {
+  description = "Name of the project"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "labels" {
+  description = "Labels to apply to created resources that support them"
+  type        = map(string)
+  default     = {}
+}
+
+# -----------------------------------------------------------------------------
+# RBAC Configuration
+# -----------------------------------------------------------------------------
+variable "create_default_rbac_roles" {
+  description = "Whether to create default RBAC roles (developer, readonly, cicd)"
+  type        = bool
+  default     = true
+}
+
+variable "custom_rbac_roles" {
+  description = "Additional custom RBAC roles to create"
+  type = map(object({
+    rules = list(object({
+      api_groups     = list(string)
+      resources      = list(string)
+      verbs          = list(string)
+      resource_names = optional(list(string), [])
+    }))
+  }))
+  default = {}
+}
+
+# -----------------------------------------------------------------------------
+# Storage Class Configuration
+# -----------------------------------------------------------------------------
+variable "create_default_storage_class" {
+  description = "Whether to create the default pd-balanced storage class"
+  type        = bool
+  default     = true
+}
+
+variable "default_storage_class_name" {
+  description = "Name of the default storage class"
+  type        = string
+  default     = "pd-balanced"
+}
+
+variable "custom_storage_classes" {
+  description = "Map of additional custom storage classes to create"
+  type = map(object({
+    storage_provisioner    = string
+    volume_binding_mode    = optional(string, "Immediate")
+    reclaim_policy         = optional(string, "Retain")
+    allow_volume_expansion = optional(bool, false)
+    parameters             = optional(map(string), {})
+    annotations            = optional(map(string), {})
+  }))
+  default = {}
+}
+
+# -----------------------------------------------------------------------------
+# Helm Deployment Configuration
+# -----------------------------------------------------------------------------
+variable "enable_helm_deployments" {
+  description = "Enable Helm deployments managed by Terraform. Set to false if using ArgoCD instead"
+  type        = bool
+  default     = false
+}
+
+variable "create_registry_pull_secret" {
+  description = "Whether to create a docker registry pull secret. Not normally needed for Artifact Registry, which authenticates via Workload Identity"
+  type        = bool
+  default     = false
+}
+
+variable "registry_pull_secret_server" {
+  description = "Registry server for the optional pull secret"
+  type        = string
+  default     = null
+}
+
+variable "registry_pull_secret_username" {
+  description = "Username for the optional pull secret"
+  type        = string
+  default     = null
+}
+
+variable "registry_pull_secret_password" {
+  description = "Password/token for the optional pull secret"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+# -----------------------------------------------------------------------------
+# Hyperswitch Helm Configuration
+# -----------------------------------------------------------------------------
+variable "hyperswitch_namespace" {
+  description = "Kubernetes namespace for Hyperswitch deployment"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "hyperswitch_release_name" {
+  description = "Helm release name for Hyperswitch stack"
+  type        = string
+  default     = "hyperswitch-stack"
+}
+
+variable "hyperswitch_helm_repository" {
+  description = "Helm repository URL for Hyperswitch chart"
+  type        = string
+  default     = "https://juspay.github.io/hyperswitch-helm"
+}
+
+variable "hyperswitch_helm_chart" {
+  description = "Helm chart name for Hyperswitch"
+  type        = string
+  default     = "hyperswitch-stack"
+}
+
+variable "hyperswitch_chart_version" {
+  description = "Helm chart version for Hyperswitch (null for latest)"
+  type        = string
+  default     = null
+}
+
+variable "hyperswitch_values_file" {
+  description = "Path to custom Helm values file for Hyperswitch (null for defaults)"
+  type        = string
+  default     = null
+}
+
+variable "hyperswitch_helm_timeout" {
+  description = "Timeout in seconds for Helm deployment"
+  type        = number
+  default     = 900
+}

--- a/terraform/gcp/modules/composition/gke-kubernetes-resources/versions.tf
+++ b/terraform/gcp/modules/composition/gke-kubernetes-resources/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 3.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.1"
+    }
+  }
+}

--- a/terraform/gcp/modules/composition/gke/README.md
+++ b/terraform/gcp/modules/composition/gke/README.md
@@ -1,0 +1,74 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 6.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_gke"></a> [gke](#module\_gke) | terraform-google-modules/kubernetes-engine/google//modules/private-cluster | 44.3.0 |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster. Defaults to '<environment>-<project\_name>-gke' | `string` | `null` | no |
+| <a name="input_create_service_account"></a> [create\_service\_account](#input\_create\_service\_account) | Whether to create a dedicated node service account | `bool` | `true` | no |
+| <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether to allow Terraform to destroy the cluster | `bool` | `true` | no |
+| <a name="input_enable_network_policy"></a> [enable\_network\_policy](#input\_enable\_network\_policy) | Enable the network policy addon (Calico) | `bool` | `false` | no |
+| <a name="input_enable_private_endpoint"></a> [enable\_private\_endpoint](#input\_enable\_private\_endpoint) | Whether the cluster's master is only accessible via its internal IP address | `bool` | `false` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_gateway_api_channel"></a> [gateway\_api\_channel](#input\_gateway\_api\_channel) | Gateway API channel: CHANNEL\_DISABLED, CHANNEL\_EXPERIMENTAL, or CHANNEL\_STANDARD | `string` | `"CHANNEL_STANDARD"` | no |
+| <a name="input_ip_range_pods"></a> [ip\_range\_pods](#input\_ip\_range\_pods) | Name of the secondary subnet IP range to use for pod alias IPs | `string` | n/a | yes |
+| <a name="input_ip_range_services"></a> [ip\_range\_services](#input\_ip\_range\_services) | Name of the secondary subnet IP range to use for service alias IPs | `string` | n/a | yes |
+| <a name="input_kms_key_name"></a> [kms\_key\_name](#input\_kms\_key\_name) | Cloud KMS CryptoKey self-link used for application-layer secrets (etcd) encryption. Null disables envelope encryption | `string` | `null` | no |
+| <a name="input_kubernetes_version"></a> [kubernetes\_version](#input\_kubernetes\_version) | Kubernetes version for the control plane. 'latest' pulls the latest available version in the region | `string` | `"latest"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels applied to the cluster | `map(string)` | `{}` | no |
+| <a name="input_logging_service"></a> [logging\_service](#input\_logging\_service) | Logging service the cluster writes to | `string` | `"logging.googleapis.com/kubernetes"` | no |
+| <a name="input_master_authorized_networks"></a> [master\_authorized\_networks](#input\_master\_authorized\_networks) | List of CIDR blocks allowed to access the Kubernetes master | <pre>list(object({<br/>    cidr_block   = string<br/>    display_name = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_master_ipv4_cidr_block"></a> [master\_ipv4\_cidr\_block](#input\_master\_ipv4\_cidr\_block) | /28 CIDR block for the control plane's private network | `string` | `null` | no |
+| <a name="input_monitoring_service"></a> [monitoring\_service](#input\_monitoring\_service) | Monitoring service the cluster writes to | `string` | `"monitoring.googleapis.com/kubernetes"` | no |
+| <a name="input_network"></a> [network](#input\_network) | Self-link of the VPC network to host the cluster in | `string` | n/a | yes |
+| <a name="input_network_project_id"></a> [network\_project\_id](#input\_network\_project\_id) | Project ID of the Shared VPC host project, if applicable | `string` | `""` | no |
+| <a name="input_node_pools"></a> [node\_pools](#input\_node\_pools) | List of node pool configuration maps, mirroring the upstream module's node\_pools variable (name, machine\_type, min\_count, max\_count, disk\_size\_gb, spot, etc.) | `list(map(any))` | <pre>[<br/>  {<br/>    "auto_repair": true,<br/>    "auto_upgrade": true,<br/>    "disk_size_gb": 100,<br/>    "disk_type": "pd-balanced",<br/>    "machine_type": "e2-standard-4",<br/>    "max_count": 5,<br/>    "min_count": 1,<br/>    "name": "default-pool"<br/>  }<br/>]</pre> | no |
+| <a name="input_node_pools_labels"></a> [node\_pools\_labels](#input\_node\_pools\_labels) | Map of node-pool name to Kubernetes labels applied to that pool's nodes | `map(map(string))` | `{}` | no |
+| <a name="input_node_pools_metadata"></a> [node\_pools\_metadata](#input\_node\_pools\_metadata) | Map of node-pool name to a map of additional instance metadata | `map(map(string))` | `{}` | no |
+| <a name="input_node_pools_oauth_scopes"></a> [node\_pools\_oauth\_scopes](#input\_node\_pools\_oauth\_scopes) | Map of node-pool name to a list of OAuth scopes granted to that pool's nodes | `map(list(string))` | <pre>{<br/>  "all": [<br/>    "https://www.googleapis.com/auth/cloud-platform"<br/>  ]<br/>}</pre> | no |
+| <a name="input_node_pools_tags"></a> [node\_pools\_tags](#input\_node\_pools\_tags) | Map of node-pool name to a list of GCE network tags applied to that pool's nodes | `map(list(string))` | `{}` | no |
+| <a name="input_node_pools_taints"></a> [node\_pools\_taints](#input\_node\_pools\_taints) | Map of node-pool name to a list of Kubernetes taints applied to that pool's nodes | <pre>map(list(object({<br/>    key    = string<br/>    value  = string<br/>    effect = string<br/>  })))</pre> | `{}` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where the cluster is created | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name used for resource naming | `string` | `"hyperswitch"` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region to host the cluster in (required for regional clusters) | `string` | n/a | yes |
+| <a name="input_regional"></a> [regional](#input\_regional) | Whether the cluster is regional (multi-zone control plane) or zonal | `bool` | `true` | no |
+| <a name="input_release_channel"></a> [release\_channel](#input\_release\_channel) | Release channel: UNSPECIFIED, RAPID, REGULAR, or STABLE | `string` | `"REGULAR"` | no |
+| <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Existing service account email to run nodes as. Ignored if create\_service\_account is true | `string` | `""` | no |
+| <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | Self-link of the subnetwork to host the cluster nodes in | `string` | n/a | yes |
+| <a name="input_zones"></a> [zones](#input\_zones) | Zones to host the cluster/nodes in (required for zonal clusters, optional otherwise) | `list(string)` | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_ca_certificate"></a> [ca\_certificate](#output\_ca\_certificate) | Base64-encoded cluster CA certificate |
+| <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | ID of the GKE cluster |
+| <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | Name of the GKE cluster |
+| <a name="output_endpoint"></a> [endpoint](#output\_endpoint) | Cluster master endpoint (internal or external depending on enable\_private\_endpoint) |
+| <a name="output_location"></a> [location](#output\_location) | Cluster location (region for regional clusters, zone for zonal) |
+| <a name="output_master_version"></a> [master\_version](#output\_master\_version) | Current master Kubernetes version |
+| <a name="output_node_pools_names"></a> [node\_pools\_names](#output\_node\_pools\_names) | Names of the created node pools |
+| <a name="output_service_account"></a> [service\_account](#output\_service\_account) | Email of the service account used by cluster nodes |
+| <a name="output_workload_identity_pool"></a> [workload\_identity\_pool](#output\_workload\_identity\_pool) | Workload Identity pool, in the form <project\_id>.svc.id.goog |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/composition/gke/README.md
+++ b/terraform/gcp/modules/composition/gke/README.md
@@ -2,7 +2,7 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 6.0 |
@@ -14,7 +14,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_gke"></a> [gke](#module\_gke) | terraform-google-modules/kubernetes-engine/google//modules/private-cluster | 44.3.0 |
 
 ## Resources
@@ -24,7 +24,7 @@ No resources.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster. Defaults to '<environment>-<project\_name>-gke' | `string` | `null` | no |
 | <a name="input_create_service_account"></a> [create\_service\_account](#input\_create\_service\_account) | Whether to create a dedicated node service account | `bool` | `true` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether to allow Terraform to destroy the cluster | `bool` | `true` | no |
@@ -61,7 +61,7 @@ No resources.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_ca_certificate"></a> [ca\_certificate](#output\_ca\_certificate) | Base64-encoded cluster CA certificate |
 | <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | ID of the GKE cluster |
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | Name of the GKE cluster |

--- a/terraform/gcp/modules/composition/gke/locals.tf
+++ b/terraform/gcp/modules/composition/gke/locals.tf
@@ -1,0 +1,14 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}"
+
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "managed_by"  = "terraform"
+    },
+    var.labels
+  )
+
+  cluster_name = var.cluster_name != null ? var.cluster_name : "${local.name_prefix}-gke"
+}

--- a/terraform/gcp/modules/composition/gke/main.tf
+++ b/terraform/gcp/modules/composition/gke/main.tf
@@ -1,0 +1,85 @@
+# ============================================================================
+# GKE Cluster (GCP equivalent of composition/eks)
+# ============================================================================
+# Standard (non-Autopilot) private-cluster GKE, matching the AWS EKS module's
+# shape: private nodes, explicit node pools, and IRSA-equivalent Workload
+# Identity enabled cluster-wide (application-resources modules bind
+# individual KSA<->GSA pairs on top of this).
+#
+# Autopilot was intentionally not used here: it does not allow per-node-pool
+# taints/labels/DaemonSets, which vector, otel-collector, and the istio
+# gateways rely on (see terraform/gcp/modules/README.md).
+#
+# Usage:
+#   module "gke" {
+#     source = "../../modules/composition/gke"
+#
+#     project_id   = "hyperswitch-dev"
+#     environment  = "dev"
+#     region       = "europe-west1"
+#     network      = module.vpc_network.network_self_link
+#     subnetwork   = module.vpc_network.gke_nodes_subnet_self_link
+#     ip_range_pods     = module.vpc_network.gke_pods_secondary_range_name
+#     ip_range_services = module.vpc_network.gke_services_secondary_range_name
+#   }
+# ============================================================================
+
+module "gke" {
+  source  = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
+  version = "44.3.0"
+
+  project_id  = var.project_id
+  name        = local.cluster_name
+  description = "Hyperswitch ${var.environment} GKE cluster"
+
+  regional = var.regional
+  region   = var.region
+  zones    = var.zones
+
+  network            = var.network
+  network_project_id = var.network_project_id
+  subnetwork         = var.subnetwork
+  ip_range_pods      = var.ip_range_pods
+  ip_range_services  = var.ip_range_services
+
+  kubernetes_version = var.kubernetes_version
+  release_channel    = var.release_channel
+
+  enable_private_nodes    = true
+  enable_private_endpoint = var.enable_private_endpoint
+  master_ipv4_cidr_block  = var.master_ipv4_cidr_block
+
+  master_authorized_networks = var.master_authorized_networks
+
+  horizontal_pod_autoscaling = true
+  http_load_balancing        = true
+  network_policy             = var.enable_network_policy
+  gateway_api_channel        = var.gateway_api_channel
+
+  identity_namespace = "enabled" # Workload Identity, cluster-wide
+
+  create_service_account = var.create_service_account
+  service_account        = var.service_account
+  grant_registry_access  = true
+
+  logging_service    = var.logging_service
+  monitoring_service = var.monitoring_service
+
+  database_encryption = var.kms_key_name != null ? [{
+    state    = "ENCRYPTED"
+    key_name = var.kms_key_name
+  }] : [{ state = "DECRYPTED", key_name = "" }]
+
+  deletion_protection      = var.deletion_protection
+  remove_default_node_pool = true
+  initial_node_count       = 1
+
+  node_pools              = var.node_pools
+  node_pools_labels       = var.node_pools_labels
+  node_pools_taints       = var.node_pools_taints
+  node_pools_tags         = var.node_pools_tags
+  node_pools_metadata     = var.node_pools_metadata
+  node_pools_oauth_scopes = var.node_pools_oauth_scopes
+
+  cluster_resource_labels = local.common_labels
+}

--- a/terraform/gcp/modules/composition/gke/outputs.tf
+++ b/terraform/gcp/modules/composition/gke/outputs.tf
@@ -1,0 +1,46 @@
+output "cluster_name" {
+  description = "Name of the GKE cluster"
+  value       = module.gke.name
+}
+
+output "cluster_id" {
+  description = "ID of the GKE cluster"
+  value       = module.gke.cluster_id
+}
+
+output "endpoint" {
+  description = "Cluster master endpoint (internal or external depending on enable_private_endpoint)"
+  value       = module.gke.endpoint
+  sensitive   = true
+}
+
+output "ca_certificate" {
+  description = "Base64-encoded cluster CA certificate"
+  value       = module.gke.ca_certificate
+  sensitive   = true
+}
+
+output "location" {
+  description = "Cluster location (region for regional clusters, zone for zonal)"
+  value       = module.gke.region
+}
+
+output "service_account" {
+  description = "Email of the service account used by cluster nodes"
+  value       = module.gke.service_account
+}
+
+output "workload_identity_pool" {
+  description = "Workload Identity pool, in the form <project_id>.svc.id.goog"
+  value       = module.gke.identity_namespace
+}
+
+output "node_pools_names" {
+  description = "Names of the created node pools"
+  value       = module.gke.node_pools_names
+}
+
+output "master_version" {
+  description = "Current master Kubernetes version"
+  value       = module.gke.master_version
+}

--- a/terraform/gcp/modules/composition/gke/variables.tf
+++ b/terraform/gcp/modules/composition/gke/variables.tf
@@ -1,0 +1,204 @@
+variable "project_id" {
+  description = "GCP project ID where the cluster is created"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name used for resource naming"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "Name of the GKE cluster. Defaults to '<environment>-<project_name>-gke'"
+  type        = string
+  default     = null
+}
+
+variable "regional" {
+  description = "Whether the cluster is regional (multi-zone control plane) or zonal"
+  type        = bool
+  default     = true
+}
+
+variable "region" {
+  description = "Region to host the cluster in (required for regional clusters)"
+  type        = string
+}
+
+variable "zones" {
+  description = "Zones to host the cluster/nodes in (required for zonal clusters, optional otherwise)"
+  type        = list(string)
+  default     = []
+}
+
+variable "network" {
+  description = "Self-link of the VPC network to host the cluster in"
+  type        = string
+}
+
+variable "network_project_id" {
+  description = "Project ID of the Shared VPC host project, if applicable"
+  type        = string
+  default     = ""
+}
+
+variable "subnetwork" {
+  description = "Self-link of the subnetwork to host the cluster nodes in"
+  type        = string
+}
+
+variable "ip_range_pods" {
+  description = "Name of the secondary subnet IP range to use for pod alias IPs"
+  type        = string
+}
+
+variable "ip_range_services" {
+  description = "Name of the secondary subnet IP range to use for service alias IPs"
+  type        = string
+}
+
+variable "kubernetes_version" {
+  description = "Kubernetes version for the control plane. 'latest' pulls the latest available version in the region"
+  type        = string
+  default     = "latest"
+}
+
+variable "release_channel" {
+  description = "Release channel: UNSPECIFIED, RAPID, REGULAR, or STABLE"
+  type        = string
+  default     = "REGULAR"
+}
+
+variable "enable_private_endpoint" {
+  description = "Whether the cluster's master is only accessible via its internal IP address"
+  type        = bool
+  default     = false
+}
+
+variable "master_ipv4_cidr_block" {
+  description = "/28 CIDR block for the control plane's private network"
+  type        = string
+  default     = null
+}
+
+variable "master_authorized_networks" {
+  description = "List of CIDR blocks allowed to access the Kubernetes master"
+  type = list(object({
+    cidr_block   = string
+    display_name = string
+  }))
+  default = []
+}
+
+variable "enable_network_policy" {
+  description = "Enable the network policy addon (Calico)"
+  type        = bool
+  default     = false
+}
+
+variable "gateway_api_channel" {
+  description = "Gateway API channel: CHANNEL_DISABLED, CHANNEL_EXPERIMENTAL, or CHANNEL_STANDARD"
+  type        = string
+  default     = "CHANNEL_STANDARD"
+}
+
+variable "create_service_account" {
+  description = "Whether to create a dedicated node service account"
+  type        = bool
+  default     = true
+}
+
+variable "service_account" {
+  description = "Existing service account email to run nodes as. Ignored if create_service_account is true"
+  type        = string
+  default     = ""
+}
+
+variable "logging_service" {
+  description = "Logging service the cluster writes to"
+  type        = string
+  default     = "logging.googleapis.com/kubernetes"
+}
+
+variable "monitoring_service" {
+  description = "Monitoring service the cluster writes to"
+  type        = string
+  default     = "monitoring.googleapis.com/kubernetes"
+}
+
+variable "kms_key_name" {
+  description = "Cloud KMS CryptoKey self-link used for application-layer secrets (etcd) encryption. Null disables envelope encryption"
+  type        = string
+  default     = null
+}
+
+variable "deletion_protection" {
+  description = "Whether to allow Terraform to destroy the cluster"
+  type        = bool
+  default     = true
+}
+
+variable "node_pools" {
+  description = "List of node pool configuration maps, mirroring the upstream module's node_pools variable (name, machine_type, min_count, max_count, disk_size_gb, spot, etc.)"
+  type        = list(map(any))
+  default = [
+    {
+      name         = "default-pool"
+      machine_type = "e2-standard-4"
+      min_count    = 1
+      max_count    = 5
+      disk_size_gb = 100
+      disk_type    = "pd-balanced"
+      auto_repair  = true
+      auto_upgrade = true
+    },
+  ]
+}
+
+variable "node_pools_labels" {
+  description = "Map of node-pool name to Kubernetes labels applied to that pool's nodes"
+  type        = map(map(string))
+  default     = {}
+}
+
+variable "node_pools_taints" {
+  description = "Map of node-pool name to a list of Kubernetes taints applied to that pool's nodes"
+  type = map(list(object({
+    key    = string
+    value  = string
+    effect = string
+  })))
+  default = {}
+}
+
+variable "node_pools_tags" {
+  description = "Map of node-pool name to a list of GCE network tags applied to that pool's nodes"
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "node_pools_metadata" {
+  description = "Map of node-pool name to a map of additional instance metadata"
+  type        = map(map(string))
+  default     = {}
+}
+
+variable "node_pools_oauth_scopes" {
+  description = "Map of node-pool name to a list of OAuth scopes granted to that pool's nodes"
+  type        = map(list(string))
+  default = {
+    all = ["https://www.googleapis.com/auth/cloud-platform"]
+  }
+}
+
+variable "labels" {
+  description = "Additional labels applied to the cluster"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/composition/gke/versions.tf
+++ b/terraform/gcp/modules/composition/gke/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/composition/kafka/README.md
+++ b/terraform/gcp/modules/composition/kafka/README.md
@@ -2,20 +2,20 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_broker_instances"></a> [broker\_instances](#module\_broker\_instances) | terraform-google-modules/vm/google//modules/compute_instance | 15.2.1 |
 | <a name="module_broker_template"></a> [broker\_template](#module\_broker\_template) | terraform-google-modules/vm/google//modules/instance_template | 15.2.1 |
 | <a name="module_controller_instances"></a> [controller\_instances](#module\_controller\_instances) | terraform-google-modules/vm/google//modules/compute_instance | 15.2.1 |
@@ -25,14 +25,14 @@
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google_compute_address.broker](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
 | [google_compute_address.controller](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_broker_count"></a> [broker\_count](#input\_broker\_count) | Number of broker instances | `number` | `3` | no |
 | <a name="input_broker_disk_size_gb"></a> [broker\_disk\_size\_gb](#input\_broker\_disk\_size\_gb) | Boot/data disk size in GB for broker instances | `number` | `500` | no |
 | <a name="input_broker_image"></a> [broker\_image](#input\_broker\_image) | Self-link or family of the custom image with Kafka broker software pre-installed | `string` | n/a | yes |
@@ -55,7 +55,7 @@
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_broker_instance_self_links"></a> [broker\_instance\_self\_links](#output\_broker\_instance\_self\_links) | Self-links of the broker instances |
 | <a name="output_broker_internal_ips"></a> [broker\_internal\_ips](#output\_broker\_internal\_ips) | Static internal IP addresses assigned to broker instances |
 | <a name="output_controller_instance_self_links"></a> [controller\_instance\_self\_links](#output\_controller\_instance\_self\_links) | Self-links of the controller instances |

--- a/terraform/gcp/modules/composition/kafka/README.md
+++ b/terraform/gcp/modules/composition/kafka/README.md
@@ -1,0 +1,64 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_broker_instances"></a> [broker\_instances](#module\_broker\_instances) | terraform-google-modules/vm/google//modules/compute_instance | 15.2.1 |
+| <a name="module_broker_template"></a> [broker\_template](#module\_broker\_template) | terraform-google-modules/vm/google//modules/instance_template | 15.2.1 |
+| <a name="module_controller_instances"></a> [controller\_instances](#module\_controller\_instances) | terraform-google-modules/vm/google//modules/compute_instance | 15.2.1 |
+| <a name="module_controller_template"></a> [controller\_template](#module\_controller\_template) | terraform-google-modules/vm/google//modules/instance_template | 15.2.1 |
+| <a name="module_service_account"></a> [service\_account](#module\_service\_account) | terraform-google-modules/service-accounts/google | 4.7.0 |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_compute_address.broker](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
+| [google_compute_address.controller](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_broker_count"></a> [broker\_count](#input\_broker\_count) | Number of broker instances | `number` | `3` | no |
+| <a name="input_broker_disk_size_gb"></a> [broker\_disk\_size\_gb](#input\_broker\_disk\_size\_gb) | Boot/data disk size in GB for broker instances | `number` | `500` | no |
+| <a name="input_broker_image"></a> [broker\_image](#input\_broker\_image) | Self-link or family of the custom image with Kafka broker software pre-installed | `string` | n/a | yes |
+| <a name="input_broker_machine_type"></a> [broker\_machine\_type](#input\_broker\_machine\_type) | Machine type for broker instances | `string` | `"n2-standard-4"` | no |
+| <a name="input_controller_count"></a> [controller\_count](#input\_controller\_count) | Number of KRaft controller instances (should be odd for quorum) | `number` | `3` | no |
+| <a name="input_controller_disk_size_gb"></a> [controller\_disk\_size\_gb](#input\_controller\_disk\_size\_gb) | Boot/data disk size in GB for controller instances | `number` | `100` | no |
+| <a name="input_controller_image"></a> [controller\_image](#input\_controller\_image) | Self-link or family of the custom image with the Kafka (KRaft) controller software pre-installed | `string` | n/a | yes |
+| <a name="input_controller_machine_type"></a> [controller\_machine\_type](#input\_controller\_machine\_type) | Machine type for controller instances | `string` | `"n2-standard-2"` | no |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Persistent disk type for all instances | `string` | `"pd-ssd"` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_metadata"></a> [metadata](#input\_metadata) | Additional instance metadata applied to both broker and controller instances (e.g. startup-script parameters) | `map(string)` | `{}` | no |
+| <a name="input_network"></a> [network](#input\_network) | Self-link of the VPC network | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where instances are created | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name used for naming resources | `string` | `"hyperswitch"` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region for regional resources (addresses, instance templates) | `string` | n/a | yes |
+| <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | Self-link of the subnetwork (typically the data-stack tier from composition/vpc-network) | `string` | n/a | yes |
+| <a name="input_zone"></a> [zone](#input\_zone) | Zone to create instances in | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_broker_instance_self_links"></a> [broker\_instance\_self\_links](#output\_broker\_instance\_self\_links) | Self-links of the broker instances |
+| <a name="output_broker_internal_ips"></a> [broker\_internal\_ips](#output\_broker\_internal\_ips) | Static internal IP addresses assigned to broker instances |
+| <a name="output_controller_instance_self_links"></a> [controller\_instance\_self\_links](#output\_controller\_instance\_self\_links) | Self-links of the controller instances |
+| <a name="output_controller_internal_ips"></a> [controller\_internal\_ips](#output\_controller\_internal\_ips) | Static internal IP addresses assigned to controller instances |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of the shared node service account |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/composition/kafka/locals.tf
+++ b/terraform/gcp/modules/composition/kafka/locals.tf
@@ -1,0 +1,13 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}-kafka"
+
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "component"   = "kafka"
+      "managed_by"  = "terraform"
+    },
+    var.labels
+  )
+}

--- a/terraform/gcp/modules/composition/kafka/main.tf
+++ b/terraform/gcp/modules/composition/kafka/main.tf
@@ -1,0 +1,134 @@
+# ============================================================================
+# Kafka (KRaft) on Compute Engine - GCP equivalent of composition/kafka
+# ============================================================================
+# Like its AWS counterpart, this module does not install Kafka itself: it
+# provisions broker and controller Compute Engine instances from a
+# pre-baked custom image (var.broker_image / var.controller_image) with
+# static internal IPs, mirroring the AWS module's ENI-per-instance /
+# fixed-identity design that KRaft's static voter-set config needs.
+#
+# Usage:
+#   module "kafka" {
+#     source = "../../modules/composition/kafka"
+#
+#     project_id       = "hyperswitch-dev"
+#     environment      = "dev"
+#     zone             = "europe-west1-b"
+#     network          = module.vpc_network.network_self_link
+#     subnetwork       = module.vpc_network.subnets_by_tier["data-stack"]
+#     broker_image     = "projects/hyperswitch-dev/global/images/kafka-broker-v1"
+#     controller_image = "projects/hyperswitch-dev/global/images/kafka-controller-v1"
+#   }
+# ============================================================================
+
+module "service_account" {
+  source  = "terraform-google-modules/service-accounts/google"
+  version = "4.7.0"
+
+  project_id = var.project_id
+  names      = ["${local.name_prefix}-node"]
+  project_roles = [
+    "${var.project_id}=>roles/logging.logWriter",
+    "${var.project_id}=>roles/monitoring.metricWriter",
+  ]
+}
+
+resource "google_compute_address" "broker" {
+  count = var.broker_count
+
+  project      = var.project_id
+  name         = "${local.name_prefix}-broker-${count.index}"
+  region       = var.region
+  subnetwork   = var.subnetwork
+  address_type = "INTERNAL"
+}
+
+resource "google_compute_address" "controller" {
+  count = var.controller_count
+
+  project      = var.project_id
+  name         = "${local.name_prefix}-controller-${count.index}"
+  region       = var.region
+  subnetwork   = var.subnetwork
+  address_type = "INTERNAL"
+}
+
+module "broker_template" {
+  source  = "terraform-google-modules/vm/google//modules/instance_template"
+  version = "15.2.1"
+
+  project_id   = var.project_id
+  region       = var.region
+  name_prefix  = "${local.name_prefix}-broker"
+  machine_type = var.broker_machine_type
+
+  source_image = var.broker_image
+  disk_size_gb = var.broker_disk_size_gb
+  disk_type    = var.disk_type
+
+  network    = var.network
+  subnetwork = var.subnetwork
+
+  service_account = {
+    email  = module.service_account.email
+    scopes = ["cloud-platform"]
+  }
+
+  tags     = ["kafka-broker"]
+  labels   = local.common_labels
+  metadata = merge(var.metadata, { role = "broker" })
+}
+
+module "controller_template" {
+  source  = "terraform-google-modules/vm/google//modules/instance_template"
+  version = "15.2.1"
+
+  project_id   = var.project_id
+  region       = var.region
+  name_prefix  = "${local.name_prefix}-controller"
+  machine_type = var.controller_machine_type
+
+  source_image = var.controller_image
+  disk_size_gb = var.controller_disk_size_gb
+  disk_type    = var.disk_type
+
+  network    = var.network
+  subnetwork = var.subnetwork
+
+  service_account = {
+    email  = module.service_account.email
+    scopes = ["cloud-platform"]
+  }
+
+  tags     = ["kafka-controller"]
+  labels   = local.common_labels
+  metadata = merge(var.metadata, { role = "controller" })
+}
+
+module "broker_instances" {
+  source  = "terraform-google-modules/vm/google//modules/compute_instance"
+  version = "15.2.1"
+
+  project_id        = var.project_id
+  region            = var.region
+  zone              = var.zone
+  hostname          = "${local.name_prefix}-broker"
+  num_instances     = var.broker_count
+  instance_template = module.broker_template.self_link
+  static_ips        = [for addr in google_compute_address.broker : addr.address]
+  labels            = local.common_labels
+}
+
+module "controller_instances" {
+  source  = "terraform-google-modules/vm/google//modules/compute_instance"
+  version = "15.2.1"
+
+  project_id        = var.project_id
+  region            = var.region
+  zone              = var.zone
+  hostname          = "${local.name_prefix}-controller"
+  num_instances     = var.controller_count
+  instance_template = module.controller_template.self_link
+  static_ips        = [for addr in google_compute_address.controller : addr.address]
+  labels            = local.common_labels
+}

--- a/terraform/gcp/modules/composition/kafka/outputs.tf
+++ b/terraform/gcp/modules/composition/kafka/outputs.tf
@@ -1,0 +1,24 @@
+output "broker_internal_ips" {
+  description = "Static internal IP addresses assigned to broker instances"
+  value       = [for addr in google_compute_address.broker : addr.address]
+}
+
+output "controller_internal_ips" {
+  description = "Static internal IP addresses assigned to controller instances"
+  value       = [for addr in google_compute_address.controller : addr.address]
+}
+
+output "broker_instance_self_links" {
+  description = "Self-links of the broker instances"
+  value       = module.broker_instances.instances_self_links
+}
+
+output "controller_instance_self_links" {
+  description = "Self-links of the controller instances"
+  value       = module.controller_instances.instances_self_links
+}
+
+output "service_account_email" {
+  description = "Email of the shared node service account"
+  value       = module.service_account.email
+}

--- a/terraform/gcp/modules/composition/kafka/variables.tf
+++ b/terraform/gcp/modules/composition/kafka/variables.tf
@@ -1,0 +1,99 @@
+variable "project_id" {
+  description = "GCP project ID where instances are created"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name used for naming resources"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "region" {
+  description = "Region for regional resources (addresses, instance templates)"
+  type        = string
+}
+
+variable "zone" {
+  description = "Zone to create instances in"
+  type        = string
+}
+
+variable "network" {
+  description = "Self-link of the VPC network"
+  type        = string
+}
+
+variable "subnetwork" {
+  description = "Self-link of the subnetwork (typically the data-stack tier from composition/vpc-network)"
+  type        = string
+}
+
+variable "broker_image" {
+  description = "Self-link or family of the custom image with Kafka broker software pre-installed"
+  type        = string
+}
+
+variable "controller_image" {
+  description = "Self-link or family of the custom image with the Kafka (KRaft) controller software pre-installed"
+  type        = string
+}
+
+variable "broker_count" {
+  description = "Number of broker instances"
+  type        = number
+  default     = 3
+}
+
+variable "controller_count" {
+  description = "Number of KRaft controller instances (should be odd for quorum)"
+  type        = number
+  default     = 3
+}
+
+variable "broker_machine_type" {
+  description = "Machine type for broker instances"
+  type        = string
+  default     = "n2-standard-4"
+}
+
+variable "controller_machine_type" {
+  description = "Machine type for controller instances"
+  type        = string
+  default     = "n2-standard-2"
+}
+
+variable "broker_disk_size_gb" {
+  description = "Boot/data disk size in GB for broker instances"
+  type        = number
+  default     = 500
+}
+
+variable "controller_disk_size_gb" {
+  description = "Boot/data disk size in GB for controller instances"
+  type        = number
+  default     = 100
+}
+
+variable "disk_type" {
+  description = "Persistent disk type for all instances"
+  type        = string
+  default     = "pd-ssd"
+}
+
+variable "metadata" {
+  description = "Additional instance metadata applied to both broker and controller instances (e.g. startup-script parameters)"
+  type        = map(string)
+  default     = {}
+}
+
+variable "labels" {
+  description = "Additional labels to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/composition/kafka/versions.tf
+++ b/terraform/gcp/modules/composition/kafka/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/composition/load-balancer/README.md
+++ b/terraform/gcp/modules/composition/load-balancer/README.md
@@ -1,0 +1,53 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_external_lb"></a> [external\_lb](#module\_external\_lb) | GoogleCloudPlatform/lb-http/google | 14.2.0 |
+| <a name="module_internal_lb"></a> [internal\_lb](#module\_internal\_lb) | terraform-google-modules/lb-internal/google | 7.1.0 |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_backends"></a> [backends](#input\_backends) | Backend service configuration for the external load balancer, in the shape expected by GoogleCloudPlatform/lb-http/google | `any` | `{}` | no |
+| <a name="input_certificate_map"></a> [certificate\_map](#input\_certificate\_map) | Certificate Manager certificate map ID to attach instead of a classic managed SSL certificate (see composition/certificate-manager) | `string` | `null` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_internal"></a> [internal](#input\_internal) | Whether this is an internal (regional TCP/UDP) load balancer instead of an external (global HTTP(S)) one | `bool` | `false` | no |
+| <a name="input_internal_backends"></a> [internal\_backends](#input\_internal\_backends) | List of {group = <instance-group-self-link>} backends for the internal load balancer | `any` | `[]` | no |
+| <a name="input_internal_lb_health_check"></a> [internal\_lb\_health\_check](#input\_internal\_lb\_health\_check) | Health check configuration for the internal load balancer, in the shape expected by terraform-google-modules/lb-internal | `any` | <pre>{<br/>  "check_interval_sec": 10,<br/>  "healthy_threshold": 2,<br/>  "port": 80,<br/>  "timeout_sec": 5,<br/>  "type": "http",<br/>  "unhealthy_threshold": 3<br/>}</pre> | no |
+| <a name="input_internal_lb_ports"></a> [internal\_lb\_ports](#input\_internal\_lb\_ports) | List of ports to forward for the internal load balancer | `list(string)` | `[]` | no |
+| <a name="input_internal_lb_source_tags"></a> [internal\_lb\_source\_tags](#input\_internal\_lb\_source\_tags) | Source network tags for the internal load balancer's firewall rules | `list(string)` | `[]` | no |
+| <a name="input_internal_lb_target_tags"></a> [internal\_lb\_target\_tags](#input\_internal\_lb\_target\_tags) | Target network tags for the internal load balancer's firewall rules | `list(string)` | `[]` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_managed_ssl_certificate_domains"></a> [managed\_ssl\_certificate\_domains](#input\_managed\_ssl\_certificate\_domains) | List of domains for the Google-managed SSL certificate, used when ssl = true and certificate\_map is null | `list(string)` | `[]` | no |
+| <a name="input_name_override"></a> [name\_override](#input\_name\_override) | Logical name for this load balancer instance (e.g. 'api', 'admin'), used in resource naming | `string` | n/a | yes |
+| <a name="input_network"></a> [network](#input\_network) | Self-link of the VPC network | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where the load balancer is created | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name used for naming resources | `string` | `"hyperswitch"` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region, required when internal = true | `string` | `null` | no |
+| <a name="input_ssl"></a> [ssl](#input\_ssl) | Whether to provision an HTTPS listener with a managed certificate and redirect HTTP to HTTPS | `bool` | `true` | no |
+| <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | Self-link of the subnetwork, required when internal = true | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_external_ip_address"></a> [external\_ip\_address](#output\_external\_ip\_address) | External IP address of the global HTTP(S) load balancer, if internal = false |
+| <a name="output_internal_ip_address"></a> [internal\_ip\_address](#output\_internal\_ip\_address) | IP address of the internal load balancer, if internal = true |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/composition/load-balancer/README.md
+++ b/terraform/gcp/modules/composition/load-balancer/README.md
@@ -2,7 +2,7 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
@@ -13,7 +13,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_external_lb"></a> [external\_lb](#module\_external\_lb) | GoogleCloudPlatform/lb-http/google | 14.2.0 |
 | <a name="module_internal_lb"></a> [internal\_lb](#module\_internal\_lb) | terraform-google-modules/lb-internal/google | 7.1.0 |
 
@@ -24,7 +24,7 @@ No resources.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_backends"></a> [backends](#input\_backends) | Backend service configuration for the external load balancer, in the shape expected by GoogleCloudPlatform/lb-http/google | `any` | `{}` | no |
 | <a name="input_certificate_map"></a> [certificate\_map](#input\_certificate\_map) | Certificate Manager certificate map ID to attach instead of a classic managed SSL certificate (see composition/certificate-manager) | `string` | `null` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
@@ -47,7 +47,7 @@ No resources.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_external_ip_address"></a> [external\_ip\_address](#output\_external\_ip\_address) | External IP address of the global HTTP(S) load balancer, if internal = false |
 | <a name="output_internal_ip_address"></a> [internal\_ip\_address](#output\_internal\_ip\_address) | IP address of the internal load balancer, if internal = true |
 <!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/composition/load-balancer/locals.tf
+++ b/terraform/gcp/modules/composition/load-balancer/locals.tf
@@ -1,0 +1,12 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}-${var.name_override}"
+
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "managed_by"  = "terraform"
+    },
+    var.labels
+  )
+}

--- a/terraform/gcp/modules/composition/load-balancer/main.tf
+++ b/terraform/gcp/modules/composition/load-balancer/main.tf
@@ -1,0 +1,74 @@
+# ============================================================================
+# Generic Load Balancer (GCP equivalent of composition/load-balancer)
+# ============================================================================
+# One `var.internal` toggle switches between:
+#   - external: Global external HTTP(S) Load Balancer (terraform-google-modules/lb-http)
+#   - internal: Regional internal TCP/UDP Load Balancer (terraform-google-modules/lb-internal)
+# mirroring the AWS module's single ALB module with an internal/external
+# toggle. DNS aliasing is handled by an optional composition/cloud-dns call
+# from the live layer, not by this module, to keep the zone/record lifecycle
+# independent of the load balancer's.
+#
+# Usage (external):
+#   module "load_balancer" {
+#     source = "../../modules/composition/load-balancer"
+#
+#     project_id   = "hyperswitch-dev"
+#     environment  = "dev"
+#     name_override = "api"
+#     internal     = false
+#
+#     backends = {
+#       default = {
+#         groups = [{ group = module.some_umig.self_links[0] }]
+#         health_check = { request_path = "/health", port = 8080 }
+#         log_config   = { enable = true, sample_rate = 1.0 }
+#       }
+#     }
+#   }
+# ============================================================================
+
+module "external_lb" {
+  source  = "GoogleCloudPlatform/lb-http/google"
+  version = "14.2.0"
+
+  count = var.internal ? 0 : 1
+
+  project = var.project_id
+  name    = local.name_prefix
+
+  firewall_networks = [var.network]
+
+  ssl                             = var.ssl
+  managed_ssl_certificate_domains = var.managed_ssl_certificate_domains
+  certificate_map                 = var.certificate_map
+  https_redirect                  = var.ssl
+
+  backends = var.backends
+
+  labels = local.common_labels
+}
+
+module "internal_lb" {
+  source  = "terraform-google-modules/lb-internal/google"
+  version = "7.1.0"
+
+  count = var.internal ? 1 : 0
+
+  project    = var.project_id
+  region     = var.region
+  name       = local.name_prefix
+  network    = var.network
+  subnetwork = var.subnetwork
+
+  ports = var.internal_lb_ports
+
+  backends = var.internal_backends
+
+  source_tags = var.internal_lb_source_tags
+  target_tags = var.internal_lb_target_tags
+
+  health_check = var.internal_lb_health_check
+
+  labels = local.common_labels
+}

--- a/terraform/gcp/modules/composition/load-balancer/outputs.tf
+++ b/terraform/gcp/modules/composition/load-balancer/outputs.tf
@@ -1,0 +1,9 @@
+output "external_ip_address" {
+  description = "External IP address of the global HTTP(S) load balancer, if internal = false"
+  value       = var.internal ? null : module.external_lb[0].external_ip
+}
+
+output "internal_ip_address" {
+  description = "IP address of the internal load balancer, if internal = true"
+  value       = var.internal ? module.internal_lb[0].ip_address : null
+}

--- a/terraform/gcp/modules/composition/load-balancer/variables.tf
+++ b/terraform/gcp/modules/composition/load-balancer/variables.tf
@@ -1,0 +1,118 @@
+variable "project_id" {
+  description = "GCP project ID where the load balancer is created"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name used for naming resources"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "name_override" {
+  description = "Logical name for this load balancer instance (e.g. 'api', 'admin'), used in resource naming"
+  type        = string
+}
+
+variable "internal" {
+  description = "Whether this is an internal (regional TCP/UDP) load balancer instead of an external (global HTTP(S)) one"
+  type        = bool
+  default     = false
+}
+
+variable "network" {
+  description = "Self-link of the VPC network"
+  type        = string
+}
+
+variable "region" {
+  description = "Region, required when internal = true"
+  type        = string
+  default     = null
+}
+
+variable "subnetwork" {
+  description = "Self-link of the subnetwork, required when internal = true"
+  type        = string
+  default     = null
+}
+
+# ==============================================================================
+# External HTTP(S) Load Balancer
+# ==============================================================================
+
+variable "ssl" {
+  description = "Whether to provision an HTTPS listener with a managed certificate and redirect HTTP to HTTPS"
+  type        = bool
+  default     = true
+}
+
+variable "managed_ssl_certificate_domains" {
+  description = "List of domains for the Google-managed SSL certificate, used when ssl = true and certificate_map is null"
+  type        = list(string)
+  default     = []
+}
+
+variable "certificate_map" {
+  description = "Certificate Manager certificate map ID to attach instead of a classic managed SSL certificate (see composition/certificate-manager)"
+  type        = string
+  default     = null
+}
+
+variable "backends" {
+  description = "Backend service configuration for the external load balancer, in the shape expected by GoogleCloudPlatform/lb-http/google"
+  type        = any
+  default     = {}
+}
+
+# ==============================================================================
+# Internal TCP/UDP Load Balancer
+# ==============================================================================
+
+variable "internal_backends" {
+  description = "List of {group = <instance-group-self-link>} backends for the internal load balancer"
+  type        = any
+  default     = []
+}
+
+variable "internal_lb_ports" {
+  description = "List of ports to forward for the internal load balancer"
+  type        = list(string)
+  default     = []
+}
+
+variable "internal_lb_source_tags" {
+  description = "Source network tags for the internal load balancer's firewall rules"
+  type        = list(string)
+  default     = []
+}
+
+variable "internal_lb_target_tags" {
+  description = "Target network tags for the internal load balancer's firewall rules"
+  type        = list(string)
+  default     = []
+}
+
+variable "internal_lb_health_check" {
+  description = "Health check configuration for the internal load balancer, in the shape expected by terraform-google-modules/lb-internal"
+  type        = any
+  default = {
+    type                = "http"
+    port                = 80
+    check_interval_sec  = 10
+    timeout_sec         = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+  }
+}
+
+variable "labels" {
+  description = "Additional labels to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/composition/load-balancer/versions.tf
+++ b/terraform/gcp/modules/composition/load-balancer/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/composition/locker/README.md
+++ b/terraform/gcp/modules/composition/locker/README.md
@@ -1,0 +1,63 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_database"></a> [database](#module\_database) | ../cloud-sql | n/a |
+| <a name="module_internal_lb"></a> [internal\_lb](#module\_internal\_lb) | terraform-google-modules/lb-internal/google | 7.1.0 |
+| <a name="module_kms"></a> [kms](#module\_kms) | terraform-google-modules/kms/google | 4.1.2 |
+| <a name="module_locker_group"></a> [locker\_group](#module\_locker\_group) | terraform-google-modules/vm/google//modules/umig | 15.2.1 |
+| <a name="module_locker_template"></a> [locker\_template](#module\_locker\_template) | terraform-google-modules/vm/google//modules/instance_template | 15.2.1 |
+| <a name="module_service_account"></a> [service\_account](#module\_service\_account) | terraform-google-modules/service-accounts/google | 4.7.0 |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_create_locker_database"></a> [create\_locker\_database](#input\_create\_locker\_database) | Whether to create a dedicated Cloud SQL database for the locker | `bool` | `true` | no |
+| <a name="input_database_config"></a> [database\_config](#input\_database\_config) | Configuration for the locker's dedicated Cloud SQL database (composition/cloud-sql) | <pre>object({<br/>    instance_name       = optional(string)<br/>    database_version    = optional(string, "POSTGRES_15")<br/>    tier                = optional(string, "db-custom-2-8192")<br/>    availability_type   = optional(string, "REGIONAL")<br/>    disk_size           = optional(number, 100)<br/>    deletion_protection = optional(bool, true)<br/>    database_name       = optional(string, "locker")<br/>    master_username     = optional(string, "locker_admin")<br/>    master_password     = optional(string)<br/>    encryption_key_name = optional(string)<br/>  })</pre> | `{}` | no |
+| <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Boot disk size in GB | `number` | `50` | no |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Persistent disk type | `string` | `"pd-ssd"` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_health_check_path"></a> [health\_check\_path](#input\_health\_check\_path) | HTTP path for the locker health check | `string` | `"/health"` | no |
+| <a name="input_health_check_port"></a> [health\_check\_port](#input\_health\_check\_port) | Port for the locker health check | `number` | `8080` | no |
+| <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Number of locker instances | `number` | `2` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_lb_subnetwork"></a> [lb\_subnetwork](#input\_lb\_subnetwork) | Self-link of the subnetwork for the internal load balancer's forwarding rule | `string` | n/a | yes |
+| <a name="input_locker_image"></a> [locker\_image](#input\_locker\_image) | Self-link or family of the custom image with the card-vault software pre-installed | `string` | n/a | yes |
+| <a name="input_locker_port"></a> [locker\_port](#input\_locker\_port) | Port the locker application listens on | `number` | `8080` | no |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Machine type for locker instances | `string` | `"n2-standard-4"` | no |
+| <a name="input_metadata"></a> [metadata](#input\_metadata) | Additional instance metadata (e.g. startup-script parameters) | `map(string)` | `{}` | no |
+| <a name="input_network"></a> [network](#input\_network) | Self-link of the VPC network | `string` | n/a | yes |
+| <a name="input_network_id"></a> [network\_id](#input\_network\_id) | ID of the VPC network (used by the optional Cloud SQL database, requires Private Service Access) | `string` | `null` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where resources are created | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name used for naming resources | `string` | `"hyperswitch"` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region for regional resources | `string` | n/a | yes |
+| <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | Self-link of the subnetwork for locker instances (typically the locker-server tier) | `string` | n/a | yes |
+| <a name="input_zone"></a> [zone](#input\_zone) | Zone to create instances in | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_database_instance_connection_name"></a> [database\_instance\_connection\_name](#output\_database\_instance\_connection\_name) | Cloud SQL Auth Proxy connection name for the locker database, if created |
+| <a name="output_internal_lb_ip_address"></a> [internal\_lb\_ip\_address](#output\_internal\_lb\_ip\_address) | IP address of the internal load balancer in front of the locker fleet |
+| <a name="output_kms_key_name"></a> [kms\_key\_name](#output\_kms\_key\_name) | Self-link of the KMS key used for the locker's disk and database encryption |
+| <a name="output_locker_instance_self_links"></a> [locker\_instance\_self\_links](#output\_locker\_instance\_self\_links) | Self-links of the locker instances |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of the shared locker node service account |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/composition/locker/README.md
+++ b/terraform/gcp/modules/composition/locker/README.md
@@ -2,7 +2,7 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
@@ -13,7 +13,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_database"></a> [database](#module\_database) | ../cloud-sql | n/a |
 | <a name="module_internal_lb"></a> [internal\_lb](#module\_internal\_lb) | terraform-google-modules/lb-internal/google | 7.1.0 |
 | <a name="module_kms"></a> [kms](#module\_kms) | terraform-google-modules/kms/google | 4.1.2 |
@@ -28,7 +28,7 @@ No resources.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_create_locker_database"></a> [create\_locker\_database](#input\_create\_locker\_database) | Whether to create a dedicated Cloud SQL database for the locker | `bool` | `true` | no |
 | <a name="input_database_config"></a> [database\_config](#input\_database\_config) | Configuration for the locker's dedicated Cloud SQL database (composition/cloud-sql) | <pre>object({<br/>    instance_name       = optional(string)<br/>    database_version    = optional(string, "POSTGRES_15")<br/>    tier                = optional(string, "db-custom-2-8192")<br/>    availability_type   = optional(string, "REGIONAL")<br/>    disk_size           = optional(number, 100)<br/>    deletion_protection = optional(bool, true)<br/>    database_name       = optional(string, "locker")<br/>    master_username     = optional(string, "locker_admin")<br/>    master_password     = optional(string)<br/>    encryption_key_name = optional(string)<br/>  })</pre> | `{}` | no |
 | <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Boot disk size in GB | `number` | `50` | no |
@@ -54,7 +54,7 @@ No resources.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_database_instance_connection_name"></a> [database\_instance\_connection\_name](#output\_database\_instance\_connection\_name) | Cloud SQL Auth Proxy connection name for the locker database, if created |
 | <a name="output_internal_lb_ip_address"></a> [internal\_lb\_ip\_address](#output\_internal\_lb\_ip\_address) | IP address of the internal load balancer in front of the locker fleet |
 | <a name="output_kms_key_name"></a> [kms\_key\_name](#output\_kms\_key\_name) | Self-link of the KMS key used for the locker's disk and database encryption |

--- a/terraform/gcp/modules/composition/locker/database.tf
+++ b/terraform/gcp/modules/composition/locker/database.tf
@@ -1,0 +1,33 @@
+# ============================================================================
+# Locker's own Cloud SQL database
+# ============================================================================
+# Called by relative path rather than a pinned git ref (the AWS module pins
+# git::...?ref=database-v0.1.6): there is no released tag for this tree yet.
+# Switch to a versioned source once composition/cloud-sql is tagged.
+module "database" {
+  count = var.create_locker_database ? 1 : 0
+
+  source = "../cloud-sql"
+
+  project_id   = var.project_id
+  environment  = var.environment
+  project_name = var.project_name
+  region       = var.region
+  network_id   = var.network_id
+
+  instance_name = coalesce(var.database_config.instance_name, "${local.name_prefix}-db")
+
+  database_version    = var.database_config.database_version
+  tier                = var.database_config.tier
+  availability_type   = var.database_config.availability_type
+  disk_size           = var.database_config.disk_size
+  deletion_protection = var.database_config.deletion_protection
+
+  database_name   = var.database_config.database_name
+  master_username = var.database_config.master_username
+  master_password = var.database_config.master_password
+
+  encryption_key_name = coalesce(var.database_config.encryption_key_name, module.kms.keys["locker"])
+
+  labels = local.common_labels
+}

--- a/terraform/gcp/modules/composition/locker/kms.tf
+++ b/terraform/gcp/modules/composition/locker/kms.tf
@@ -1,0 +1,17 @@
+# ============================================================================
+# CMEK for the locker's disks and its Cloud SQL database
+# ============================================================================
+module "kms" {
+  source  = "terraform-google-modules/kms/google"
+  version = "4.1.2"
+
+  project_id = var.project_id
+  location   = var.region
+  keyring    = "${local.name_prefix}-keyring"
+  keys       = ["locker"]
+
+  key_protection_level = "SOFTWARE"
+  key_rotation_period  = "7776000s" # 90 days
+
+  labels = local.common_labels
+}

--- a/terraform/gcp/modules/composition/locker/locals.tf
+++ b/terraform/gcp/modules/composition/locker/locals.tf
@@ -1,0 +1,13 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}-locker"
+
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "component"   = "locker"
+      "managed_by"  = "terraform"
+    },
+    var.labels
+  )
+}

--- a/terraform/gcp/modules/composition/locker/main.tf
+++ b/terraform/gcp/modules/composition/locker/main.tf
@@ -1,0 +1,117 @@
+# ============================================================================
+# Card Vault Locker (GCP equivalent of composition/locker)
+# ============================================================================
+# PCI-DSS scoped card-vault instances on Compute Engine, fronted by an
+# internal TCP load balancer, with a dedicated CMEK key and (optionally) its
+# own Cloud SQL database - mirroring the AWS module's EC2 + ALB + KMS +
+# dedicated-RDS shape.
+#
+# Usage:
+#   module "locker" {
+#     source = "../../modules/composition/locker"
+#
+#     project_id    = "hyperswitch-dev"
+#     environment   = "dev"
+#     region        = "europe-west1"
+#     zone          = "europe-west1-b"
+#     network       = module.vpc_network.network_self_link
+#     network_id    = module.vpc_network.network_id
+#     subnetwork    = module.vpc_network.subnets_by_tier["locker-server"]
+#     lb_subnetwork = module.vpc_network.subnets_by_tier["locker-server"]
+#     locker_image  = "projects/hyperswitch-dev/global/images/locker-v1"
+#
+#     database_config = {
+#       database_name   = "locker"
+#       master_username = "locker_admin"
+#     }
+#   }
+# ============================================================================
+
+module "service_account" {
+  source  = "terraform-google-modules/service-accounts/google"
+  version = "4.7.0"
+
+  project_id = var.project_id
+  names      = ["${local.name_prefix}-node"]
+  project_roles = [
+    "${var.project_id}=>roles/logging.logWriter",
+    "${var.project_id}=>roles/monitoring.metricWriter",
+    "${var.project_id}=>roles/cloudkms.cryptoKeyEncrypterDecrypter",
+  ]
+}
+
+module "locker_template" {
+  source  = "terraform-google-modules/vm/google//modules/instance_template"
+  version = "15.2.1"
+
+  project_id   = var.project_id
+  region       = var.region
+  name_prefix  = local.name_prefix
+  machine_type = var.machine_type
+
+  source_image        = var.locker_image
+  disk_size_gb        = var.disk_size_gb
+  disk_type           = var.disk_type
+  disk_encryption_key = module.kms.keys["locker"]
+
+  network    = var.network
+  subnetwork = var.subnetwork
+
+  service_account = {
+    email  = module.service_account.email
+    scopes = ["cloud-platform"]
+  }
+
+  tags     = ["locker-node"]
+  labels   = local.common_labels
+  metadata = var.metadata
+}
+
+module "locker_group" {
+  source  = "terraform-google-modules/vm/google//modules/umig"
+  version = "15.2.1"
+
+  project_id        = var.project_id
+  region            = var.region
+  zones             = [var.zone]
+  hostname          = local.name_prefix
+  num_instances     = var.instance_count
+  instance_template = module.locker_template.self_link
+  named_ports = [
+    { name = "locker", port = var.locker_port },
+  ]
+}
+
+module "internal_lb" {
+  source  = "terraform-google-modules/lb-internal/google"
+  version = "7.1.0"
+
+  project    = var.project_id
+  region     = var.region
+  name       = "${local.name_prefix}-ilb"
+  network    = var.network
+  subnetwork = var.lb_subnetwork
+
+  ports = [tostring(var.locker_port)]
+
+  backends = [
+    for group in module.locker_group.self_links : { group = group }
+  ]
+
+  source_tags = []
+  target_tags = ["locker-node"]
+
+  health_check = {
+    type                = "http"
+    port                = var.health_check_port
+    request_path        = var.health_check_path
+    check_interval_sec  = 10
+    timeout_sec         = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    response            = null
+    proxy_header        = "NONE"
+  }
+
+  labels = local.common_labels
+}

--- a/terraform/gcp/modules/composition/locker/outputs.tf
+++ b/terraform/gcp/modules/composition/locker/outputs.tf
@@ -1,0 +1,24 @@
+output "locker_instance_self_links" {
+  description = "Self-links of the locker instances"
+  value       = module.locker_group.instances_self_links
+}
+
+output "internal_lb_ip_address" {
+  description = "IP address of the internal load balancer in front of the locker fleet"
+  value       = module.internal_lb.ip_address
+}
+
+output "kms_key_name" {
+  description = "Self-link of the KMS key used for the locker's disk and database encryption"
+  value       = module.kms.keys["locker"]
+}
+
+output "service_account_email" {
+  description = "Email of the shared locker node service account"
+  value       = module.service_account.email
+}
+
+output "database_instance_connection_name" {
+  description = "Cloud SQL Auth Proxy connection name for the locker database, if created"
+  value       = var.create_locker_database ? module.database[0].instance_connection_name : null
+}

--- a/terraform/gcp/modules/composition/locker/variables.tf
+++ b/terraform/gcp/modules/composition/locker/variables.tf
@@ -1,0 +1,132 @@
+variable "project_id" {
+  description = "GCP project ID where resources are created"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name used for naming resources"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "region" {
+  description = "Region for regional resources"
+  type        = string
+}
+
+variable "zone" {
+  description = "Zone to create instances in"
+  type        = string
+}
+
+variable "network" {
+  description = "Self-link of the VPC network"
+  type        = string
+}
+
+variable "network_id" {
+  description = "ID of the VPC network (used by the optional Cloud SQL database, requires Private Service Access)"
+  type        = string
+  default     = null
+}
+
+variable "subnetwork" {
+  description = "Self-link of the subnetwork for locker instances (typically the locker-server tier)"
+  type        = string
+}
+
+variable "lb_subnetwork" {
+  description = "Self-link of the subnetwork for the internal load balancer's forwarding rule"
+  type        = string
+}
+
+variable "locker_image" {
+  description = "Self-link or family of the custom image with the card-vault software pre-installed"
+  type        = string
+}
+
+variable "instance_count" {
+  description = "Number of locker instances"
+  type        = number
+  default     = 2
+}
+
+variable "machine_type" {
+  description = "Machine type for locker instances"
+  type        = string
+  default     = "n2-standard-4"
+}
+
+variable "disk_size_gb" {
+  description = "Boot disk size in GB"
+  type        = number
+  default     = 50
+}
+
+variable "disk_type" {
+  description = "Persistent disk type"
+  type        = string
+  default     = "pd-ssd"
+}
+
+variable "locker_port" {
+  description = "Port the locker application listens on"
+  type        = number
+  default     = 8080
+}
+
+variable "health_check_port" {
+  description = "Port for the locker health check"
+  type        = number
+  default     = 8080
+}
+
+variable "health_check_path" {
+  description = "HTTP path for the locker health check"
+  type        = string
+  default     = "/health"
+}
+
+variable "metadata" {
+  description = "Additional instance metadata (e.g. startup-script parameters)"
+  type        = map(string)
+  default     = {}
+}
+
+# ============================================================================
+# Locker Database
+# ============================================================================
+
+variable "create_locker_database" {
+  description = "Whether to create a dedicated Cloud SQL database for the locker"
+  type        = bool
+  default     = true
+}
+
+variable "database_config" {
+  description = "Configuration for the locker's dedicated Cloud SQL database (composition/cloud-sql)"
+  type = object({
+    instance_name       = optional(string)
+    database_version    = optional(string, "POSTGRES_15")
+    tier                = optional(string, "db-custom-2-8192")
+    availability_type   = optional(string, "REGIONAL")
+    disk_size           = optional(number, 100)
+    deletion_protection = optional(bool, true)
+    database_name       = optional(string, "locker")
+    master_username     = optional(string, "locker_admin")
+    master_password     = optional(string)
+    encryption_key_name = optional(string)
+  })
+  default = {}
+}
+
+variable "labels" {
+  description = "Additional labels to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/composition/locker/versions.tf
+++ b/terraform/gcp/modules/composition/locker/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/composition/memorystore/README.md
+++ b/terraform/gcp/modules/composition/memorystore/README.md
@@ -1,0 +1,53 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_memorystore"></a> [memorystore](#module\_memorystore) | terraform-google-modules/memorystore/google | 16.1.1 |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_auth_enabled"></a> [auth\_enabled](#input\_auth\_enabled) | Whether to enable Redis AUTH | `bool` | `true` | no |
+| <a name="input_authorized_network"></a> [authorized\_network](#input\_authorized\_network) | Self-link/ID of the VPC network the instance is peered to (requires Private Service Access, see composition/vpc-network) | `string` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_instance_name"></a> [instance\_name](#input\_instance\_name) | Name of the Redis instance. Defaults to '<environment>-<project\_name>-redis-<region>' | `string` | `null` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_memory_size_gb"></a> [memory\_size\_gb](#input\_memory\_size\_gb) | Redis memory size in GB | `number` | `5` | no |
+| <a name="input_persistence_mode"></a> [persistence\_mode](#input\_persistence\_mode) | Persistence mode: RDB or DISABLED. Null leaves persistence unmanaged by this module | `string` | `null` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where the instance is created | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name for labeling and naming resources | `string` | `"hyperswitch"` | no |
+| <a name="input_rdb_snapshot_period"></a> [rdb\_snapshot\_period](#input\_rdb\_snapshot\_period) | RDB snapshot period, required when persistence\_mode is RDB | `string` | `"TWENTY_FOUR_HOURS"` | no |
+| <a name="input_redis_configs"></a> [redis\_configs](#input\_redis\_configs) | Map of Redis configuration parameters (e.g. maxmemory-policy) | `map(any)` | `{}` | no |
+| <a name="input_redis_version"></a> [redis\_version](#input\_redis\_version) | Redis version | `string` | `"REDIS_7_2"` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region for the Memorystore instance | `string` | n/a | yes |
+| <a name="input_replica_count"></a> [replica\_count](#input\_replica\_count) | Number of read replicas (0 disables read replicas). Only supported on STANDARD\_HA | `number` | `0` | no |
+| <a name="input_tier"></a> [tier](#input\_tier) | Service tier: BASIC or STANDARD\_HA (STANDARD\_HA is the closest match to the AWS module's replication-group default) | `string` | `"STANDARD_HA"` | no |
+| <a name="input_transit_encryption_mode"></a> [transit\_encryption\_mode](#input\_transit\_encryption\_mode) | Transit encryption mode: SERVER\_AUTHENTICATION or DISABLED | `string` | `"SERVER_AUTHENTICATION"` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_auth_string"></a> [auth\_string](#output\_auth\_string) | AUTH string for the instance, if auth\_enabled is true |
+| <a name="output_host"></a> [host](#output\_host) | Primary endpoint hostname/IP of the instance |
+| <a name="output_instance_id"></a> [instance\_id](#output\_instance\_id) | Fully qualified ID of the Memorystore instance |
+| <a name="output_port"></a> [port](#output\_port) | Port the instance listens on |
+| <a name="output_read_endpoint"></a> [read\_endpoint](#output\_read\_endpoint) | Read endpoint (host/port), populated only when read replicas are enabled |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/composition/memorystore/README.md
+++ b/terraform/gcp/modules/composition/memorystore/README.md
@@ -2,7 +2,7 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
@@ -13,7 +13,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_memorystore"></a> [memorystore](#module\_memorystore) | terraform-google-modules/memorystore/google | 16.1.1 |
 
 ## Resources
@@ -23,7 +23,7 @@ No resources.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_auth_enabled"></a> [auth\_enabled](#input\_auth\_enabled) | Whether to enable Redis AUTH | `bool` | `true` | no |
 | <a name="input_authorized_network"></a> [authorized\_network](#input\_authorized\_network) | Self-link/ID of the VPC network the instance is peered to (requires Private Service Access, see composition/vpc-network) | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
@@ -44,7 +44,7 @@ No resources.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_auth_string"></a> [auth\_string](#output\_auth\_string) | AUTH string for the instance, if auth\_enabled is true |
 | <a name="output_host"></a> [host](#output\_host) | Primary endpoint hostname/IP of the instance |
 | <a name="output_instance_id"></a> [instance\_id](#output\_instance\_id) | Fully qualified ID of the Memorystore instance |

--- a/terraform/gcp/modules/composition/memorystore/locals.tf
+++ b/terraform/gcp/modules/composition/memorystore/locals.tf
@@ -1,0 +1,15 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}-redis"
+
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "component"   = "cache"
+      "managed_by"  = "terraform"
+    },
+    var.labels
+  )
+
+  instance_name = var.instance_name != null ? var.instance_name : "${local.name_prefix}-${var.region}"
+}

--- a/terraform/gcp/modules/composition/memorystore/main.tf
+++ b/terraform/gcp/modules/composition/memorystore/main.tf
@@ -1,0 +1,51 @@
+# ============================================================================
+# Memorystore for Redis (GCP equivalent of composition/elasticache)
+# ============================================================================
+# STANDARD_HA tier with optional read replicas, matching the AWS module's
+# replication-group + optional global-replication-group shape. GCP has no
+# direct Global Datastore equivalent; the closest analogue is a second
+# Memorystore instance in another region kept in sync at the application
+# layer, which is out of scope for this module (see README).
+#
+# Usage:
+#   module "memorystore" {
+#     source = "../../modules/composition/memorystore"
+#
+#     project_id          = "hyperswitch-dev"
+#     environment         = "dev"
+#     region              = "europe-west1"
+#     authorized_network  = module.vpc_network.network_id
+#
+#     depends_on = [module.vpc_network] # for Private Service Access
+#   }
+# ============================================================================
+
+module "memorystore" {
+  source  = "terraform-google-modules/memorystore/google"
+  version = "16.1.1"
+
+  project_id = var.project_id
+  region     = var.region
+  name       = local.instance_name
+
+  tier           = var.tier
+  memory_size_gb = var.memory_size_gb
+  redis_version  = var.redis_version
+  connect_mode   = "PRIVATE_SERVICE_ACCESS"
+
+  authorized_network = var.authorized_network
+  read_replicas_mode = var.replica_count > 0 ? "READ_REPLICAS_ENABLED" : "READ_REPLICAS_DISABLED"
+  replica_count      = var.replica_count
+
+  auth_enabled            = var.auth_enabled
+  transit_encryption_mode = var.transit_encryption_mode
+
+  redis_configs = var.redis_configs
+
+  persistence_config = var.persistence_mode != null ? {
+    persistence_mode    = var.persistence_mode
+    rdb_snapshot_period = var.rdb_snapshot_period
+  } : null
+
+  labels = local.common_labels
+}

--- a/terraform/gcp/modules/composition/memorystore/outputs.tf
+++ b/terraform/gcp/modules/composition/memorystore/outputs.tf
@@ -1,0 +1,25 @@
+output "instance_id" {
+  description = "Fully qualified ID of the Memorystore instance"
+  value       = module.memorystore.id
+}
+
+output "host" {
+  description = "Primary endpoint hostname/IP of the instance"
+  value       = module.memorystore.host
+}
+
+output "port" {
+  description = "Port the instance listens on"
+  value       = module.memorystore.port
+}
+
+output "read_endpoint" {
+  description = "Read endpoint (host/port), populated only when read replicas are enabled"
+  value       = module.memorystore.read_endpoint
+}
+
+output "auth_string" {
+  description = "AUTH string for the instance, if auth_enabled is true"
+  value       = module.memorystore.auth_string
+  sensitive   = true
+}

--- a/terraform/gcp/modules/composition/memorystore/variables.tf
+++ b/terraform/gcp/modules/composition/memorystore/variables.tf
@@ -1,0 +1,91 @@
+variable "project_id" {
+  description = "GCP project ID where the instance is created"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for labeling and naming resources"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "region" {
+  description = "Region for the Memorystore instance"
+  type        = string
+}
+
+variable "instance_name" {
+  description = "Name of the Redis instance. Defaults to '<environment>-<project_name>-redis-<region>'"
+  type        = string
+  default     = null
+}
+
+variable "authorized_network" {
+  description = "Self-link/ID of the VPC network the instance is peered to (requires Private Service Access, see composition/vpc-network)"
+  type        = string
+}
+
+variable "tier" {
+  description = "Service tier: BASIC or STANDARD_HA (STANDARD_HA is the closest match to the AWS module's replication-group default)"
+  type        = string
+  default     = "STANDARD_HA"
+}
+
+variable "memory_size_gb" {
+  description = "Redis memory size in GB"
+  type        = number
+  default     = 5
+}
+
+variable "redis_version" {
+  description = "Redis version"
+  type        = string
+  default     = "REDIS_7_2"
+}
+
+variable "replica_count" {
+  description = "Number of read replicas (0 disables read replicas). Only supported on STANDARD_HA"
+  type        = number
+  default     = 0
+}
+
+variable "auth_enabled" {
+  description = "Whether to enable Redis AUTH"
+  type        = bool
+  default     = true
+}
+
+variable "transit_encryption_mode" {
+  description = "Transit encryption mode: SERVER_AUTHENTICATION or DISABLED"
+  type        = string
+  default     = "SERVER_AUTHENTICATION"
+}
+
+variable "redis_configs" {
+  description = "Map of Redis configuration parameters (e.g. maxmemory-policy)"
+  type        = map(any)
+  default     = {}
+}
+
+variable "persistence_mode" {
+  description = "Persistence mode: RDB or DISABLED. Null leaves persistence unmanaged by this module"
+  type        = string
+  default     = null
+}
+
+variable "rdb_snapshot_period" {
+  description = "RDB snapshot period, required when persistence_mode is RDB"
+  type        = string
+  default     = "TWENTY_FOUR_HOURS"
+}
+
+variable "labels" {
+  description = "Additional labels to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/composition/memorystore/versions.tf
+++ b/terraform/gcp/modules/composition/memorystore/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/composition/opensearch/README.md
+++ b/terraform/gcp/modules/composition/opensearch/README.md
@@ -2,20 +2,20 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_internal_lb"></a> [internal\_lb](#module\_internal\_lb) | terraform-google-modules/lb-internal/google | 7.1.0 |
 | <a name="module_node_group"></a> [node\_group](#module\_node\_group) | terraform-google-modules/vm/google//modules/umig | 15.2.1 |
 | <a name="module_node_template"></a> [node\_template](#module\_node\_template) | terraform-google-modules/vm/google//modules/instance_template | 15.2.1 |
@@ -24,14 +24,14 @@
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google_compute_attached_disk.data](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_attached_disk) | resource |
 | [google_compute_disk.data](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_boot_disk_size_gb"></a> [boot\_disk\_size\_gb](#input\_boot\_disk\_size\_gb) | Boot disk size in GB | `number` | `50` | no |
 | <a name="input_data_disk_size_gb"></a> [data\_disk\_size\_gb](#input\_data\_disk\_size\_gb) | Attached data disk size in GB per node | `number` | `500` | no |
 | <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Persistent disk type used for both boot and data disks | `string` | `"pd-ssd"` | no |
@@ -53,7 +53,7 @@
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_internal_lb_ip_address"></a> [internal\_lb\_ip\_address](#output\_internal\_lb\_ip\_address) | IP address of the internal load balancer in front of the node fleet |
 | <a name="output_node_instance_self_links"></a> [node\_instance\_self\_links](#output\_node\_instance\_self\_links) | Self-links of the OpenSearch node instances |
 | <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of the shared node service account |

--- a/terraform/gcp/modules/composition/opensearch/README.md
+++ b/terraform/gcp/modules/composition/opensearch/README.md
@@ -1,0 +1,60 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_internal_lb"></a> [internal\_lb](#module\_internal\_lb) | terraform-google-modules/lb-internal/google | 7.1.0 |
+| <a name="module_node_group"></a> [node\_group](#module\_node\_group) | terraform-google-modules/vm/google//modules/umig | 15.2.1 |
+| <a name="module_node_template"></a> [node\_template](#module\_node\_template) | terraform-google-modules/vm/google//modules/instance_template | 15.2.1 |
+| <a name="module_service_account"></a> [service\_account](#module\_service\_account) | terraform-google-modules/service-accounts/google | 4.7.0 |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_compute_attached_disk.data](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_attached_disk) | resource |
+| [google_compute_disk.data](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_boot_disk_size_gb"></a> [boot\_disk\_size\_gb](#input\_boot\_disk\_size\_gb) | Boot disk size in GB | `number` | `50` | no |
+| <a name="input_data_disk_size_gb"></a> [data\_disk\_size\_gb](#input\_data\_disk\_size\_gb) | Attached data disk size in GB per node | `number` | `500` | no |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Persistent disk type used for both boot and data disks | `string` | `"pd-ssd"` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_http_port"></a> [http\_port](#input\_http\_port) | OpenSearch REST API port | `number` | `9200` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_lb_subnetwork"></a> [lb\_subnetwork](#input\_lb\_subnetwork) | Self-link of the subnetwork for the internal load balancer's forwarding rule | `string` | n/a | yes |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Machine type for node instances | `string` | `"n2-standard-4"` | no |
+| <a name="input_metadata"></a> [metadata](#input\_metadata) | Additional instance metadata (e.g. startup-script parameters) | `map(string)` | `{}` | no |
+| <a name="input_network"></a> [network](#input\_network) | Self-link of the VPC network | `string` | n/a | yes |
+| <a name="input_node_count"></a> [node\_count](#input\_node\_count) | Number of OpenSearch node instances | `number` | `3` | no |
+| <a name="input_node_image"></a> [node\_image](#input\_node\_image) | Self-link or family of the custom image with OpenSearch pre-installed | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where instances are created | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name used for naming resources | `string` | `"hyperswitch"` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region for regional resources | `string` | n/a | yes |
+| <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | Self-link of the subnetwork for OpenSearch nodes | `string` | n/a | yes |
+| <a name="input_zone"></a> [zone](#input\_zone) | Zone to create instances in | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_internal_lb_ip_address"></a> [internal\_lb\_ip\_address](#output\_internal\_lb\_ip\_address) | IP address of the internal load balancer in front of the node fleet |
+| <a name="output_node_instance_self_links"></a> [node\_instance\_self\_links](#output\_node\_instance\_self\_links) | Self-links of the OpenSearch node instances |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of the shared node service account |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/composition/opensearch/locals.tf
+++ b/terraform/gcp/modules/composition/opensearch/locals.tf
@@ -1,0 +1,13 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}-opensearch"
+
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "component"   = "opensearch"
+      "managed_by"  = "terraform"
+    },
+    var.labels
+  )
+}

--- a/terraform/gcp/modules/composition/opensearch/main.tf
+++ b/terraform/gcp/modules/composition/opensearch/main.tf
@@ -1,0 +1,131 @@
+# ============================================================================
+# OpenSearch on Compute Engine - GCP equivalent of composition/opensearch
+# ============================================================================
+# GCP has no first-party managed OpenSearch/Elasticsearch service (unlike
+# AWS's Amazon OpenSearch Service), so - consistent with kafka/cassandra/
+# clickhouse - this module runs OpenSearch on a Compute Engine node fleet
+# built from a pre-baked custom image, private-IP only, fronted by an
+# internal TCP load balancer. See terraform/gcp/modules/README.md for the
+# rationale and alternatives (Elastic Cloud on GCP Marketplace, BigQuery/Log
+# Analytics) if a managed service is preferred instead.
+#
+# Usage:
+#   module "opensearch" {
+#     source = "../../modules/composition/opensearch"
+#
+#     project_id    = "hyperswitch-dev"
+#     environment   = "dev"
+#     region        = "europe-west1"
+#     zone          = "europe-west1-b"
+#     network       = module.vpc_network.network_self_link
+#     subnetwork    = module.vpc_network.subnets_by_tier["data-stack"]
+#     lb_subnetwork = module.vpc_network.subnets_by_tier["data-stack"]
+#     node_image    = "projects/hyperswitch-dev/global/images/opensearch-v1"
+#   }
+# ============================================================================
+
+module "service_account" {
+  source  = "terraform-google-modules/service-accounts/google"
+  version = "4.7.0"
+
+  project_id = var.project_id
+  names      = ["${local.name_prefix}-node"]
+  project_roles = [
+    "${var.project_id}=>roles/logging.logWriter",
+    "${var.project_id}=>roles/monitoring.metricWriter",
+  ]
+}
+
+resource "google_compute_disk" "data" {
+  count = var.node_count
+
+  project = var.project_id
+  name    = "${local.name_prefix}-${count.index}-data"
+  zone    = var.zone
+  type    = var.disk_type
+  size    = var.data_disk_size_gb
+  labels  = local.common_labels
+}
+
+module "node_template" {
+  source  = "terraform-google-modules/vm/google//modules/instance_template"
+  version = "15.2.1"
+
+  project_id   = var.project_id
+  region       = var.region
+  name_prefix  = local.name_prefix
+  machine_type = var.machine_type
+
+  source_image = var.node_image
+  disk_size_gb = var.boot_disk_size_gb
+  disk_type    = var.disk_type
+
+  network    = var.network
+  subnetwork = var.subnetwork
+
+  service_account = {
+    email  = module.service_account.email
+    scopes = ["cloud-platform"]
+  }
+
+  tags     = ["opensearch-node"]
+  labels   = local.common_labels
+  metadata = var.metadata
+}
+
+module "node_group" {
+  source  = "terraform-google-modules/vm/google//modules/umig"
+  version = "15.2.1"
+
+  project_id        = var.project_id
+  region            = var.region
+  zones             = [var.zone]
+  hostname          = local.name_prefix
+  num_instances     = var.node_count
+  instance_template = module.node_template.self_link
+  named_ports = [
+    { name = "http", port = var.http_port },
+  ]
+}
+
+resource "google_compute_attached_disk" "data" {
+  count = var.node_count
+
+  project     = var.project_id
+  disk        = google_compute_disk.data[count.index].id
+  instance    = module.node_group.instances_self_links[count.index]
+  device_name = "opensearch-data"
+}
+
+module "internal_lb" {
+  source  = "terraform-google-modules/lb-internal/google"
+  version = "7.1.0"
+
+  project    = var.project_id
+  region     = var.region
+  name       = "${local.name_prefix}-ilb"
+  network    = var.network
+  subnetwork = var.lb_subnetwork
+
+  ports = [tostring(var.http_port)]
+
+  backends = [
+    for group in module.node_group.self_links : { group = group }
+  ]
+
+  source_tags = []
+  target_tags = ["opensearch-node"]
+
+  health_check = {
+    type                = "http"
+    port                = var.http_port
+    check_interval_sec  = 10
+    timeout_sec         = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    response            = null
+    proxy_header        = "NONE"
+  }
+
+  labels = local.common_labels
+}

--- a/terraform/gcp/modules/composition/opensearch/outputs.tf
+++ b/terraform/gcp/modules/composition/opensearch/outputs.tf
@@ -1,0 +1,14 @@
+output "node_instance_self_links" {
+  description = "Self-links of the OpenSearch node instances"
+  value       = module.node_group.instances_self_links
+}
+
+output "internal_lb_ip_address" {
+  description = "IP address of the internal load balancer in front of the node fleet"
+  value       = module.internal_lb.ip_address
+}
+
+output "service_account_email" {
+  description = "Email of the shared node service account"
+  value       = module.service_account.email
+}

--- a/terraform/gcp/modules/composition/opensearch/variables.tf
+++ b/terraform/gcp/modules/composition/opensearch/variables.tf
@@ -1,0 +1,93 @@
+variable "project_id" {
+  description = "GCP project ID where instances are created"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name used for naming resources"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "region" {
+  description = "Region for regional resources"
+  type        = string
+}
+
+variable "zone" {
+  description = "Zone to create instances in"
+  type        = string
+}
+
+variable "network" {
+  description = "Self-link of the VPC network"
+  type        = string
+}
+
+variable "subnetwork" {
+  description = "Self-link of the subnetwork for OpenSearch nodes"
+  type        = string
+}
+
+variable "lb_subnetwork" {
+  description = "Self-link of the subnetwork for the internal load balancer's forwarding rule"
+  type        = string
+}
+
+variable "node_image" {
+  description = "Self-link or family of the custom image with OpenSearch pre-installed"
+  type        = string
+}
+
+variable "node_count" {
+  description = "Number of OpenSearch node instances"
+  type        = number
+  default     = 3
+}
+
+variable "machine_type" {
+  description = "Machine type for node instances"
+  type        = string
+  default     = "n2-standard-4"
+}
+
+variable "boot_disk_size_gb" {
+  description = "Boot disk size in GB"
+  type        = number
+  default     = 50
+}
+
+variable "data_disk_size_gb" {
+  description = "Attached data disk size in GB per node"
+  type        = number
+  default     = 500
+}
+
+variable "disk_type" {
+  description = "Persistent disk type used for both boot and data disks"
+  type        = string
+  default     = "pd-ssd"
+}
+
+variable "http_port" {
+  description = "OpenSearch REST API port"
+  type        = number
+  default     = 9200
+}
+
+variable "metadata" {
+  description = "Additional instance metadata (e.g. startup-script parameters)"
+  type        = map(string)
+  default     = {}
+}
+
+variable "labels" {
+  description = "Additional labels to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/composition/opensearch/versions.tf
+++ b/terraform/gcp/modules/composition/opensearch/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/composition/pubsub/README.md
+++ b/terraform/gcp/modules/composition/pubsub/README.md
@@ -1,0 +1,48 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_pubsub"></a> [pubsub](#module\_pubsub) | terraform-google-modules/pubsub/google | 8.8.0 |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_allowed_persistence_regions"></a> [allowed\_persistence\_regions](#input\_allowed\_persistence\_regions) | List of regions messages may be persisted in. Null leaves the default (global) policy | `list(string)` | `null` | no |
+| <a name="input_bigquery_subscriptions"></a> [bigquery\_subscriptions](#input\_bigquery\_subscriptions) | List of BigQuery subscriptions to create, in the shape expected by terraform-google-modules/pubsub | `any` | `[]` | no |
+| <a name="input_cloud_storage_subscriptions"></a> [cloud\_storage\_subscriptions](#input\_cloud\_storage\_subscriptions) | List of Cloud Storage subscriptions to create, in the shape expected by terraform-google-modules/pubsub | `any` | `[]` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels applied to the topic and subscriptions | `map(string)` | `{}` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where the topic is created | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name used for naming resources | `string` | `"hyperswitch"` | no |
+| <a name="input_pull_subscriptions"></a> [pull\_subscriptions](#input\_pull\_subscriptions) | List of pull subscriptions to create, in the shape expected by terraform-google-modules/pubsub | `any` | `[]` | no |
+| <a name="input_push_subscriptions"></a> [push\_subscriptions](#input\_push\_subscriptions) | List of push subscriptions to create, in the shape expected by terraform-google-modules/pubsub | `any` | `[]` | no |
+| <a name="input_topic"></a> [topic](#input\_topic) | Logical topic name, auto-prefixed with '<environment>-<project\_name>-' | `string` | n/a | yes |
+| <a name="input_topic_kms_key_name"></a> [topic\_kms\_key\_name](#input\_topic\_kms\_key\_name) | Self-link of a KMS CryptoKey used to encrypt messages at rest. Null uses Google-managed encryption | `string` | `null` | no |
+| <a name="input_topic_message_retention_duration"></a> [topic\_message\_retention\_duration](#input\_topic\_message\_retention\_duration) | How long to retain unacknowledged messages on the topic (e.g. '86400s'). Null uses the service default (7 days) | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_subscription_names"></a> [subscription\_names](#output\_subscription\_names) | Map of all created subscription names |
+| <a name="output_subscription_paths"></a> [subscription\_paths](#output\_subscription\_paths) | Map of all created subscription fully qualified paths |
+| <a name="output_topic"></a> [topic](#output\_topic) | Name of the created topic |
+| <a name="output_topic_id"></a> [topic\_id](#output\_topic\_id) | Fully qualified ID of the topic |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/composition/pubsub/README.md
+++ b/terraform/gcp/modules/composition/pubsub/README.md
@@ -2,7 +2,7 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
@@ -13,7 +13,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_pubsub"></a> [pubsub](#module\_pubsub) | terraform-google-modules/pubsub/google | 8.8.0 |
 
 ## Resources
@@ -23,7 +23,7 @@ No resources.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_allowed_persistence_regions"></a> [allowed\_persistence\_regions](#input\_allowed\_persistence\_regions) | List of regions messages may be persisted in. Null leaves the default (global) policy | `list(string)` | `null` | no |
 | <a name="input_bigquery_subscriptions"></a> [bigquery\_subscriptions](#input\_bigquery\_subscriptions) | List of BigQuery subscriptions to create, in the shape expected by terraform-google-modules/pubsub | `any` | `[]` | no |
 | <a name="input_cloud_storage_subscriptions"></a> [cloud\_storage\_subscriptions](#input\_cloud\_storage\_subscriptions) | List of Cloud Storage subscriptions to create, in the shape expected by terraform-google-modules/pubsub | `any` | `[]` | no |
@@ -40,7 +40,7 @@ No resources.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_subscription_names"></a> [subscription\_names](#output\_subscription\_names) | Map of all created subscription names |
 | <a name="output_subscription_paths"></a> [subscription\_paths](#output\_subscription\_paths) | Map of all created subscription fully qualified paths |
 | <a name="output_topic"></a> [topic](#output\_topic) | Name of the created topic |

--- a/terraform/gcp/modules/composition/pubsub/locals.tf
+++ b/terraform/gcp/modules/composition/pubsub/locals.tf
@@ -1,0 +1,12 @@
+locals {
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "managed_by"  = "terraform"
+    },
+    var.labels
+  )
+
+  topic_name = "${var.environment}-${var.project_name}-${var.topic}"
+}

--- a/terraform/gcp/modules/composition/pubsub/main.tf
+++ b/terraform/gcp/modules/composition/pubsub/main.tf
@@ -1,0 +1,42 @@
+# ============================================================================
+# Pub/Sub (GCP equivalent of composition/sns)
+# ============================================================================
+# One topic plus its subscriptions/IAM, matching the AWS module's
+# topic+subscription+policy shape. Called once per logical topic; the live
+# layer (or an application-resources module like vector/loki) instantiates
+# it per notification channel.
+#
+# Usage:
+#   module "pubsub" {
+#     source = "../../modules/composition/pubsub"
+#
+#     project_id  = "hyperswitch-dev"
+#     environment = "dev"
+#     topic       = "vector-log-events"
+#
+#     pull_subscriptions = [{ name = "vector-consumer" }]
+#   }
+# ============================================================================
+
+module "pubsub" {
+  source  = "terraform-google-modules/pubsub/google"
+  version = "8.8.0"
+
+  project_id = var.project_id
+  topic      = local.topic_name
+
+  topic_labels        = local.common_labels
+  subscription_labels = local.common_labels
+
+  topic_message_retention_duration = var.topic_message_retention_duration
+  topic_kms_key_name               = var.topic_kms_key_name
+
+  pull_subscriptions          = var.pull_subscriptions
+  push_subscriptions          = var.push_subscriptions
+  bigquery_subscriptions      = var.bigquery_subscriptions
+  cloud_storage_subscriptions = var.cloud_storage_subscriptions
+
+  message_storage_policy = var.allowed_persistence_regions != null ? {
+    allowed_persistence_regions = var.allowed_persistence_regions
+  } : {}
+}

--- a/terraform/gcp/modules/composition/pubsub/outputs.tf
+++ b/terraform/gcp/modules/composition/pubsub/outputs.tf
@@ -1,0 +1,19 @@
+output "topic" {
+  description = "Name of the created topic"
+  value       = module.pubsub.topic
+}
+
+output "topic_id" {
+  description = "Fully qualified ID of the topic"
+  value       = module.pubsub.id
+}
+
+output "subscription_names" {
+  description = "Map of all created subscription names"
+  value       = module.pubsub.subscription_names
+}
+
+output "subscription_paths" {
+  description = "Map of all created subscription fully qualified paths"
+  value       = module.pubsub.subscription_paths
+}

--- a/terraform/gcp/modules/composition/pubsub/variables.tf
+++ b/terraform/gcp/modules/composition/pubsub/variables.tf
@@ -1,0 +1,68 @@
+variable "project_id" {
+  description = "GCP project ID where the topic is created"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name used for naming resources"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "topic" {
+  description = "Logical topic name, auto-prefixed with '<environment>-<project_name>-'"
+  type        = string
+}
+
+variable "topic_message_retention_duration" {
+  description = "How long to retain unacknowledged messages on the topic (e.g. '86400s'). Null uses the service default (7 days)"
+  type        = string
+  default     = null
+}
+
+variable "topic_kms_key_name" {
+  description = "Self-link of a KMS CryptoKey used to encrypt messages at rest. Null uses Google-managed encryption"
+  type        = string
+  default     = null
+}
+
+variable "pull_subscriptions" {
+  description = "List of pull subscriptions to create, in the shape expected by terraform-google-modules/pubsub"
+  type        = any
+  default     = []
+}
+
+variable "push_subscriptions" {
+  description = "List of push subscriptions to create, in the shape expected by terraform-google-modules/pubsub"
+  type        = any
+  default     = []
+}
+
+variable "bigquery_subscriptions" {
+  description = "List of BigQuery subscriptions to create, in the shape expected by terraform-google-modules/pubsub"
+  type        = any
+  default     = []
+}
+
+variable "cloud_storage_subscriptions" {
+  description = "List of Cloud Storage subscriptions to create, in the shape expected by terraform-google-modules/pubsub"
+  type        = any
+  default     = []
+}
+
+variable "allowed_persistence_regions" {
+  description = "List of regions messages may be persisted in. Null leaves the default (global) policy"
+  type        = list(string)
+  default     = null
+}
+
+variable "labels" {
+  description = "Additional labels applied to the topic and subscriptions"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/composition/pubsub/versions.tf
+++ b/terraform/gcp/modules/composition/pubsub/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/composition/squid-proxy/README.md
+++ b/terraform/gcp/modules/composition/squid-proxy/README.md
@@ -1,0 +1,66 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_config_bucket"></a> [config\_bucket](#module\_config\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
+| <a name="module_internal_lb"></a> [internal\_lb](#module\_internal\_lb) | terraform-google-modules/lb-internal/google | 7.1.0 |
+| <a name="module_log_bucket"></a> [log\_bucket](#module\_log\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
+| <a name="module_proxy_mig"></a> [proxy\_mig](#module\_proxy\_mig) | terraform-google-modules/vm/google//modules/mig | 15.2.1 |
+| <a name="module_proxy_template"></a> [proxy\_template](#module\_proxy\_template) | terraform-google-modules/vm/google//modules/instance_template | 15.2.1 |
+| <a name="module_service_account"></a> [service\_account](#module\_service\_account) | terraform-google-modules/service-accounts/google | 4.7.0 |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_storage_bucket_object.squid_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_autoscaling_cpu_target"></a> [autoscaling\_cpu\_target](#input\_autoscaling\_cpu\_target) | Target CPU utilization (0-1) for the autoscaler | `number` | `0.6` | no |
+| <a name="input_bucket_location"></a> [bucket\_location](#input\_bucket\_location) | Location for the config/log buckets | `string` | `"US"` | no |
+| <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Boot disk size in GB | `number` | `20` | no |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Persistent disk type | `string` | `"pd-balanced"` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_lb_subnetwork"></a> [lb\_subnetwork](#input\_lb\_subnetwork) | Self-link of the subnetwork for the internal load balancer's forwarding rule | `string` | n/a | yes |
+| <a name="input_log_retention_days"></a> [log\_retention\_days](#input\_log\_retention\_days) | Number of days to retain access log objects before deletion | `number` | `90` | no |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Machine type for proxy instances | `string` | `"n2-standard-2"` | no |
+| <a name="input_max_replicas"></a> [max\_replicas](#input\_max\_replicas) | Maximum number of proxy instances | `number` | `6` | no |
+| <a name="input_metadata"></a> [metadata](#input\_metadata) | Additional instance metadata applied to proxy instances (e.g. startup-script parameters) | `map(string)` | `{}` | no |
+| <a name="input_min_replicas"></a> [min\_replicas](#input\_min\_replicas) | Minimum number of proxy instances | `number` | `2` | no |
+| <a name="input_network"></a> [network](#input\_network) | Self-link of the VPC network | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where resources are created | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name used for naming resources | `string` | `"hyperswitch"` | no |
+| <a name="input_proxy_subnetwork"></a> [proxy\_subnetwork](#input\_proxy\_subnetwork) | Self-link of the subnetwork for Squid proxy instances (typically the outgoing-proxy tier) | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | Region for regional resources | `string` | n/a | yes |
+| <a name="input_squid_config_content"></a> [squid\_config\_content](#input\_squid\_config\_content) | squid.conf content, written to the config bucket. Null skips writing a config object | `string` | `null` | no |
+| <a name="input_squid_image"></a> [squid\_image](#input\_squid\_image) | Self-link or family of the custom image with Squid pre-installed | `string` | n/a | yes |
+| <a name="input_squid_port"></a> [squid\_port](#input\_squid\_port) | Port Squid listens on | `number` | `3128` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_config_bucket_name"></a> [config\_bucket\_name](#output\_config\_bucket\_name) | Name of the config bucket |
+| <a name="output_instance_group"></a> [instance\_group](#output\_instance\_group) | Self-link of the proxy fleet's managed instance group |
+| <a name="output_internal_lb_ip_address"></a> [internal\_lb\_ip\_address](#output\_internal\_lb\_ip\_address) | IP address of the internal load balancer in front of the Squid fleet |
+| <a name="output_log_bucket_name"></a> [log\_bucket\_name](#output\_log\_bucket\_name) | Name of the access-log bucket |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of the proxy fleet's service account |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/composition/squid-proxy/README.md
+++ b/terraform/gcp/modules/composition/squid-proxy/README.md
@@ -2,20 +2,20 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_config_bucket"></a> [config\_bucket](#module\_config\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
 | <a name="module_internal_lb"></a> [internal\_lb](#module\_internal\_lb) | terraform-google-modules/lb-internal/google | 7.1.0 |
 | <a name="module_log_bucket"></a> [log\_bucket](#module\_log\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 12.3.0 |
@@ -26,13 +26,13 @@
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google_storage_bucket_object.squid_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_autoscaling_cpu_target"></a> [autoscaling\_cpu\_target](#input\_autoscaling\_cpu\_target) | Target CPU utilization (0-1) for the autoscaler | `number` | `0.6` | no |
 | <a name="input_bucket_location"></a> [bucket\_location](#input\_bucket\_location) | Location for the config/log buckets | `string` | `"US"` | no |
 | <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Boot disk size in GB | `number` | `20` | no |
@@ -57,7 +57,7 @@
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_config_bucket_name"></a> [config\_bucket\_name](#output\_config\_bucket\_name) | Name of the config bucket |
 | <a name="output_instance_group"></a> [instance\_group](#output\_instance\_group) | Self-link of the proxy fleet's managed instance group |
 | <a name="output_internal_lb_ip_address"></a> [internal\_lb\_ip\_address](#output\_internal\_lb\_ip\_address) | IP address of the internal load balancer in front of the Squid fleet |

--- a/terraform/gcp/modules/composition/squid-proxy/locals.tf
+++ b/terraform/gcp/modules/composition/squid-proxy/locals.tf
@@ -1,0 +1,13 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}-squid"
+
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "component"   = "squid-proxy"
+      "managed_by"  = "terraform"
+    },
+    var.labels
+  )
+}

--- a/terraform/gcp/modules/composition/squid-proxy/main.tf
+++ b/terraform/gcp/modules/composition/squid-proxy/main.tf
@@ -1,0 +1,171 @@
+# ============================================================================
+# Squid Egress Proxy (GCP equivalent of composition/squid-proxy)
+# ============================================================================
+# Autoscaled Squid fleet on Compute Engine (instance template + MIG) fronted
+# by an internal TCP load balancer, with config/log GCS buckets - mirroring
+# the AWS module's ASG + NLB + S3-config/log shape. Unlike the AWS module,
+# this does not build its own NAT path: outbound internet access for
+# clients routing through Squid is provided by the Cloud Router + Cloud NAT
+# already created in composition/vpc-network.
+#
+# Usage:
+#   module "squid_proxy" {
+#     source = "../../modules/composition/squid-proxy"
+#
+#     project_id       = "hyperswitch-dev"
+#     environment      = "dev"
+#     region           = "europe-west1"
+#     network          = module.vpc_network.network_self_link
+#     proxy_subnetwork = module.vpc_network.subnets_by_tier["outgoing-proxy"]
+#     lb_subnetwork    = module.vpc_network.subnets_by_tier["outgoing-proxy"]
+#     squid_image      = "projects/hyperswitch-dev/global/images/squid-v1"
+#   }
+# ============================================================================
+
+module "service_account" {
+  source  = "terraform-google-modules/service-accounts/google"
+  version = "4.7.0"
+
+  project_id = var.project_id
+  names      = ["${local.name_prefix}-node"]
+  project_roles = [
+    "${var.project_id}=>roles/logging.logWriter",
+    "${var.project_id}=>roles/monitoring.metricWriter",
+  ]
+}
+
+module "config_bucket" {
+  source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
+  version = "12.3.0"
+
+  project_id         = var.project_id
+  name               = "${local.name_prefix}-config"
+  location           = var.bucket_location
+  versioning         = true
+  bucket_policy_only = true
+  labels             = local.common_labels
+}
+
+module "log_bucket" {
+  source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
+  version = "12.3.0"
+
+  project_id         = var.project_id
+  name               = "${local.name_prefix}-logs"
+  location           = var.bucket_location
+  versioning         = true
+  bucket_policy_only = true
+
+  lifecycle_rules = [{
+    action    = { type = "Delete" }
+    condition = { age = var.log_retention_days }
+  }]
+
+  labels = local.common_labels
+}
+
+resource "google_storage_bucket_object" "squid_config" {
+  count = var.squid_config_content != null ? 1 : 0
+
+  bucket  = module.config_bucket.name
+  name    = "squid.conf"
+  content = var.squid_config_content
+}
+
+module "proxy_template" {
+  source  = "terraform-google-modules/vm/google//modules/instance_template"
+  version = "15.2.1"
+
+  project_id   = var.project_id
+  region       = var.region
+  name_prefix  = local.name_prefix
+  machine_type = var.machine_type
+
+  source_image = var.squid_image
+  disk_size_gb = var.disk_size_gb
+  disk_type    = var.disk_type
+
+  network    = var.network
+  subnetwork = var.proxy_subnetwork
+
+  service_account = {
+    email  = module.service_account.email
+    scopes = ["cloud-platform"]
+  }
+
+  tags     = ["squid-proxy"]
+  labels   = local.common_labels
+  metadata = merge(var.metadata, { "config-bucket" = module.config_bucket.name })
+}
+
+module "proxy_mig" {
+  source  = "terraform-google-modules/vm/google//modules/mig"
+  version = "15.2.1"
+
+  project_id        = var.project_id
+  region            = var.region
+  mig_name          = local.name_prefix
+  hostname          = local.name_prefix
+  target_size       = var.min_replicas
+  instance_template = module.proxy_template.self_link
+
+  named_ports = [
+    { name = "squid", port = var.squid_port },
+  ]
+
+  autoscaling_enabled = true
+  min_replicas        = var.min_replicas
+  max_replicas        = var.max_replicas
+  autoscaling_cpu = [{
+    target            = var.autoscaling_cpu_target
+    predictive_method = "NONE"
+  }]
+
+  health_check = {
+    type                = "tcp"
+    initial_delay_sec   = 30
+    check_interval_sec  = 10
+    healthy_threshold   = 2
+    timeout_sec         = 5
+    unhealthy_threshold = 3
+    response            = null
+    proxy_header        = "NONE"
+    port                = var.squid_port
+    request             = null
+    request_path        = null
+    host                = null
+    enable_logging      = true
+  }
+
+  labels = local.common_labels
+}
+
+module "internal_lb" {
+  source  = "terraform-google-modules/lb-internal/google"
+  version = "7.1.0"
+
+  project    = var.project_id
+  region     = var.region
+  name       = "${local.name_prefix}-ilb"
+  network    = var.network
+  subnetwork = var.lb_subnetwork
+
+  ports = [tostring(var.squid_port)]
+
+  backends = [{ group = module.proxy_mig.instance_group }]
+
+  source_tags = []
+  target_tags = ["squid-proxy"]
+
+  health_check = {
+    type                = "tcp"
+    port                = var.squid_port
+    check_interval_sec  = 10
+    timeout_sec         = 5
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    proxy_header        = "NONE"
+  }
+
+  labels = local.common_labels
+}

--- a/terraform/gcp/modules/composition/squid-proxy/outputs.tf
+++ b/terraform/gcp/modules/composition/squid-proxy/outputs.tf
@@ -1,0 +1,24 @@
+output "internal_lb_ip_address" {
+  description = "IP address of the internal load balancer in front of the Squid fleet"
+  value       = module.internal_lb.ip_address
+}
+
+output "instance_group" {
+  description = "Self-link of the proxy fleet's managed instance group"
+  value       = module.proxy_mig.instance_group
+}
+
+output "config_bucket_name" {
+  description = "Name of the config bucket"
+  value       = module.config_bucket.name
+}
+
+output "log_bucket_name" {
+  description = "Name of the access-log bucket"
+  value       = module.log_bucket.name
+}
+
+output "service_account_email" {
+  description = "Email of the proxy fleet's service account"
+  value       = module.service_account.email
+}

--- a/terraform/gcp/modules/composition/squid-proxy/variables.tf
+++ b/terraform/gcp/modules/composition/squid-proxy/variables.tf
@@ -1,0 +1,112 @@
+variable "project_id" {
+  description = "GCP project ID where resources are created"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name used for naming resources"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "region" {
+  description = "Region for regional resources"
+  type        = string
+}
+
+variable "network" {
+  description = "Self-link of the VPC network"
+  type        = string
+}
+
+variable "proxy_subnetwork" {
+  description = "Self-link of the subnetwork for Squid proxy instances (typically the outgoing-proxy tier)"
+  type        = string
+}
+
+variable "lb_subnetwork" {
+  description = "Self-link of the subnetwork for the internal load balancer's forwarding rule"
+  type        = string
+}
+
+variable "squid_image" {
+  description = "Self-link or family of the custom image with Squid pre-installed"
+  type        = string
+}
+
+variable "squid_config_content" {
+  description = "squid.conf content, written to the config bucket. Null skips writing a config object"
+  type        = string
+  default     = null
+}
+
+variable "bucket_location" {
+  description = "Location for the config/log buckets"
+  type        = string
+  default     = "US"
+}
+
+variable "log_retention_days" {
+  description = "Number of days to retain access log objects before deletion"
+  type        = number
+  default     = 90
+}
+
+variable "machine_type" {
+  description = "Machine type for proxy instances"
+  type        = string
+  default     = "n2-standard-2"
+}
+
+variable "disk_size_gb" {
+  description = "Boot disk size in GB"
+  type        = number
+  default     = 20
+}
+
+variable "disk_type" {
+  description = "Persistent disk type"
+  type        = string
+  default     = "pd-balanced"
+}
+
+variable "min_replicas" {
+  description = "Minimum number of proxy instances"
+  type        = number
+  default     = 2
+}
+
+variable "max_replicas" {
+  description = "Maximum number of proxy instances"
+  type        = number
+  default     = 6
+}
+
+variable "autoscaling_cpu_target" {
+  description = "Target CPU utilization (0-1) for the autoscaler"
+  type        = number
+  default     = 0.6
+}
+
+variable "squid_port" {
+  description = "Port Squid listens on"
+  type        = number
+  default     = 3128
+}
+
+variable "metadata" {
+  description = "Additional instance metadata applied to proxy instances (e.g. startup-script parameters)"
+  type        = map(string)
+  default     = {}
+}
+
+variable "labels" {
+  description = "Additional labels to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/gcp/modules/composition/squid-proxy/versions.tf
+++ b/terraform/gcp/modules/composition/squid-proxy/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+  }
+}

--- a/terraform/gcp/modules/composition/vpc-network/README.md
+++ b/terraform/gcp/modules/composition/vpc-network/README.md
@@ -2,7 +2,7 @@
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 6.0 |
@@ -14,7 +14,7 @@ No providers.
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_cloud_nat"></a> [cloud\_nat](#module\_cloud\_nat) | terraform-google-modules/cloud-nat/google | 7.0.0 |
 | <a name="module_cloud_router"></a> [cloud\_router](#module\_cloud\_router) | terraform-google-modules/cloud-router/google | 9.0.0 |
 | <a name="module_private_service_access"></a> [private\_service\_access](#module\_private\_service\_access) | terraform-google-modules/network/google//modules/private-service-access | 18.1.2 |
@@ -27,7 +27,7 @@ No resources.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_custom_subnets"></a> [custom\_subnets](#input\_custom\_subnets) | Additional custom subnets keyed by tier name, merged alongside the named tiers | <pre>map(object({<br/>    cidr                     = string<br/>    private_ip_google_access = optional(bool, true)<br/>    purpose                  = optional(string)<br/>    description              = optional(string)<br/>    secondary_ranges = optional(list(object({<br/>      range_name    = string<br/>      ip_cidr_range = string<br/>    })), [])<br/>  }))</pre> | `{}` | no |
 | <a name="input_data_stack_subnet_cidr"></a> [data\_stack\_subnet\_cidr](#input\_data\_stack\_subnet\_cidr) | CIDR for the Kafka/Cassandra/ClickHouse/OpenSearch data-stack subnet | `string` | `null` | no |
 | <a name="input_database_subnet_cidr"></a> [database\_subnet\_cidr](#input\_database\_subnet\_cidr) | CIDR for the database-adjacent subnet (Cloud SQL proxies, private consumers) | `string` | `null` | no |
@@ -61,7 +61,7 @@ No resources.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_gke_nodes_subnet_self_link"></a> [gke\_nodes\_subnet\_self\_link](#output\_gke\_nodes\_subnet\_self\_link) | Self-link of the GKE node pool subnet |
 | <a name="output_gke_pods_secondary_range_name"></a> [gke\_pods\_secondary\_range\_name](#output\_gke\_pods\_secondary\_range\_name) | Name of the GKE pods secondary range, for wiring into composition/gke |
 | <a name="output_gke_services_secondary_range_name"></a> [gke\_services\_secondary\_range\_name](#output\_gke\_services\_secondary\_range\_name) | Name of the GKE services secondary range, for wiring into composition/gke |

--- a/terraform/gcp/modules/composition/vpc-network/README.md
+++ b/terraform/gcp/modules/composition/vpc-network/README.md
@@ -1,0 +1,76 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 6.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_cloud_nat"></a> [cloud\_nat](#module\_cloud\_nat) | terraform-google-modules/cloud-nat/google | 7.0.0 |
+| <a name="module_cloud_router"></a> [cloud\_router](#module\_cloud\_router) | terraform-google-modules/cloud-router/google | 9.0.0 |
+| <a name="module_private_service_access"></a> [private\_service\_access](#module\_private\_service\_access) | terraform-google-modules/network/google//modules/private-service-access | 18.1.2 |
+| <a name="module_vpc_network"></a> [vpc\_network](#module\_vpc\_network) | terraform-google-modules/network/google | 18.1.2 |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_custom_subnets"></a> [custom\_subnets](#input\_custom\_subnets) | Additional custom subnets keyed by tier name, merged alongside the named tiers | <pre>map(object({<br/>    cidr                     = string<br/>    private_ip_google_access = optional(bool, true)<br/>    purpose                  = optional(string)<br/>    description              = optional(string)<br/>    secondary_ranges = optional(list(object({<br/>      range_name    = string<br/>      ip_cidr_range = string<br/>    })), [])<br/>  }))</pre> | `{}` | no |
+| <a name="input_data_stack_subnet_cidr"></a> [data\_stack\_subnet\_cidr](#input\_data\_stack\_subnet\_cidr) | CIDR for the Kafka/Cassandra/ClickHouse/OpenSearch data-stack subnet | `string` | `null` | no |
+| <a name="input_database_subnet_cidr"></a> [database\_subnet\_cidr](#input\_database\_subnet\_cidr) | CIDR for the database-adjacent subnet (Cloud SQL proxies, private consumers) | `string` | `null` | no |
+| <a name="input_enable_default_deny_ingress"></a> [enable\_default\_deny\_ingress](#input\_enable\_default\_deny\_ingress) | Whether to add a lowest-priority default-deny-all ingress rule | `bool` | `true` | no |
+| <a name="input_enable_flow_logs"></a> [enable\_flow\_logs](#input\_enable\_flow\_logs) | Enable VPC flow logs on every created subnet | `bool` | `false` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, integ, prod, sandbox) | `string` | n/a | yes |
+| <a name="input_external_incoming_subnet_cidr"></a> [external\_incoming\_subnet\_cidr](#input\_external\_incoming\_subnet\_cidr) | CIDR for the internet-facing (external load balancer) subnet | `string` | n/a | yes |
+| <a name="input_gke_nodes_subnet_cidr"></a> [gke\_nodes\_subnet\_cidr](#input\_gke\_nodes\_subnet\_cidr) | Primary CIDR for the GKE node pool subnet | `string` | n/a | yes |
+| <a name="input_gke_pods_secondary_range_cidr"></a> [gke\_pods\_secondary\_range\_cidr](#input\_gke\_pods\_secondary\_range\_cidr) | Secondary range CIDR for GKE pod alias IPs | `string` | n/a | yes |
+| <a name="input_gke_services_secondary_range_cidr"></a> [gke\_services\_secondary\_range\_cidr](#input\_gke\_services\_secondary\_range\_cidr) | Secondary range CIDR for GKE service alias IPs | `string` | n/a | yes |
+| <a name="input_incoming_envoy_subnet_cidr"></a> [incoming\_envoy\_subnet\_cidr](#input\_incoming\_envoy\_subnet\_cidr) | CIDR for the Envoy ingress proxy subnet | `string` | `null` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Additional labels to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_locker_database_subnet_cidr"></a> [locker\_database\_subnet\_cidr](#input\_locker\_database\_subnet\_cidr) | CIDR for the PCI-DSS scoped locker database subnet | `string` | `null` | no |
+| <a name="input_locker_server_subnet_cidr"></a> [locker\_server\_subnet\_cidr](#input\_locker\_server\_subnet\_cidr) | CIDR for the PCI-DSS scoped locker server subnet | `string` | `null` | no |
+| <a name="input_management_subnet_cidr"></a> [management\_subnet\_cidr](#input\_management\_subnet\_cidr) | CIDR for the bastion/jump-host subnet | `string` | n/a | yes |
+| <a name="input_memorystore_subnet_cidr"></a> [memorystore\_subnet\_cidr](#input\_memorystore\_subnet\_cidr) | Reserved CIDR range for Memorystore direct-peering instances | `string` | `null` | no |
+| <a name="input_mtu"></a> [mtu](#input\_mtu) | Maximum transmission unit for the VPC | `number` | `1460` | no |
+| <a name="input_nat_min_ports_per_vm"></a> [nat\_min\_ports\_per\_vm](#input\_nat\_min\_ports\_per\_vm) | Minimum number of ports allocated per VM for Cloud NAT | `number` | `64` | no |
+| <a name="input_network_name"></a> [network\_name](#input\_network\_name) | Name of the VPC network | `string` | n/a | yes |
+| <a name="input_outgoing_proxy_subnet_cidr"></a> [outgoing\_proxy\_subnet\_cidr](#input\_outgoing\_proxy\_subnet\_cidr) | CIDR for the Squid egress proxy subnet | `string` | `null` | no |
+| <a name="input_private_service_access_prefix_length"></a> [private\_service\_access\_prefix\_length](#input\_private\_service\_access\_prefix\_length) | Prefix length of the reserved IP range for Private Service Access peering | `number` | `16` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID where the network is created | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name used for resource naming | `string` | `"hyperswitch"` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region all subnets and regional resources (router, NAT, PSA) are created in | `string` | n/a | yes |
+| <a name="input_router_asn"></a> [router\_asn](#input\_router\_asn) | BGP ASN for the Cloud Router | `number` | `64514` | no |
+| <a name="input_routing_mode"></a> [routing\_mode](#input\_routing\_mode) | Network routing mode: GLOBAL or REGIONAL | `string` | `"GLOBAL"` | no |
+| <a name="input_serverless_connector_subnet_cidr"></a> [serverless\_connector\_subnet\_cidr](#input\_serverless\_connector\_subnet\_cidr) | CIDR (/28) for the Serverless VPC Access connector used by Cloud Functions/Cloud Run | `string` | `null` | no |
+| <a name="input_utils_subnet_cidr"></a> [utils\_subnet\_cidr](#input\_utils\_subnet\_cidr) | CIDR for shared utility workloads | `string` | `null` | no |
+| <a name="input_vpc_internal_ranges"></a> [vpc\_internal\_ranges](#input\_vpc\_internal\_ranges) | Map of CIDR ranges considered internal to the VPC, allowed to talk to each other on the allow-internal rule | `map(string)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_gke_nodes_subnet_self_link"></a> [gke\_nodes\_subnet\_self\_link](#output\_gke\_nodes\_subnet\_self\_link) | Self-link of the GKE node pool subnet |
+| <a name="output_gke_pods_secondary_range_name"></a> [gke\_pods\_secondary\_range\_name](#output\_gke\_pods\_secondary\_range\_name) | Name of the GKE pods secondary range, for wiring into composition/gke |
+| <a name="output_gke_services_secondary_range_name"></a> [gke\_services\_secondary\_range\_name](#output\_gke\_services\_secondary\_range\_name) | Name of the GKE services secondary range, for wiring into composition/gke |
+| <a name="output_nat_name"></a> [nat\_name](#output\_nat\_name) | Name of the Cloud NAT gateway |
+| <a name="output_network_id"></a> [network\_id](#output\_network\_id) | The ID of the VPC network |
+| <a name="output_network_name"></a> [network\_name](#output\_network\_name) | The name of the VPC network |
+| <a name="output_network_self_link"></a> [network\_self\_link](#output\_network\_self\_link) | The self-link of the VPC network |
+| <a name="output_private_service_access_enabled"></a> [private\_service\_access\_enabled](#output\_private\_service\_access\_enabled) | Whether the Private Service Access peering range/connection was created; downstream Cloud SQL/Memorystore modules should depend\_on this module before using it |
+| <a name="output_router_name"></a> [router\_name](#output\_router\_name) | Name of the Cloud Router |
+| <a name="output_subnets"></a> [subnets](#output\_subnets) | Map of created subnets, keyed by region/name, as returned by the network module |
+| <a name="output_subnets_by_tier"></a> [subnets\_by\_tier](#output\_subnets\_by\_tier) | Map of subnet self-links keyed by tier name (external-incoming, management, gke-nodes, ...) |
+<!-- END_TF_DOCS -->

--- a/terraform/gcp/modules/composition/vpc-network/locals.tf
+++ b/terraform/gcp/modules/composition/vpc-network/locals.tf
@@ -1,0 +1,198 @@
+locals {
+  name_prefix = "${var.project_name}-${var.environment}"
+
+  common_labels = merge(
+    {
+      "environment" = var.environment
+      "project"     = var.project_name
+      "managed_by"  = "terraform"
+    },
+    var.labels
+  )
+
+  # ==========================================================================
+  # Named subnet tiers
+  # ==========================================================================
+  # GCP subnets are regional (span every zone in the region), so unlike the
+  # AWS vpc-network module there is no per-AZ subnet fan-out here: one CIDR
+  # per tier is enough. There is also no `eks-control-plane` tier - GKE's
+  # control plane lives outside the VPC and is configured via
+  # `master_ipv4_cidr_block` on the composition/gke module, not a subnet.
+  named_subnets = {
+    external-incoming = {
+      cidr                     = var.external_incoming_subnet_cidr
+      private_ip_google_access = false
+      purpose                  = null
+      secondary_ranges         = []
+      description              = "Internet-facing subnet for external load balancers"
+    }
+    management = {
+      cidr                     = var.management_subnet_cidr
+      private_ip_google_access = true
+      purpose                  = null
+      secondary_ranges         = []
+      description              = "Bastion / jump-host subnet"
+    }
+    gke-nodes = {
+      cidr                     = var.gke_nodes_subnet_cidr
+      private_ip_google_access = true
+      purpose                  = null
+      secondary_ranges = [
+        { range_name = "${local.name_prefix}-gke-pods", ip_cidr_range = var.gke_pods_secondary_range_cidr },
+        { range_name = "${local.name_prefix}-gke-services", ip_cidr_range = var.gke_services_secondary_range_cidr },
+      ]
+      description = "GKE node pool subnet with pods/services alias ranges"
+    }
+    database = {
+      cidr                     = var.database_subnet_cidr
+      private_ip_google_access = true
+      purpose                  = null
+      secondary_ranges         = []
+      description              = "Cloud SQL proxies / private-services consumers"
+    }
+    locker-database = {
+      cidr                     = var.locker_database_subnet_cidr
+      private_ip_google_access = true
+      purpose                  = null
+      secondary_ranges         = []
+      description              = "PCI-DSS scoped locker database subnet"
+    }
+    locker-server = {
+      cidr                     = var.locker_server_subnet_cidr
+      private_ip_google_access = true
+      purpose                  = null
+      secondary_ranges         = []
+      description              = "PCI-DSS scoped locker server subnet"
+    }
+    memorystore = {
+      cidr                     = var.memorystore_subnet_cidr
+      private_ip_google_access = true
+      purpose                  = null
+      secondary_ranges         = []
+      description              = "Reserved range for Memorystore direct-peering instances"
+    }
+    data-stack = {
+      cidr                     = var.data_stack_subnet_cidr
+      private_ip_google_access = true
+      purpose                  = null
+      secondary_ranges         = []
+      description              = "Kafka / Cassandra / ClickHouse / OpenSearch data-stack subnet"
+    }
+    incoming-envoy = {
+      cidr                     = var.incoming_envoy_subnet_cidr
+      private_ip_google_access = true
+      purpose                  = null
+      secondary_ranges         = []
+      description              = "Envoy ingress proxy subnet"
+    }
+    outgoing-proxy = {
+      cidr                     = var.outgoing_proxy_subnet_cidr
+      private_ip_google_access = true
+      purpose                  = null
+      secondary_ranges         = []
+      description              = "Squid egress proxy subnet"
+    }
+    utils = {
+      cidr                     = var.utils_subnet_cidr
+      private_ip_google_access = true
+      purpose                  = null
+      secondary_ranges         = []
+      description              = "Shared utility workloads subnet"
+    }
+    serverless-connector = {
+      cidr                     = var.serverless_connector_subnet_cidr
+      private_ip_google_access = true
+      purpose                  = null
+      secondary_ranges         = []
+      description              = "Serverless VPC Access connector subnet for Cloud Functions/Cloud Run"
+    }
+  }
+
+  custom_subnets = {
+    for key, subnet in var.custom_subnets : key => {
+      cidr                     = subnet.cidr
+      private_ip_google_access = try(subnet.private_ip_google_access, true)
+      purpose                  = try(subnet.purpose, null)
+      secondary_ranges         = try(subnet.secondary_ranges, [])
+      description              = try(subnet.description, "Custom subnet: ${key}")
+    }
+  }
+
+  all_subnets = merge(local.named_subnets, local.custom_subnets)
+
+  subnets_list = [
+    for tier, subnet in local.all_subnets : {
+      subnet_name           = "${local.name_prefix}-${tier}"
+      subnet_ip             = subnet.cidr
+      subnet_region         = var.region
+      subnet_private_access = tostring(subnet.private_ip_google_access)
+      subnet_flow_logs      = tostring(var.enable_flow_logs)
+      description           = subnet.description
+      purpose               = subnet.purpose
+    }
+    if subnet.cidr != null
+  ]
+
+  secondary_ranges = {
+    for tier, subnet in local.all_subnets :
+    "${local.name_prefix}-${tier}" => subnet.secondary_ranges
+    if subnet.cidr != null && length(subnet.secondary_ranges) > 0
+  }
+
+  gke_nodes_subnet_name = "${local.name_prefix}-gke-nodes"
+
+  # ==========================================================================
+  # Baseline network-wide firewall rules
+  # ==========================================================================
+  # Module-internal only - cross-module rules belong in
+  # composition/firewall-rules, applied last in the deployment order.
+  ingress_rules = concat(
+    [
+      {
+        name          = "${local.name_prefix}-allow-internal"
+        description   = "Allow all traffic between resources inside the VPC"
+        priority      = 1000
+        source_ranges = values(var.vpc_internal_ranges)
+        allow = [
+          { protocol = "tcp", ports = ["0-65535"] },
+          { protocol = "udp", ports = ["0-65535"] },
+          { protocol = "icmp" },
+        ]
+      },
+      {
+        name          = "${local.name_prefix}-allow-health-checks"
+        description   = "Allow Google Cloud health check probes"
+        priority      = 1000
+        source_ranges = ["35.191.0.0/16", "130.211.0.0/22", "209.85.152.0/22", "209.85.204.0/22"]
+        allow         = [{ protocol = "tcp" }]
+      },
+      {
+        name          = "${local.name_prefix}-allow-iap-ssh"
+        description   = "Allow SSH from Identity-Aware Proxy for bastion access"
+        priority      = 1000
+        source_ranges = ["35.235.240.0/20"]
+        target_tags   = ["iap-ssh"]
+        allow         = [{ protocol = "tcp", ports = ["22"] }]
+      },
+    ],
+    var.enable_default_deny_ingress ? [
+      {
+        name          = "${local.name_prefix}-deny-all-ingress"
+        description   = "Default-deny all other ingress traffic"
+        priority      = 65534
+        source_ranges = ["0.0.0.0/0"]
+        deny          = [{ protocol = "all" }]
+      },
+    ] : []
+  )
+
+  egress_rules = [
+    {
+      name               = "${local.name_prefix}-allow-all-egress"
+      description        = "Allow all outbound traffic; scoping is done via per-service firewall-rules"
+      priority           = 65534
+      destination_ranges = ["0.0.0.0/0"]
+      allow              = [{ protocol = "all" }]
+    },
+  ]
+}

--- a/terraform/gcp/modules/composition/vpc-network/main.tf
+++ b/terraform/gcp/modules/composition/vpc-network/main.tf
@@ -1,0 +1,93 @@
+# ============================================================================
+# VPC Network (GCP equivalent of composition/vpc-network)
+# ============================================================================
+# Builds the shared VPC: one regional subnet per workload tier, Cloud Router
+# + Cloud NAT for private egress, and a Private Service Access peering range
+# for Cloud SQL / Memorystore. Baseline network-wide firewall rules (deny-all
+# ingress, allow-internal, allow health checks, allow IAP) live here because
+# they are internal to this module; cross-module rules belong in
+# composition/firewall-rules (see that module's README).
+#
+# GCP has no NACL equivalent (stateful firewall rules make them redundant)
+# and no per-AZ subnet fan-out (GCP subnets are already regional), so this
+# module is intentionally flatter than its AWS counterpart.
+#
+# Usage:
+#   module "vpc_network" {
+#     source = "../../modules/composition/vpc-network"
+#
+#     project_id   = "hyperswitch-dev"
+#     environment  = "dev"
+#     network_name = "hyperswitch-dev-vpc"
+#     region       = "europe-west1"
+#
+#     external_incoming_subnet_cidr    = "10.0.0.0/24"
+#     management_subnet_cidr           = "10.0.1.0/24"
+#     gke_nodes_subnet_cidr            = "10.0.16.0/20"
+#     gke_pods_secondary_range_cidr    = "10.4.0.0/14"
+#     gke_services_secondary_range_cidr = "10.8.0.0/20"
+#     ...
+#   }
+# ============================================================================
+
+module "vpc_network" {
+  source  = "terraform-google-modules/network/google"
+  version = "18.1.2"
+
+  project_id   = var.project_id
+  network_name = var.network_name
+  routing_mode = var.routing_mode
+  mtu          = var.mtu
+
+  subnets          = local.subnets_list
+  secondary_ranges = local.secondary_ranges
+
+  ingress_rules = local.ingress_rules
+  egress_rules  = local.egress_rules
+}
+
+# ==============================================================================
+# Cloud Router + Cloud NAT (egress for private subnets, replaces AWS NAT GW)
+# ==============================================================================
+module "cloud_router" {
+  source  = "terraform-google-modules/cloud-router/google"
+  version = "9.0.0"
+
+  name       = "${local.name_prefix}-router"
+  project_id = var.project_id
+  region     = var.region
+  network    = module.vpc_network.network_self_link
+
+  bgp = {
+    asn = var.router_asn
+  }
+}
+
+module "cloud_nat" {
+  source  = "terraform-google-modules/cloud-nat/google"
+  version = "7.0.0"
+
+  project_id = var.project_id
+  region     = var.region
+  router     = module.cloud_router.router.name
+  name       = "${local.name_prefix}-nat"
+
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+  min_ports_per_vm                   = var.nat_min_ports_per_vm
+
+  log_config_enable = true
+  log_config_filter = "ERRORS_ONLY"
+}
+
+# ==============================================================================
+# Private Service Access (Cloud SQL / Memorystore standard-tier peering)
+# ==============================================================================
+module "private_service_access" {
+  source  = "terraform-google-modules/network/google//modules/private-service-access"
+  version = "18.1.2"
+
+  project_id    = var.project_id
+  network_id    = module.vpc_network.network_id
+  address_name  = "${local.name_prefix}-psa-range"
+  prefix_length = var.private_service_access_prefix_length
+}

--- a/terraform/gcp/modules/composition/vpc-network/outputs.tf
+++ b/terraform/gcp/modules/composition/vpc-network/outputs.tf
@@ -1,0 +1,74 @@
+# ==============================================================================
+# Network Outputs
+# ==============================================================================
+
+output "network_id" {
+  description = "The ID of the VPC network"
+  value       = module.vpc_network.network_id
+}
+
+output "network_name" {
+  description = "The name of the VPC network"
+  value       = module.vpc_network.network_name
+}
+
+output "network_self_link" {
+  description = "The self-link of the VPC network"
+  value       = module.vpc_network.network_self_link
+}
+
+# ==============================================================================
+# Subnet Outputs
+# ==============================================================================
+
+output "subnets" {
+  description = "Map of created subnets, keyed by region/name, as returned by the network module"
+  value       = module.vpc_network.subnets
+}
+
+output "subnets_by_tier" {
+  description = "Map of subnet self-links keyed by tier name (external-incoming, management, gke-nodes, ...)"
+  value = {
+    for tier, subnet in local.all_subnets :
+    tier => module.vpc_network.subnets["${var.region}/${local.name_prefix}-${tier}"].self_link
+    if subnet.cidr != null
+  }
+}
+
+output "gke_nodes_subnet_self_link" {
+  description = "Self-link of the GKE node pool subnet"
+  value       = module.vpc_network.subnets["${var.region}/${local.gke_nodes_subnet_name}"].self_link
+}
+
+output "gke_pods_secondary_range_name" {
+  description = "Name of the GKE pods secondary range, for wiring into composition/gke"
+  value       = "${local.name_prefix}-gke-pods"
+}
+
+output "gke_services_secondary_range_name" {
+  description = "Name of the GKE services secondary range, for wiring into composition/gke"
+  value       = "${local.name_prefix}-gke-services"
+}
+
+# ==============================================================================
+# Cloud Router / Cloud NAT Outputs
+# ==============================================================================
+
+output "router_name" {
+  description = "Name of the Cloud Router"
+  value       = module.cloud_router.router.name
+}
+
+output "nat_name" {
+  description = "Name of the Cloud NAT gateway"
+  value       = module.cloud_nat.name
+}
+
+# ==============================================================================
+# Private Service Access Outputs
+# ==============================================================================
+
+output "private_service_access_enabled" {
+  description = "Whether the Private Service Access peering range/connection was created; downstream Cloud SQL/Memorystore modules should depend_on this module before using it"
+  value       = true
+}

--- a/terraform/gcp/modules/composition/vpc-network/variables.tf
+++ b/terraform/gcp/modules/composition/vpc-network/variables.tf
@@ -1,0 +1,192 @@
+# ==============================================================================
+# General
+# ==============================================================================
+
+variable "project_id" {
+  description = "GCP project ID where the network is created"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name used for resource naming"
+  type        = string
+  default     = "hyperswitch"
+}
+
+variable "environment" {
+  description = "Environment name (dev, integ, prod, sandbox)"
+  type        = string
+}
+
+variable "region" {
+  description = "Region all subnets and regional resources (router, NAT, PSA) are created in"
+  type        = string
+}
+
+variable "network_name" {
+  description = "Name of the VPC network"
+  type        = string
+}
+
+variable "routing_mode" {
+  description = "Network routing mode: GLOBAL or REGIONAL"
+  type        = string
+  default     = "GLOBAL"
+}
+
+variable "mtu" {
+  description = "Maximum transmission unit for the VPC"
+  type        = number
+  default     = 1460
+}
+
+variable "labels" {
+  description = "Additional labels to apply to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+# ==============================================================================
+# Subnet CIDRs (one regional subnet per tier - see locals.tf for the full list)
+# ==============================================================================
+
+variable "external_incoming_subnet_cidr" {
+  description = "CIDR for the internet-facing (external load balancer) subnet"
+  type        = string
+}
+
+variable "management_subnet_cidr" {
+  description = "CIDR for the bastion/jump-host subnet"
+  type        = string
+}
+
+variable "gke_nodes_subnet_cidr" {
+  description = "Primary CIDR for the GKE node pool subnet"
+  type        = string
+}
+
+variable "gke_pods_secondary_range_cidr" {
+  description = "Secondary range CIDR for GKE pod alias IPs"
+  type        = string
+}
+
+variable "gke_services_secondary_range_cidr" {
+  description = "Secondary range CIDR for GKE service alias IPs"
+  type        = string
+}
+
+variable "database_subnet_cidr" {
+  description = "CIDR for the database-adjacent subnet (Cloud SQL proxies, private consumers)"
+  type        = string
+  default     = null
+}
+
+variable "locker_database_subnet_cidr" {
+  description = "CIDR for the PCI-DSS scoped locker database subnet"
+  type        = string
+  default     = null
+}
+
+variable "locker_server_subnet_cidr" {
+  description = "CIDR for the PCI-DSS scoped locker server subnet"
+  type        = string
+  default     = null
+}
+
+variable "memorystore_subnet_cidr" {
+  description = "Reserved CIDR range for Memorystore direct-peering instances"
+  type        = string
+  default     = null
+}
+
+variable "data_stack_subnet_cidr" {
+  description = "CIDR for the Kafka/Cassandra/ClickHouse/OpenSearch data-stack subnet"
+  type        = string
+  default     = null
+}
+
+variable "incoming_envoy_subnet_cidr" {
+  description = "CIDR for the Envoy ingress proxy subnet"
+  type        = string
+  default     = null
+}
+
+variable "outgoing_proxy_subnet_cidr" {
+  description = "CIDR for the Squid egress proxy subnet"
+  type        = string
+  default     = null
+}
+
+variable "utils_subnet_cidr" {
+  description = "CIDR for shared utility workloads"
+  type        = string
+  default     = null
+}
+
+variable "serverless_connector_subnet_cidr" {
+  description = "CIDR (/28) for the Serverless VPC Access connector used by Cloud Functions/Cloud Run"
+  type        = string
+  default     = null
+}
+
+variable "custom_subnets" {
+  description = "Additional custom subnets keyed by tier name, merged alongside the named tiers"
+  type = map(object({
+    cidr                     = string
+    private_ip_google_access = optional(bool, true)
+    purpose                  = optional(string)
+    description              = optional(string)
+    secondary_ranges = optional(list(object({
+      range_name    = string
+      ip_cidr_range = string
+    })), [])
+  }))
+  default = {}
+}
+
+variable "enable_flow_logs" {
+  description = "Enable VPC flow logs on every created subnet"
+  type        = bool
+  default     = false
+}
+
+# ==============================================================================
+# Cloud Router / Cloud NAT
+# ==============================================================================
+
+variable "router_asn" {
+  description = "BGP ASN for the Cloud Router"
+  type        = number
+  default     = 64514
+}
+
+variable "nat_min_ports_per_vm" {
+  description = "Minimum number of ports allocated per VM for Cloud NAT"
+  type        = number
+  default     = 64
+}
+
+# ==============================================================================
+# Private Service Access (Cloud SQL / Memorystore)
+# ==============================================================================
+
+variable "private_service_access_prefix_length" {
+  description = "Prefix length of the reserved IP range for Private Service Access peering"
+  type        = number
+  default     = 16
+}
+
+# ==============================================================================
+# Baseline Firewall Rules
+# ==============================================================================
+
+variable "vpc_internal_ranges" {
+  description = "Map of CIDR ranges considered internal to the VPC, allowed to talk to each other on the allow-internal rule"
+  type        = map(string)
+}
+
+variable "enable_default_deny_ingress" {
+  description = "Whether to add a lowest-priority default-deny-all ingress rule"
+  type        = bool
+  default     = true
+}

--- a/terraform/gcp/modules/composition/vpc-network/versions.tf
+++ b/terraform/gcp/modules/composition/vpc-network/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 6.0"
+    }
+  }
+}


### PR DESCRIPTION
…resources modules

Ports terraform/aws/modules/{composition,application-resources} to terraform/gcp/modules/, using only official terraform-google-modules / GoogleCloudPlatform registry modules (no base/ layer, no third-party modules). 23 composition modules and 14 application-resources modules, each validated with terraform init/validate against the real registry.

See terraform/gcp/modules/README.md for the AWS->GCP module map and the list of intentional divergences (no NACL/lock-table equivalents, SES -> Secret Manager, CloudFront Functions has no Cloud CDN analog, etc).

Also wires the new tree into the existing tooling: justfile gen-docs, the terraform-docs CI workflow, and a google provider override in the terraform-validate CI workflow.