### PR TITLE
feat(gcp): add terragrunt catalog units

### DIFF
--- a/.github/workflows/terragrunt-validate-gcp.yml
+++ b/.github/workflows/terragrunt-validate-gcp.yml
@@ -1,5 +1,8 @@
 name: Terragrunt Validate (GCP)
 
+permissions:
+  contents: read
+
 # Scoped to the GCP catalog. This workflow deliberately does NOT run
 # `terragrunt stack generate` or `terragrunt hcl validate` yet: those need a
 # stack and a live layer to render into, which arrive in the follow-up PR.

--- a/.github/workflows/terragrunt-validate-gcp.yml
+++ b/.github/workflows/terragrunt-validate-gcp.yml
@@ -1,0 +1,62 @@
+name: Terragrunt Validate (GCP)
+
+# Scoped to the GCP catalog. This workflow deliberately does NOT run
+# `terragrunt stack generate` or `terragrunt hcl validate` yet: those need a
+# stack and a live layer to render into, which arrive in the follow-up PR.
+# Until then a unit's `include "root"` has no root.hcl to resolve against, so
+# only formatting, pins and the sensitive-data gate are checkable here.
+#
+# PR #302 adds a repo-wide sensitive-scan workflow and an AWS-scoped
+# terragrunt-validate workflow. Neither can pass on `main` today: the repo-wide
+# scan trips on the hand-written terraform/aws/live tree that #302 deletes.
+# When #302 lands, fold this into a single workflow with a cloud matrix and
+# drop the scoped scan step in favour of the repo-wide one.
+#
+# `hcl format` targets the catalog directory rather than terraform/gcp because
+# terraform/gcp/packer/squid-proxy/scripts/vector.toml.pkrtpl.hcl is a Vector
+# TOML template that happens to carry an .hcl extension, and the HCL parser
+# cannot read it.
+
+on:
+  pull_request:
+    paths:
+      - 'terraform/gcp/catalog/**'
+      - 'scripts/ci/check-gcp-pins.sh'
+      - '.github/workflows/terragrunt-validate-gcp.yml'
+
+env:
+  TG_VERSION: 1.1.1
+
+jobs:
+  hcl-checks:
+    name: hclfmt + sensitive-data gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install terragrunt
+        run: |
+          curl -fsSL -o /usr/local/bin/terragrunt \
+            "https://github.com/gruntwork-io/terragrunt/releases/download/v${TG_VERSION}/terragrunt_linux_amd64"
+          chmod +x /usr/local/bin/terragrunt
+          terragrunt --version
+
+      - name: hcl format check
+        run: terragrunt hcl format --check --diff --working-dir terraform/gcp/catalog
+
+      - name: Sensitive-data gate (terraform/gcp)
+        run: bash scripts/ci/check-sensitive.sh terraform/gcp
+
+  pins:
+    name: Catalog pins resolve to real tags
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Check GCP catalog pins
+        run: bash scripts/ci/check-gcp-pins.sh

--- a/.github/workflows/terragrunt-validate-gcp.yml
+++ b/.github/workflows/terragrunt-validate-gcp.yml
@@ -24,6 +24,9 @@ on:
       - 'scripts/ci/check-gcp-pins.sh'
       - '.github/workflows/terragrunt-validate-gcp.yml'
 
+permissions:
+  contents: read
+
 env:
   TG_VERSION: 1.1.1
 

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,9 @@ load-test/test_env/
 load-test/output/
 
 load-test/__pycache__
+
+#terragrunt
+.terragrunt-cache/
+.terragrunt-stack-manifest
+*.tfstate
+*.tfstate.backup

--- a/scripts/ci/check-gcp-pins.sh
+++ b/scripts/ci/check-gcp-pins.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# GCP catalog pin gate: every `?ref=` in terraform/gcp/catalog must point at a
+# tag that actually exists in this repository.
+#
+# A catalog is only consumable if its pins resolve. A unit pinned to a branch
+# (or to a tag nobody cut) silently changes under its consumers, or fails at
+# `terragrunt init` with a confusing "couldn't find remote ref" error.
+#
+# Usage: scripts/ci/check-gcp-pins.sh
+#
+# Requires a checkout with tags fetched (actions/checkout needs fetch-depth: 0
+# and fetch-tags: true).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CATALOG="${REPO_ROOT}/terraform/gcp/catalog"
+
+if [[ ! -d "$CATALOG" ]]; then
+    echo "✗ ${CATALOG} not found" >&2
+    exit 1
+fi
+
+missing=()
+branch_pins=()
+checked=0
+
+while IFS= read -r line; do
+    file="${line%%:*}"
+    ref="${line##*\?ref=}"
+    ref="${ref%%\"*}"
+    checked=$((checked + 1))
+
+    # A pin that isn't a tag is a bug regardless of whether it resolves.
+    if ! [[ "$ref" =~ ^gcp-[a-z0-9-]+-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        branch_pins+=("${file#"${REPO_ROOT}/"} -> ${ref}")
+        continue
+    fi
+
+    if ! git -C "$REPO_ROOT" rev-parse -q --verify "refs/tags/${ref}" >/dev/null; then
+        missing+=("${file#"${REPO_ROOT}/"} -> ${ref}")
+    fi
+done < <(grep -rn '?ref=' "$CATALOG" --include='*.hcl' | sed 's/^\([^:]*\):[0-9]*:/\1:/')
+
+status=0
+
+if ((${#branch_pins[@]})); then
+    echo "✗ Non-tag pins found (expected gcp-<module>-vX.Y.Z):" >&2
+    printf '    %s\n' "${branch_pins[@]}" >&2
+    echo "" >&2
+    status=1
+fi
+
+if ((${#missing[@]})); then
+    echo "✗ Pinned tags that do not exist in this repository:" >&2
+    printf '    %s\n' "${missing[@]}" >&2
+    echo "" >&2
+    echo "  Cut the missing module tags (see terraform/gcp/catalog/README.md)" >&2
+    echo "  or correct the pin." >&2
+    status=1
+fi
+
+if ((status == 0)); then
+    echo "✓ All ${checked} GCP catalog pins resolve to existing tags"
+fi
+
+exit "$status"

--- a/scripts/ci/check-sensitive.sh
+++ b/scripts/ci/check-sensitive.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Sensitive-data gate: fails if internal Juspay identifiers, endpoints or
+# credentials-looking strings appear anywhere in the repo.
+#
+# Usage: scripts/ci/check-sensitive.sh [path]   (default: repo root)
+#
+# Legitimate hits (public registries, docs links) go in
+# scripts/ci/sensitive-allowlist.txt — one substring per line, '#' comments.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="${1:-$(cd "${SCRIPT_DIR}/../.." && pwd)}"
+ALLOWLIST="${SCRIPT_DIR}/sensitive-allowlist.txt"
+
+# Internal account IDs, hosts, identifiers and secret-shaped strings.
+PATTERN='223655089699|143555788000|211125655926|997208230940|576373346466|bitbucket\.juspay\.net|[a-z0-9.-]*juspay\.net|@juspay\.in|\.gr7\.|C05SDGYKFM1|AWSReservedSSO|InfraMCP|StrongPassword|chpasswd|44\.214\.22\.235|44\.213\.159\.167|vpce-svc-[0-9a-f]+|vpc-hyperswitch'
+
+hits="$(grep -rInE "$PATTERN" "$TARGET" \
+    --exclude-dir=.git \
+    --exclude-dir=.terragrunt-cache \
+    --exclude-dir=img \
+    --exclude-dir=node_modules \
+    --exclude='*.zip' \
+    --exclude='sensitive-allowlist.txt' \
+    --exclude='check-sensitive.sh' \
+    2>/dev/null || true)"
+
+# Filter out allowlisted substrings
+if [[ -n "$hits" && -f "$ALLOWLIST" ]]; then
+    while IFS= read -r allow; do
+        [[ -z "$allow" || "$allow" == \#* ]] && continue
+        hits="$(printf '%s\n' "$hits" | grep -vF "$allow" || true)"
+    done <"$ALLOWLIST"
+fi
+
+if [[ -n "$hits" ]]; then
+    echo "✗ Sensitive/internal data found:" >&2
+    printf '%s\n' "$hits" >&2
+    echo "" >&2
+    echo "Remove the data or, if it is a legitimate public reference, add a line to ${ALLOWLIST}." >&2
+    exit 1
+fi
+
+echo "✓ No sensitive data found under ${TARGET}"

--- a/scripts/ci/sensitive-allowlist.txt
+++ b/scripts/ci/sensitive-allowlist.txt
@@ -1,0 +1,13 @@
+# Legitimate public references that match the sensitive-data patterns.
+# One substring per line; lines are matched with `grep -F` against scan hits.
+
+# Public docs site linked from the envoy maintenance page
+https://docs.hyperswitch.io
+
+# Redacted placeholder examples in the pre-existing dev environment / module docs
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.gr7.
+AWSReservedSSO_AWSAdministratorAccess_XXXXXXXXXXXXXXXX
+012345678903AB2BAE5D1E0BFE0E2B50.gr7.us-east-1
+
+# Public support email mentioned in the upstream changelog
+hyperswitch@juspay.in to support.global@juspay.io

--- a/terraform/gcp/catalog/README.md
+++ b/terraform/gcp/catalog/README.md
@@ -1,0 +1,162 @@
+# GCP Terragrunt Catalog — units
+
+Reusable Terragrunt **units** for deploying Hyperswitch on GCP. Each unit is a
+parameterized `terragrunt.hcl` wrapping exactly one module from
+`terraform/gcp/modules` at a pinned release tag.
+
+```
+terraform/gcp/catalog/units/
+├── vpc-network/          ├── envoy-proxy/        ├── artifact-registry/
+├── alloydb/              ├── squid-proxy/        ├── bastion-host/
+├── memorystore-valkey/   ├── locker/             ├── firewall-rules/
+└── application-stack/
+    ├── gke/
+    └── apps/{argocd, external-secrets-operator, gateway-controller, grafana,
+               hyperswitch, istio, loki, superposition, vector}
+```
+
+19 units. This mirrors the AWS catalog proposed in
+[PR #302](https://github.com/juspay/hyperswitch-suite/pull/302) — same unit
+skeleton, same tag-pinning discipline.
+
+> **This PR ships units only.** The stack that composes them
+> (`catalog/stacks/internal`, including the `root.hcl` every unit includes) and
+> the generated live layer follow in a separate PR, once these units are
+> tagged.
+
+## Unit skeleton
+
+```hcl
+include "root" {
+  path   = find_in_parent_folders("root.hcl")   # travels with the *stack*
+  expose = true
+}
+
+dependency "gke" {
+  config_path  = "../../gke"
+  mock_outputs = { ... }
+}
+
+terraform {
+  source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/application-resources/<name>?ref=<tag>"
+}
+
+inputs = { ... }
+```
+
+### The root contract
+
+Units read exactly five things from the stack's `root.hcl`. This is the whole
+interface between a unit and whatever composes it — adding a local is cheap,
+renaming one is not:
+
+| Local | Used by |
+|---|---|
+| `include.root.locals.environment.short` | every unit (resource naming) |
+| `include.root.locals.project_name` | every unit (resource naming) |
+| `include.root.locals.project_id` | every unit |
+| `include.root.locals.region` | every unit |
+| `include.root.locals.vpn_cidr_blocks` | `gke` only |
+
+### Stack values
+
+Everything else that varies per environment arrives through Terragrunt Stacks
+`values`, so nothing environment-specific is hardcoded in a unit:
+
+| Value | Consumed by |
+|---|---|
+| `vpc_cidr_prefix`, `gke_pods_secondary_range_cidr`, `gke_services_secondary_range_cidr` | `vpc-network`; the first two also by `squid-proxy` and `firewall-rules` |
+| `machine_types` | `gke`, `bastion-host` |
+| `domains` (`api`, `grafana`) | `istio`, `grafana`, `hyperswitch` |
+| `custom_images` (`envoy`, `squid`) | `envoy-proxy`, `squid-proxy` |
+| `bastion_iap_members` | `bastion-host` |
+| `smtp_secret_id` | `hyperswitch` |
+| `alloydb`, `valkey`, `locker` (optional maps) | the matching data units |
+
+### Dependency layout
+
+Unit `path`s in the consuming stack are load-bearing — `config_path` values are
+written against this layout:
+
+```
+vpc-network                      alloydb              -> ../vpc-network
+memorystore-valkey               envoy-proxy          -> ../vpc-network
+artifact-registry                squid-proxy          -> ../vpc-network
+bastion-host                     firewall-rules       -> ../vpc-network
+locker                           -> ../vpc-network, ../application-stack/gke
+application-stack/gke            -> ../../vpc-network
+application-stack/apps/<name>    -> ../../gke, ../../../vpc-network
+```
+
+## Scope
+
+A unit exists here only if its module is published on `main`. All 19 pins
+resolve to existing tags — `scripts/ci/check-gcp-pins.sh` enforces it.
+
+| Excluded | Why |
+|---|---|
+| `load-balancer`, `cloud-cdn`, `cloud-dns`, `certificate-manager`, `pubsub` | published, but out of scope for the application stack |
+| `kafka`, `cassandra`, `clickhouse`, `opensearch`, `filestore`, `cloud-monitoring`, `gke-kubernetes-resources` | no module on `main` |
+| `apps/decision-engine`, `apps/otel-collector`, `apps/ratelimiter` | no module on `main` — add back when they land |
+| `gke-workload-identity` | needs no unit; every app module calls it as a nested Terraform module |
+| `shared-iam-roles` | nothing consumes it yet |
+
+## Pinned module tags
+
+| Unit | Module | Tag |
+|---|---|---|
+| `vpc-network` | `composition/vpc-network` | `gcp-vpc-network-v0.1.0` |
+| `alloydb` | `composition/alloydb` | `gcp-alloydb-v0.1.0` |
+| `memorystore-valkey` | `composition/memorystore-valkey` | `gcp-memorystore-valkey-v0.1.0` |
+| `artifact-registry` | `composition/artifact-registry` | `gcp-artifact-registry-v0.1.0` |
+| `bastion-host` | `composition/bastion-host` | `gcp-bastion-host-v0.1.0` |
+| `locker` | `composition/locker` | `gcp-locker-v0.1.0` |
+| `firewall-rules` | `composition/firewall-rules` | `gcp-firewall-rules-v0.1.0` |
+| `envoy-proxy` | `composition/envoy-proxy` | `gcp-envoy-proxy-v0.1.0` |
+| `squid-proxy` | `composition/squid-proxy` | `gcp-squid-proxy-v0.1.0` |
+| `application-stack/gke` | `composition/gke` | `gcp-gke-v0.1.0` |
+| `…/apps/argocd` | `application-resources/argocd` | `gcp-apps-argocd-v0.1.0` |
+| `…/apps/external-secrets-operator` | `application-resources/external-secrets-operator` | `gcp-apps-eso-v0.1.0` |
+| `…/apps/gateway-controller` | `application-resources/gateway-controller` | `gcp-apps-gcp-v0.1.0` |
+| `…/apps/grafana` | `application-resources/grafana` | `gcp-apps-grafana-v0.1.0` |
+| `…/apps/hyperswitch` | `application-resources/hyperswitch` | `gcp-apps-hyperswitch-v0.1.0` |
+| `…/apps/istio` | `application-resources/istio` | `gcp-apps-istio-v0.1.0` |
+| `…/apps/loki` | `application-resources/loki` | `gcp-apps-loki-v0.1.0` |
+| `…/apps/superposition` | `application-resources/superposition` | `gcp-apps-superposition-v0.1.0` |
+| `…/apps/vector` | `application-resources/vector` | `gcp-apps-vector-v0.1.0` |
+
+### Two tag names to clean up
+
+Both are published and pinned as-is so the catalog works today, but neither
+follows the `gcp-apps-<module>-vX.Y.Z` grammar the other eight use:
+
+- `gcp-apps-eso-v0.1.0` abbreviates `external-secrets-operator`.
+- **`gcp-apps-gcp-v0.1.0` is the gateway-controller module** — that reads like
+  a mis-typed tag name. Re-tag as `gcp-apps-gateway-controller-vX.Y.Z` and
+  repoint the unit.
+
+## Versioning
+
+Module tags:
+
+- composition module `<name>` → `gcp-<name>-vX.Y.Z`
+- application-resources module `<name>` → `gcp-apps-<name>-vX.Y.Z`
+
+Unit tags follow the AWS grammar,
+`unit/<name>-v<module-version>-v<unit-revision>` — the wrapped module's tag is
+pinned inside the unit, and the trailing revision bumps whenever the unit file
+changes. Tagging these units is the step between this PR and the stack PR that
+consumes them by ref.
+
+## CI
+
+`.github/workflows/terragrunt-validate-gcp.yml`:
+
+- `terragrunt hcl format --check` on the catalog
+- `scripts/ci/check-sensitive.sh terraform/gcp` — no internal identifiers or
+  credential-shaped strings may land in this repo
+- `scripts/ci/check-gcp-pins.sh` — every `?ref=` is a tag of the expected shape
+  and that tag exists
+
+`terragrunt stack generate` and `terragrunt hcl validate` are added in the
+stack PR; they need a stack and a live tree to run against.

--- a/terraform/gcp/catalog/units/alloydb/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/alloydb/terragrunt.hcl
@@ -1,0 +1,86 @@
+# AlloyDB — the primary Postgres for the application stack.
+#
+# GCP's Aurora-equivalent: disaggregated storage, sub-second-ish failover on
+# REGIONAL primaries, read pools sharing the primary's storage layer. This
+# unit replaces an earlier `cloud-sql` unit — composition/cloud-sql is not on
+# main, and AlloyDB is what the live GCP environment actually runs.
+#
+# Shipped MINIMAL: one ZONAL primary, no read pools. Every knob is settable
+# from the stack, so scaling to production HA (REGIONAL primary + read pools)
+# is a values edit, not a module change.
+#
+# KNOWN GAP: AlloyDB has no Terraform resource for creating an
+# application-level database inside the cluster (no `google_alloydb_database`
+# exists) — only cluster / instance / user. Creating the per-service databases
+# needs a separate psql step once the instance is up; this unit does not do it.
+
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "vpc" {
+  config_path = "../vpc-network"
+
+  mock_outputs = {
+    network_id                        = "projects/mock/global/networks/mock-vpc"
+    private_service_access_range_name = "mock-psa-range"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/composition/alloydb?ref=gcp-alloydb-v0.1.0"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+  region       = include.root.locals.region
+
+  network_id = dependency.vpc.outputs.network_id
+
+  # AlloyDB's network_config.allocated_ip_range wants the reserved PSA range's
+  # NAME, not a CIDR. Read from the vpc-network unit rather than hardcoded —
+  # the module exposes this output, so the live layer's earlier
+  # hardcoded-name workaround is no longer needed here.
+  allocated_ip_range = dependency.vpc.outputs.private_service_access_range_name
+
+  database_version = try(values.alloydb.database_version, "POSTGRES_15")
+  master_username  = try(values.alloydb.master_username, "hyperswitch_admin")
+
+  # master_password left unset — the module generates one and writes it to
+  # Secret Manager (AlloyDB has no built-in generation the way Cloud SQL's
+  # registry module does).
+  secret_manager = {
+    create = true
+  }
+
+  # A cluster has exactly ONE primary instance; read scaling is read pools,
+  # each fronting node_count identical nodes over the primary's storage.
+  primary_instance = {
+    availability_type = try(values.alloydb.availability_type, "ZONAL")
+    cpu_count         = try(values.alloydb.cpu_count, 2)
+  }
+
+  # Keyed by pool name. A production HA layout sets availability_type to
+  # REGIONAL above and adds e.g. { read-1 = { node_count = 2, cpu_count = 4 } }.
+  read_pool_instances = try(values.alloydb.read_pool_instances, {})
+
+  continuous_backup_enabled              = true
+  continuous_backup_recovery_window_days = 14
+  automated_backup_enabled               = true
+  automated_backup_retention_count       = 14
+
+  # Must be flipped and applied BEFORE a destroy is attempted, not alongside
+  # it — the same constraint gke's deletion_protection has.
+  deletion_protection = try(values.alloydb.deletion_protection, true)
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    component   = "database"
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/catalog/units/application-stack/apps/argocd/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/argocd/terragrunt.hcl
@@ -1,0 +1,45 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "gke" {
+  config_path = "../../gke"
+
+  mock_outputs = {
+    endpoint       = "mock-endpoint"
+    ca_certificate = "bW9jaw=="
+    cluster_name   = "mock-cluster"
+    location       = "asia-south1"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/application-resources/argocd?ref=gcp-apps-argocd-v0.1.0"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+
+  cluster_name = dependency.gke.outputs.cluster_name
+
+  # Required by the module since #310 — the Kubernetes/Helm provider is
+
+  # configured from these rather than from a kubeconfig lookup.
+
+  cluster_endpoint = dependency.gke.outputs.endpoint
+
+  cluster_ca_certificate = dependency.gke.outputs.ca_certificate
+  cluster_location       = dependency.gke.outputs.location
+
+  # No cross-project deployments configured yet.
+  cross_project_target_service_accounts = []
+
+  labels = {
+    environment = include.root.locals.environment.short
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/catalog/units/application-stack/apps/external-secrets-operator/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/external-secrets-operator/terragrunt.hcl
@@ -1,0 +1,47 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "gke" {
+  config_path = "../../gke"
+
+  mock_outputs = {
+    endpoint       = "mock-endpoint"
+    ca_certificate = "bW9jaw=="
+    cluster_name   = "mock-cluster"
+    location       = "asia-south1"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  # NOTE: the published tag abbreviates the module name to `eso`.
+  source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/application-resources/external-secrets-operator?ref=gcp-apps-eso-v0.1.0"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+
+  cluster_name = dependency.gke.outputs.cluster_name
+
+  # Required by the module since #310 — the Kubernetes/Helm provider is
+
+  # configured from these rather than from a kubeconfig lookup.
+
+  cluster_endpoint = dependency.gke.outputs.endpoint
+
+  cluster_ca_certificate = dependency.gke.outputs.ca_certificate
+  cluster_location       = dependency.gke.outputs.location
+
+  # Project-wide roles/secretmanager.secretAccessor by default; switch to
+  # scope_to_project = false + explicit secret_ids for least privilege.
+  scope_to_project = true
+
+  labels = {
+    environment = include.root.locals.environment.short
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/catalog/units/application-stack/apps/gateway-controller/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/gateway-controller/terragrunt.hcl
@@ -1,0 +1,32 @@
+# GKE's Gateway/Ingress controller is built in - this unit only creates the
+# supporting SSL policy. Gateway/HTTPRoute objects are Kubernetes-native and
+# applied via GitOps/kubectl, not Terraform.
+
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+terraform {
+  # NOTE: `gcp-apps-gcp` is the published tag for the gateway-controller
+  # module — it looks like a mis-typed tag name. Re-tag as
+  # gcp-apps-gateway-controller-vX.Y.Z and repoint this when convenient.
+  source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/application-resources/gateway-controller?ref=gcp-apps-gcp-v0.1.0"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+
+  create_ssl_policy          = true
+  ssl_policy_profile         = "MODERN"
+  ssl_policy_min_tls_version = "TLS_1_2"
+
+  create_service_account = false
+
+  labels = {
+    environment = include.root.locals.environment.short
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/catalog/units/application-stack/apps/grafana/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/grafana/terragrunt.hcl
@@ -1,0 +1,62 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "vpc" {
+  config_path = "../../../vpc-network"
+
+  mock_outputs = {
+    network_id = "projects/mock/global/networks/mock-vpc"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+dependency "gke" {
+  config_path = "../../gke"
+
+  mock_outputs = {
+    endpoint       = "mock-endpoint"
+    ca_certificate = "bW9jaw=="
+    cluster_name   = "mock-cluster"
+    location       = "asia-south1"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/application-resources/grafana?ref=gcp-apps-grafana-v0.1.0"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+  region       = include.root.locals.region
+
+  cluster_name = dependency.gke.outputs.cluster_name
+
+  # Required by the module since #310 — the Kubernetes/Helm provider is
+
+  # configured from these rather than from a kubeconfig lookup.
+
+  cluster_endpoint = dependency.gke.outputs.endpoint
+
+  cluster_ca_certificate = dependency.gke.outputs.ca_certificate
+  cluster_location       = dependency.gke.outputs.location
+
+  create_database = true
+  database_config = {
+    network_id = dependency.vpc.outputs.network_id
+    tier       = "db-custom-1-3840" # small - dashboard metadata only
+  }
+
+  host_domains = {
+    grafana = values.domains.grafana
+  }
+
+  labels = {
+    environment = include.root.locals.environment.short
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/catalog/units/application-stack/apps/hyperswitch/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/hyperswitch/terragrunt.hcl
@@ -1,0 +1,81 @@
+# The core application. KMS + GCS buckets created internally; SMTP left
+# unwired by default (see decision-engine's unit for the same
+# GCP-has-no-SES note).
+
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "gke" {
+  config_path = "../../gke"
+
+  mock_outputs = {
+    endpoint       = "mock-endpoint"
+    ca_certificate = "bW9jaw=="
+    cluster_name   = "mock-cluster"
+    location       = "asia-south1"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/application-resources/hyperswitch?ref=gcp-apps-hyperswitch-v0.1.0"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+
+  public_domain = values.domains.api
+
+  cluster_name = dependency.gke.outputs.cluster_name
+
+  # Required by the module since #310 — the Kubernetes/Helm provider is
+
+  # configured from these rather than from a kubeconfig lookup.
+
+  cluster_endpoint = dependency.gke.outputs.endpoint
+
+  cluster_ca_certificate = dependency.gke.outputs.ca_certificate
+  cluster_location       = dependency.gke.outputs.location
+
+  kms = {
+    create          = true
+    location        = include.root.locals.region
+    rotation_period = "7776000s" # 90 days
+  }
+
+  gcs_dashboard_themes = {
+    create             = true
+    location           = include.root.locals.region
+    versioning_enabled = true
+  }
+
+  gcs_file_uploads = {
+    create             = true
+    location           = include.root.locals.region
+    versioning_enabled = true
+  }
+
+  smtp_secret_id = try(values.smtp_secret_id, null)
+
+  secret_ids = []
+
+  cloud_functions = {
+    enabled = false
+  }
+
+  cross_project_assume = {
+    enabled = false
+  }
+
+  additional_custom_role_ids = []
+
+  labels = {
+    environment = include.root.locals.environment.short
+    managed_by  = "terraform"
+    component   = "hyperswitch"
+  }
+}

--- a/terraform/gcp/catalog/units/application-stack/apps/istio/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/istio/terragrunt.hcl
@@ -1,0 +1,55 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "vpc" {
+  config_path = "../../../vpc-network"
+
+  mock_outputs = {
+    network_self_link = "projects/mock/global/networks/mock-vpc"
+    network_name      = "mock-vpc"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+dependency "gke" {
+  config_path = "../../gke"
+
+  mock_outputs = {
+    cluster_name   = "mock-cluster"
+    endpoint       = "mock-endpoint"
+    ca_certificate = "bW9jaw=="
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/application-resources/istio?ref=gcp-apps-istio-v0.1.0"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+  region       = include.root.locals.region
+
+  cluster_name           = dependency.gke.outputs.cluster_name
+  cluster_endpoint       = dependency.gke.outputs.endpoint
+  cluster_ca_certificate = dependency.gke.outputs.ca_certificate
+
+  network      = dependency.vpc.outputs.network_self_link
+  network_name = dependency.vpc.outputs.network_name
+
+  create_gateway_static_ip = true
+  create_firewall_rules    = true
+
+  host_domains = {
+    sandbox = [values.domains.api]
+  }
+
+  labels = {
+    environment = include.root.locals.environment.short
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/catalog/units/application-stack/apps/loki/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/loki/terragrunt.hcl
@@ -1,0 +1,44 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "gke" {
+  config_path = "../../gke"
+
+  mock_outputs = {
+    endpoint       = "mock-endpoint"
+    ca_certificate = "bW9jaw=="
+    cluster_name   = "mock-cluster"
+    location       = "asia-south1"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/application-resources/loki?ref=gcp-apps-loki-v0.1.0"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+
+  cluster_name = dependency.gke.outputs.cluster_name
+
+  # Required by the module since #310 — the Kubernetes/Helm provider is
+
+  # configured from these rather than from a kubeconfig lookup.
+
+  cluster_endpoint = dependency.gke.outputs.endpoint
+
+  cluster_ca_certificate = dependency.gke.outputs.ca_certificate
+  cluster_location       = dependency.gke.outputs.location
+
+  bucket_location = include.root.locals.region
+
+  labels = {
+    environment = include.root.locals.environment.short
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/catalog/units/application-stack/apps/superposition/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/superposition/terragrunt.hcl
@@ -1,0 +1,58 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "vpc" {
+  config_path = "../../../vpc-network"
+
+  mock_outputs = {
+    network_id = "projects/mock/global/networks/mock-vpc"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+dependency "gke" {
+  config_path = "../../gke"
+
+  mock_outputs = {
+    endpoint       = "mock-endpoint"
+    ca_certificate = "bW9jaw=="
+    cluster_name   = "mock-cluster"
+    location       = "asia-south1"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/application-resources/superposition?ref=gcp-apps-superposition-v0.1.0"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+  region       = include.root.locals.region
+
+  cluster_name = dependency.gke.outputs.cluster_name
+
+  # Required by the module since #310 — the Kubernetes/Helm provider is
+
+  # configured from these rather than from a kubeconfig lookup.
+
+  cluster_endpoint = dependency.gke.outputs.endpoint
+
+  cluster_ca_certificate = dependency.gke.outputs.ca_certificate
+  cluster_location       = dependency.gke.outputs.location
+
+  create_database = true
+  database_config = {
+    network_id = dependency.vpc.outputs.network_id
+    tier       = "db-custom-2-8192"
+  }
+
+  labels = {
+    environment = include.root.locals.environment.short
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/catalog/units/application-stack/apps/vector/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/vector/terragrunt.hcl
@@ -1,0 +1,47 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "gke" {
+  config_path = "../../gke"
+
+  mock_outputs = {
+    endpoint       = "mock-endpoint"
+    ca_certificate = "bW9jaw=="
+    cluster_name   = "mock-cluster"
+    location       = "asia-south1"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/application-resources/vector?ref=gcp-apps-vector-v0.1.0"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+
+  cluster_name = dependency.gke.outputs.cluster_name
+
+  # Required by the module since #310 — the Kubernetes/Helm provider is
+
+  # configured from these rather than from a kubeconfig lookup.
+
+  cluster_endpoint = dependency.gke.outputs.endpoint
+
+  cluster_ca_certificate = dependency.gke.outputs.ca_certificate
+  cluster_location       = dependency.gke.outputs.location
+
+  bucket_location = include.root.locals.region
+
+  # No cross-region reads configured yet (single-region setup).
+  cross_region_reader_members = []
+
+  labels = {
+    environment = include.root.locals.environment.short
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/catalog/units/application-stack/gke/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/gke/terragrunt.hcl
@@ -1,0 +1,80 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "vpc" {
+  config_path = "../../vpc-network"
+
+  mock_outputs = {
+    network_self_link                 = "projects/mock/global/networks/mock-vpc"
+    gke_nodes_subnet_self_link        = "projects/mock/regions/asia-south1/subnetworks/mock-gke-nodes"
+    gke_pods_secondary_range_name     = "mock-gke-pods"
+    gke_services_secondary_range_name = "mock-gke-services"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/composition/gke?ref=gcp-gke-v0.1.0"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+  region       = include.root.locals.region
+
+  cluster_name = "${include.root.locals.project_name}-${include.root.locals.environment.short}-gke"
+  regional     = true
+
+  network           = dependency.vpc.outputs.network_self_link
+  subnetwork        = dependency.vpc.outputs.gke_nodes_subnet_self_link
+  ip_range_pods     = dependency.vpc.outputs.gke_pods_secondary_range_name
+  ip_range_services = dependency.vpc.outputs.gke_services_secondary_range_name
+
+  kubernetes_version = "latest"
+  release_channel    = "REGULAR"
+
+  enable_private_endpoint = false
+  master_ipv4_cidr_block  = "172.16.0.0/28"
+
+  # Falls back to an allow-all placeholder until include.root.locals.vpn_cidr_blocks
+  # is populated with real office/VPN CIDRs - not safe to apply as-is.
+  master_authorized_networks = (
+    length(include.root.locals.vpn_cidr_blocks) > 0
+    ? [for idx, cidr in include.root.locals.vpn_cidr_blocks : { cidr_block = cidr, display_name = "vpn-${idx}" }]
+    : [{ cidr_block = "0.0.0.0/0", display_name = "placeholder-allow-all-REPLACE-ME" }]
+  )
+
+  deletion_protection = true
+
+  node_pools = [
+    {
+      name         = "system-pool"
+      machine_type = values.machine_types.gke_system_pool
+      min_count    = 1
+      max_count    = 5
+      disk_size_gb = 100
+      disk_type    = "pd-balanced"
+      auto_repair  = true
+      auto_upgrade = true
+    },
+    {
+      name         = "generic-compute"
+      machine_type = values.machine_types.gke_generic_compute
+      min_count    = 1
+      max_count    = 10
+      disk_size_gb = 100
+      disk_type    = "pd-balanced"
+      auto_repair  = true
+      auto_upgrade = true
+    },
+  ]
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/catalog/units/artifact-registry/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/artifact-registry/terragrunt.hcl
@@ -1,0 +1,36 @@
+# No dependency on vpc-network (Artifact Registry is a regional API service,
+# not VPC-attached).
+
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+terraform {
+  source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/composition/artifact-registry?ref=gcp-artifact-registry-v0.1.0"
+}
+
+inputs = {
+  project_id  = include.root.locals.project_id
+  environment = include.root.locals.environment.short
+  location    = include.root.locals.region
+
+  repositories = {
+    hyperswitch = {
+      description    = "Hyperswitch application images"
+      format         = "DOCKER"
+      immutable_tags = false
+      cleanup_policies = {
+        keep-recent = {
+          action               = "KEEP"
+          most_recent_versions = 15
+        }
+      }
+    }
+  }
+
+  labels = {
+    environment = include.root.locals.environment.short
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/catalog/units/bastion-host/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/bastion-host/terragrunt.hcl
@@ -1,0 +1,52 @@
+# IAP-tunneled, no public IP.
+
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "vpc" {
+  config_path = "../vpc-network"
+
+  mock_outputs = {
+    network_self_link = "projects/mock/global/networks/mock-vpc"
+    subnets_by_tier   = { management = "projects/mock/regions/asia-south1/subnetworks/mock-management" }
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/composition/bastion-host?ref=gcp-bastion-host-v0.1.0"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+  region       = include.root.locals.region
+  zone         = "${include.root.locals.region}-a"
+
+  network = dependency.vpc.outputs.network_self_link
+  subnet  = dependency.vpc.outputs.subnets_by_tier["management"]
+
+  machine_type = values.machine_types.bastion
+
+  # Workaround for a bug in terraform-google-modules/bastion-host v9.0.0:
+  # its default image-family path (image=null, image_family="debian-12")
+  # forwards a literal null through a nested `!= ""` sentinel check three
+  # layers down (terraform-google-modules/vm's instance_template module),
+  # which then tries to string-interpolate that null and fails at plan
+  # time. Passing an explicit family self-link instead avoids the null
+  # path entirely while still tracking the latest image in the family.
+  image = "projects/debian-cloud/global/images/family/debian-12"
+
+  members = values.bastion_iap_members
+
+  enable_session_logging = true
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/catalog/units/envoy-proxy/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/envoy-proxy/terragrunt.hcl
@@ -1,0 +1,47 @@
+# envoy_image needs a pre-baked custom image with Envoy installed - see
+# values.custom_images in the stack.
+
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "vpc" {
+  config_path = "../vpc-network"
+
+  mock_outputs = {
+    network_self_link = "projects/mock/global/networks/mock-vpc"
+    subnets_by_tier   = { incoming-envoy = "projects/mock/regions/asia-south1/subnetworks/mock-incoming-envoy" }
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/composition/envoy-proxy?ref=gcp-envoy-proxy-v0.1.0"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+  region       = include.root.locals.region
+
+  network          = dependency.vpc.outputs.network_self_link
+  proxy_subnetwork = dependency.vpc.outputs.subnets_by_tier["incoming-envoy"]
+
+  envoy_image = "projects/${include.root.locals.project_id}/global/images/${values.custom_images.envoy}"
+
+  min_replicas = 2
+  max_replicas = 6
+
+  managed_ssl_certificate_domains = [values.domains.api]
+
+  enable_cloud_armor   = true
+  enable_mtls_listener = false
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/catalog/units/firewall-rules/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/firewall-rules/terragrunt.hcl
@@ -1,0 +1,80 @@
+# Cross-unit connectivity, assembled from the network tags the other units'
+# modules set. Rules internal to one unit stay in that unit; only paths that
+# span two units are declared here.
+#
+# APPLY LAST. This unit depends only on vpc-network, so Terragrunt is free to
+# schedule it early — that is harmless (a rule may reference a tag no instance
+# carries yet, which GCP accepts) but means the rules only take effect once
+# the units they describe exist.
+#
+# Instance tags come from the modules, not from this file:
+#   bastion-host  -> ["bastion-host", "iap-ssh"]
+#   envoy-proxy   -> ["envoy-proxy",  "iap-ssh"]
+#   squid-proxy   -> ["squid-proxy",  "iap-ssh"]
+#
+# The locker no longer runs a VM fleet (it is a GKE workload with an AlloyDB
+# cluster reached over Private Service Access, which vpc-network's internal
+# egress rule already covers), so it needs no rule here.
+
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "vpc" {
+  config_path = "../vpc-network"
+
+  mock_outputs = {
+    network_name = "mock-vpc"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/composition/firewall-rules?ref=gcp-firewall-rules-v0.1.0"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+
+  network_name = dependency.vpc.outputs.network_name
+
+  rules = {
+    bastion-to-proxies = {
+      rules = [
+        {
+          name        = "allow-bastion-ssh"
+          description = "Bastion IAP SSH to the edge proxy fleets"
+          direction   = "INGRESS"
+          # GCP firewall rules cannot mix service-account and tag matching in
+          # one rule (source_service_accounts conflicts with target_tags), so
+          # source by the bastion's instance tag rather than its SA.
+          source_tags = ["bastion-host"]
+          target_tags = ["envoy-proxy", "squid-proxy"]
+          allow       = [{ protocol = "tcp", ports = ["22"] }]
+        },
+      ]
+    }
+
+    gke-to-squid-egress = {
+      rules = [
+        {
+          name        = "allow-gke-to-squid"
+          description = "GKE nodes and pods to the Squid forward proxy"
+          direction   = "INGRESS"
+          # Range-based, not tag-based: the clients are GKE pods, which carry
+          # no network tags. Keep in sync with squid-proxy's ilb_source_ranges
+          # — both derive from the same two stack values.
+          source_ranges = [
+            "${values.vpc_cidr_prefix}.16.0/20",
+            values.gke_pods_secondary_range_cidr,
+          ]
+          target_tags = ["squid-proxy"]
+          allow       = [{ protocol = "tcp", ports = ["3128"] }]
+        },
+      ]
+    }
+  }
+}

--- a/terraform/gcp/catalog/units/locker/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/locker/terragrunt.hcl
@@ -1,0 +1,149 @@
+# Card vault (locker) — DATA TIER AND IDENTITY ONLY.
+#
+# The locker deploys as a workload on GKE through the same GitOps/Helm flow as
+# every other application in the cluster. Terraform's job here is only what
+# Kubernetes cannot create for itself: the vault's own database, the identity
+# its pod assumes, and the CMEK key both depend on.
+#
+# `composition/locker` was rewritten for this — it no longer provisions a VM
+# fleet from a baked image, so this unit needs no `custom_images` entry.
+
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "vpc" {
+  config_path = "../vpc-network"
+
+  mock_outputs = {
+    network_id                        = "projects/mock/global/networks/mock-vpc"
+    private_service_access_range_name = "mock-psa-range"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+dependency "gke" {
+  config_path = "../application-stack/gke"
+
+  mock_outputs = {
+    cluster_name   = "mock-cluster"
+    location       = "mock-region"
+    endpoint       = "mock-endpoint"
+    ca_certificate = "bW9jaw=="
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/composition/locker?ref=gcp-locker-v0.1.0"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+  region       = include.root.locals.region
+
+  # ---------------------------------------------------------------------------
+  # Identity
+  # ---------------------------------------------------------------------------
+  cluster_name     = dependency.gke.outputs.cluster_name
+  cluster_location = dependency.gke.outputs.location
+
+  # Required to configure the module's own `kubernetes` provider.
+  cluster_endpoint       = dependency.gke.outputs.endpoint
+  cluster_ca_certificate = dependency.gke.outputs.ca_certificate
+
+  # These two are fixed by the chart, not by the environment. The
+  # hyperswitch-card-vault subchart HARDCODES the ServiceAccount name
+  # `hyperswitch-vault-role` in its templates/sa.yaml and the same name as
+  # serviceAccountName in its deployment.yaml, with no
+  # `serviceAccount.create: false` toggle — so the GSA binding must target
+  # exactly this name in the hyperswitch release namespace.
+  k8s_namespace            = "hyperswitch"
+  k8s_service_account_name = "hyperswitch-vault-role"
+
+  # Helm owns the ServiceAccount object; Terraform must not create a second
+  # one. The module creates only the GSA and the workloadIdentityUser binding.
+  use_existing_k8s_sa = true
+
+  # FALSE deliberately — this leaves ONE MANUAL STEP.
+  #
+  # The upstream workload-identity module annotates an existing KSA by
+  # shelling out to `gcloud container clusters get-credentials` + `kubectl
+  # annotate` as a local-exec at apply time. Against a private cluster with
+  # master_authorized_networks, that fails on any runner without a working
+  # tunnel — and it would fail the WHOLE apply, including the database.
+  #
+  # So the IAM half is done deterministically here, and the annotation is an
+  # explicit one-liner run with a working context:
+  #
+  #   kubectl annotate --overwrite sa -n hyperswitch hyperswitch-vault-role \
+  #     iam.gke.io/gcp-service-account=$(terragrunt output -raw service_account_email)
+  #
+  # WITHOUT IT, Workload Identity does not engage and the pod silently falls
+  # back to the node's default service account — it does not error.
+  annotate_k8s_sa = false
+
+  # roles/alloydb.client and roles/serviceusage.serviceUsageConsumer are
+  # granted unconditionally by the module; the connector needs both.
+  additional_project_roles = []
+
+  # ---------------------------------------------------------------------------
+  # Dedicated AlloyDB cluster
+  # ---------------------------------------------------------------------------
+  # Kept separate from ../alloydb (the platform's shared cluster) so card data
+  # stays in its own PCI-DSS scope.
+  create_database = true
+
+  database_config = {
+    network_id         = dependency.vpc.outputs.network_id
+    allocated_ip_range = dependency.vpc.outputs.private_service_access_range_name
+
+    availability_type = try(values.locker.availability_type, "ZONAL")
+    cpu_count         = try(values.locker.cpu_count, 2)
+
+    # The vault's database holds card data — leave this true anywhere it
+    # matters.
+    deletion_protection = try(values.locker.deletion_protection, true)
+
+    master_username = "locker_admin"
+
+    # master_password deliberately unset -> composition/alloydb generates one
+    # and writes it to Secret Manager, and composition/locker grants the
+    # vault's service account accessor on THAT SECRET ONLY.
+    secret_manager = {
+      create = true
+    }
+  }
+
+  # ---------------------------------------------------------------------------
+  # CMEK
+  # ---------------------------------------------------------------------------
+  create_kms_key = true
+  kms_key_id     = "locker"
+
+  kms_protection_level = try(values.locker.kms_protection_level, "SOFTWARE")
+  kms_rotation_period  = "7776000s"
+
+  # TRUE, and do not relax it. The upstream KMS module does not implement this
+  # with a lifecycle meta-argument — it ships two crypto-key resources at
+  # DIFFERENT STATE ADDRESSES and switches between them on this flag, so
+  # flipping it plans a destroy of the live key and a create of a new one.
+  # Since the key encrypts the vault's database and its backups, that is
+  # destructive even where the guard would allow it.
+  kms_prevent_destroy = true
+
+  # Off: the key exists to encrypt the AlloyDB cluster. The vault manages its
+  # own data-encryption keys internally, so granting the pod
+  # cryptoKeyEncrypterDecrypter would widen its permissions for nothing.
+  grant_kms_access = false
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    compliance  = "pci-dss"
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/catalog/units/memorystore-valkey/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/memorystore-valkey/terragrunt.hcl
@@ -1,0 +1,110 @@
+# Memorystore for Valkey, cluster mode — the GCP analogue of ElastiCache with
+# engine = "valkey" / cluster_mode = "enabled". Replaces an earlier
+# `memorystore` unit (classic Memorystore for Redis, which has no cluster
+# support and is not on main).
+#
+# Requires Private Service Connect, NOT the PSA peering AlloyDB uses: the
+# module creates a service_connection_policy on a DEDICATED subnet. The
+# vpc-network unit already provisions a `memorystore` tier subnet for exactly
+# this — PSC reserves addresses directly out of it, so nothing else may use it.
+#
+# auth and transit encryption are left at the module defaults (disabled),
+# matching the application's lack of Redis AUTH/TLS support.
+
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+locals {
+  # vpc-network keys its `subnets` output by "<region>/<name_prefix>-<tier>",
+  # where name_prefix is "<project_name>-<environment>". Derived rather than
+  # hardcoded so the unit works in any environment.
+  memorystore_subnet_key = format(
+    "%s/%s-%s-memorystore",
+    include.root.locals.region,
+    include.root.locals.project_name,
+    include.root.locals.environment.short,
+  )
+}
+
+dependency "vpc" {
+  config_path = "../vpc-network"
+
+  mock_outputs = {
+    network_name = "mock-vpc"
+    subnets = {
+      (local.memorystore_subnet_key) = { name = "mock-memorystore" }
+    }
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  # KEEP THIS PINNED TO A TAG THAT ACTUALLY CARRIES THE INPUTS BELOW.
+  # Terragrunt passes `inputs` as TF_VAR_* environment variables, and
+  # Terraform SILENTLY IGNORES a TF_VAR_ for a variable the module does not
+  # declare — pointing this at an older tag does not fail, it just makes every
+  # input below read as applied config while doing nothing.
+  source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/composition/memorystore-valkey?ref=gcp-memorystore-valkey-v0.1.0"
+}
+
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+  region       = include.root.locals.region
+
+  network      = dependency.vpc.outputs.network_name
+  subnet_names = [dependency.vpc.outputs.subnets[local.memorystore_subnet_key].name]
+
+  mode          = "CLUSTER"
+  shard_count   = try(values.valkey.shard_count, 1)
+  replica_count = try(values.valkey.replica_count, 1)
+  node_type     = try(values.valkey.node_type, "SHARED_CORE_NANO")
+
+  # Pinned rather than inherited from module defaults, so neither drifts with a
+  # default bump. MULTI_ZONE is the analogue of AWS multi_az_enabled = true and
+  # is IMMUTABLE — changing it later forces instance replacement.
+  engine_version                = "VALKEY_8_0"
+  zone_distribution_config_mode = try(values.valkey.zone_distribution_config_mode, "MULTI_ZONE")
+
+  # ElastiCache folds persistence and backups into one concept (snapshots);
+  # Memorystore splits them, so parity needs both blocks.
+  persistence_config = {
+    mode       = "RDB"
+    rdb_config = { rdb_snapshot_period = "TWENTY_FOUR_HOURS" }
+  }
+
+  # retention 604800s = 7 days, matching the AWS units' snapshot_retention_limit.
+  # start_time is the UTC hour. Times are UTC on both clouds.
+  automated_backup_config = {
+    retention  = "604800s"
+    start_time = "23"
+  }
+
+  # Analogue of AWS maintenance_window = "mon:04:00-mon:05:00". Left unset,
+  # Google picks the window — exactly the kind of thing that should not differ
+  # silently between clouds.
+  weekly_maintenance_window = [{
+    day_of_week        = "MONDAY"
+    start_time_hour    = "4"
+    start_time_minutes = "0"
+  }]
+
+  # engine_configs (the parameter_group_name analogue) is deliberately unset:
+  # Memorystore's defaults already agree with the stock ElastiCache group on
+  # the parameter that matters (maxmemory-policy = volatile-lru). The knob is
+  # plumbed if a custom group ever needs porting.
+
+  deletion_protection_enabled = try(values.valkey.deletion_protection_enabled, true)
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    component   = "cache"
+    engine      = "valkey"
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/catalog/units/squid-proxy/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/squid-proxy/terragrunt.hcl
@@ -1,0 +1,57 @@
+# squid_image needs a pre-baked custom image with Squid installed - see
+# values.custom_images in the stack. Outbound internet access is provided by
+# the Cloud Router + Cloud NAT already created in ../vpc-network.
+
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "vpc" {
+  config_path = "../vpc-network"
+
+  mock_outputs = {
+    network_self_link = "projects/mock/global/networks/mock-vpc"
+    subnets_by_tier   = { outgoing-proxy = "projects/mock/regions/asia-south1/subnetworks/mock-outgoing-proxy" }
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/composition/squid-proxy?ref=gcp-squid-proxy-v0.1.0"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+  region       = include.root.locals.region
+
+  network          = dependency.vpc.outputs.network_self_link
+  proxy_subnetwork = dependency.vpc.outputs.subnets_by_tier["outgoing-proxy"]
+  lb_subnetwork    = dependency.vpc.outputs.subnets_by_tier["outgoing-proxy"]
+
+  squid_image = "projects/${include.root.locals.project_id}/global/images/${values.custom_images.squid}"
+
+  # Required since #309, with no default: the underlying lb-internal module
+  # falls back to 0.0.0.0/0 when both source_ip_ranges and source_tags are
+  # unset. Squid's clients are GKE pods, which carry no network tags to match
+  # on, so this has to be IP-range based.
+  #
+  # Derived from the same stack values ../vpc-network builds its GKE ranges
+  # from, so the two cannot drift: the gke-nodes subnet CIDR and the pods
+  # secondary range.
+  ilb_source_ranges = [
+    "${values.vpc_cidr_prefix}.16.0/20",
+    values.gke_pods_secondary_range_cidr,
+  ]
+
+  min_replicas = 2
+  max_replicas = 6
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/catalog/units/vpc-network/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/vpc-network/terragrunt.hcl
@@ -1,0 +1,75 @@
+# Foundation unit - every other GCP unit depends on it, directly or
+# transitively. No `dependency` blocks here.
+
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+terraform {
+  source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/composition/vpc-network?ref=gcp-vpc-network-v0.1.0"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+  region       = include.root.locals.region
+
+  network_name = "${include.root.locals.project_name}-${include.root.locals.environment.short}-vpc"
+  routing_mode = "GLOBAL"
+
+  # ---------------------------------------------------------------------------
+  # Subnet CIDRs - one regional subnet per tier (GCP subnets already span
+  # every zone in the region, unlike AWS's per-AZ subnets)
+  # ---------------------------------------------------------------------------
+  external_incoming_subnet_cidr = "${values.vpc_cidr_prefix}.0.0/24"
+  management_subnet_cidr        = "${values.vpc_cidr_prefix}.1.0/24"
+
+  gke_nodes_subnet_cidr             = "${values.vpc_cidr_prefix}.16.0/20"
+  gke_pods_secondary_range_cidr     = values.gke_pods_secondary_range_cidr
+  gke_services_secondary_range_cidr = values.gke_services_secondary_range_cidr
+
+  database_subnet_cidr             = "${values.vpc_cidr_prefix}.2.0/24"
+  locker_database_subnet_cidr      = "${values.vpc_cidr_prefix}.3.0/24"
+  locker_server_subnet_cidr        = "${values.vpc_cidr_prefix}.4.0/24"
+  memorystore_subnet_cidr          = "${values.vpc_cidr_prefix}.5.0/24"
+  data_stack_subnet_cidr           = "${values.vpc_cidr_prefix}.6.0/24"
+  incoming_envoy_subnet_cidr       = "${values.vpc_cidr_prefix}.7.0/24"
+  outgoing_proxy_subnet_cidr       = "${values.vpc_cidr_prefix}.8.0/24"
+  utils_subnet_cidr                = "${values.vpc_cidr_prefix}.9.0/24"
+  serverless_connector_subnet_cidr = "${values.vpc_cidr_prefix}.10.0/28"
+
+  custom_subnets = {}
+
+  enable_flow_logs = false
+
+  # ---------------------------------------------------------------------------
+  # Cloud Router / Cloud NAT
+  # ---------------------------------------------------------------------------
+  router_asn           = 64514
+  nat_min_ports_per_vm = 64
+
+  # ---------------------------------------------------------------------------
+  # Private Service Access (Cloud SQL / Memorystore)
+  # ---------------------------------------------------------------------------
+  private_service_access_prefix_length = 16
+
+  # ---------------------------------------------------------------------------
+  # Baseline firewall rules (cross-module rules live in ../firewall-rules,
+  # deployed last)
+  # ---------------------------------------------------------------------------
+  vpc_internal_ranges = {
+    primary  = "${values.vpc_cidr_prefix}.0.0/16"
+    gke_pods = values.gke_pods_secondary_range_cidr
+    gke_svcs = values.gke_services_secondary_range_cidr
+  }
+  enable_default_deny_ingress = true
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    team        = "infra"
+    managed_by  = "terraform"
+  }
+}


### PR DESCRIPTION
19 reusable Terragrunt units wrapping the published GCP modules - the VPC, the GKE cluster and its 9 workloads, AlloyDB, Memorystore Valkey, the edge proxies, artifact registry, bastion host, the card vault's data tier and the cross-unit firewall rules. 

Units only. The stack that composes them (catalog/stacks/internal, including the root.hcl every unit includes) and the generated live layer follow in a separate PR, once these units are tagged.

A unit exists here only if its module is published on main; all 19 pins resolve to existing tags, enforced by scripts/ci/check-gcp-pins.sh.

Every unit's inputs were diffed against its module's variables.tf on main - no unknown inputs and no unset required variables remain. That check turned up four real problems, fixed here:

- composition/locker is a different module now - it no longer provisions a VM fleet from a baked image, and every input the earlier draft set is gone. The vault runs on GKE via Helm, so the unit creates only what Kubernetes cannot create for itself: a dedicated AlloyDB cluster (keeping card data in its own PCI-DSS scope), the Workload Identity binding and the CMEK key.
- firewall-rules had rules targeting instance tags that no longer exist (locker-node, and the data-stack fleets that have no published module). Replaced with rules for the units that do exist, using the tags the modules actually set.

Ships the shared CI scripts alongside: check-sensitive.sh (verbatim from #302) and a new check-gcp-pins.sh that fails if any ?ref= is not a tag of the expected shape, or names a tag that does not exist.