### PR TITLE
fix(envoy-proxy): fix ResourceInUse error when destroying target group during canary rollback

### DIFF
--- a/terraform/aws/modules/composition/envoy-proxy/README.md
+++ b/terraform/aws/modules/composition/envoy-proxy/README.md
@@ -5,12 +5,14 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.29 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.29 |
+| <a name="provider_time"></a> [time](#provider\_time) | >= 0.9 |
 
 ## Modules
 
@@ -47,6 +49,7 @@
 | [aws_security_group_rule.lb_default_egress_to_asg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_ssm_parameter.envoy_private_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_wafv2_web_acl_association.envoy_alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_association) | resource |
+| [time_sleep.wait_before_target_group_destroy](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_role.existing_envoy_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |

--- a/terraform/aws/modules/composition/envoy-proxy/main.tf
+++ b/terraform/aws/modules/composition/envoy-proxy/main.tf
@@ -377,24 +377,8 @@ module "alb" {
 # Target Group (Conditional - Create only if needed)
 # =========================================================================
 
-# Listeners must reference target group ARNs (local.target_group_arns) to
-# build their weighted forward action, so the listeners always implicitly
-# depend on aws_lb_target_group.envoy for creation — that edge can't be
-# reversed without introducing a cycle. On destroy, when a deployment key
-# is dropped from var.deployments, Terraform's default graph can still
-# race the target group deletion against AWS finishing propagation of
-# the listener's ModifyListener call, and AWS rejects the delete with
-# ResourceInUse even though the plan shows the listener losing its
-# reference to the target group in the same apply.
-#
-# This sleep depends_on the target group (so it plays time_sleep's
-# documented "previous" role: destroyed only after destroy_duration
-# elapses), while the listeners depends_on the sleep (the "next" role:
-# destroyed/updated immediately). Per the time_sleep resource's destroy
-# ordering, that makes the actual destroy sequence:
-#   listeners updated/destroyed (immediately) -> destroy_duration pause -> target group destroyed
-# giving the ALB control plane time to finish detaching the target group
-# from its listeners before its destroy is attempted.
+# Ensures listeners finish detaching a target group before it is destroyed,
+# avoiding an AWS ResourceInUse error on canary/stable rollback.
 resource "time_sleep" "wait_before_target_group_destroy" {
   depends_on       = [aws_lb_target_group.envoy]
   destroy_duration = "30s"

--- a/terraform/aws/modules/composition/envoy-proxy/main.tf
+++ b/terraform/aws/modules/composition/envoy-proxy/main.tf
@@ -376,6 +376,30 @@ module "alb" {
 # =========================================================================
 # Target Group (Conditional - Create only if needed)
 # =========================================================================
+
+# Listeners must reference target group ARNs (local.target_group_arns) to
+# build their weighted forward action, so the listeners always implicitly
+# depend on aws_lb_target_group.envoy for creation — that edge can't be
+# reversed without introducing a cycle. On destroy, when a deployment key
+# is dropped from var.deployments, Terraform's default graph can still
+# race the target group deletion against AWS finishing propagation of
+# the listener's ModifyListener call, and AWS rejects the delete with
+# ResourceInUse even though the plan shows the listener losing its
+# reference to the target group in the same apply.
+#
+# This sleep depends_on the target group (so it plays time_sleep's
+# documented "previous" role: destroyed only after destroy_duration
+# elapses), while the listeners depends_on the sleep (the "next" role:
+# destroyed/updated immediately). Per the time_sleep resource's destroy
+# ordering, that makes the actual destroy sequence:
+#   listeners updated/destroyed (immediately) -> destroy_duration pause -> target group destroyed
+# giving the ALB control plane time to finish detaching the target group
+# from its listeners before its destroy is attempted.
+resource "time_sleep" "wait_before_target_group_destroy" {
+  depends_on       = [aws_lb_target_group.envoy]
+  destroy_duration = "30s"
+}
+
 # Target group for ALB → Envoy ASG
 # Targets Envoy traffic listener port
 resource "aws_lb_target_group" "envoy" {
@@ -461,7 +485,7 @@ resource "aws_lb_listener" "envoy_http" {
 
   tags = local.common_tags
 
-  depends_on = [aws_lb_target_group.envoy]
+  depends_on = [time_sleep.wait_before_target_group_destroy]
 }
 
 # HTTPS Listener - SSL/TLS termination at ALB
@@ -493,7 +517,7 @@ resource "aws_lb_listener" "envoy_https" {
 
   tags = local.common_tags
 
-  depends_on = [aws_lb_target_group.envoy]
+  depends_on = [time_sleep.wait_before_target_group_destroy]
 }
 
 # Separate mTLS Listener - SSL/TLS termination with mutual authentication
@@ -530,7 +554,7 @@ resource "aws_lb_listener" "envoy_mtls" {
 
   tags = local.common_tags
 
-  depends_on = [aws_lb_target_group.envoy]
+  depends_on = [time_sleep.wait_before_target_group_destroy]
 }
 
 # =========================================================================

--- a/terraform/aws/modules/composition/envoy-proxy/versions.tf
+++ b/terraform/aws/modules/composition/envoy-proxy/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 6.29"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.9"
+    }
   }
 }


### PR DESCRIPTION
## Problem

Rolling back a canary deployment (removing a key like "stable" from
`var.deployments`) fails during `terraform apply` with:

    Error: deleting ELBv2 Target Group (...): ResourceInUse: Target group
    '...' is currently in use by a listener or a rule

This happens even though the plan correctly shows the ALB listeners
(`envoy_https`, `envoy_mtls`) being updated in-place to drop the target
group from their weighted `forward.target_group` block in the same apply.
Retrying the apply does not reliably fix it.

## Root cause

The listeners had `depends_on = [aws_lb_target_group.envoy]`. Plain
resource-level `depends_on` reliably orders resource *creation*, but does
not guarantee that an in-place listener *update* (removing its reference
to a target group) finishes propagating on AWS's side before Terraform
attempts to *destroy* that target group. On destroy, Terraform's graph
could start deleting the target group before the listener's
`ModifyListener` call had actually detached it.

## Fix

Since the listeners also read the target group's ARN to build their
`forward` block, simply reversing the `depends_on` direction creates a
dependency cycle. Instead, this introduces a `time_sleep` resource as an
ordering + delay buffer:

- `time_sleep.wait_before_target_group_destroy` depends on
  `aws_lb_target_group.envoy`, with `destroy_duration = "30s"`.
- All three listeners (`envoy_http`, `envoy_https`, `envoy_mtls`) now
  depend on that `time_sleep` instead of depending on the target group
  directly.

This preserves create-order (listeners still transitively wait for the
target group to exist), but flips destroy-order to: listeners
reconcile first → 30s pause → target group destroyed last, giving AWS
time to fully detach the target group from its listeners before
Terraform attempts to delete it.

Also adds the `hashicorp/time` provider requirement to `versions.tf`.

## Impact / breaking change assessment

- No resource is renamed, replaced, or has its `for_each`/`count` key
  changed — this is a pure dependency-graph/ordering fix.
- The only *new* resource is `time_sleep.wait_before_target_group_destroy`,
  which Terraform will show as `+ create` (a no-op, no AWS API cost) on
  every environment using this module on first apply after this change.
- No existing target group, listener, or ALB is destroyed or replaced by
  this change on its own.
- Expected plan output on environments with a stable deployment only:
  `1 to add` (the `time_sleep`), `0 to change`, `0 to destroy`.

## Testing

- `terraform validate` — passes, no dependency cycle.
- `terraform fmt -check` — clean.
- Plan output attached below from `<env>` showing no destructive changes.