### PR TITLE
feat(gcp): add dev live layer for asia-south1

### DIFF
--- a/terraform/gcp/live/dev/asia-south1/alloydb/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/alloydb/terragrunt.hcl
@@ -1,0 +1,58 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "vpc" {
+  config_path = "../vpc-network"
+
+  mock_outputs = {
+    network_id = "projects/mock/global/networks/mock-vpc"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "../../../..//modules/composition/alloydb"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+  region       = include.root.locals.region
+
+  network_id = dependency.vpc.outputs.network_id
+
+  allocated_ip_range = "hyperswitch-dev-psa-range"
+
+  database_version = "POSTGRES_15"
+
+  master_username = "hyperswitch_admin"
+
+  secret_manager = {
+    create = true
+  }
+
+  primary_instance = {
+    availability_type = "ZONAL"
+    cpu_count         = 2
+
+  }
+
+  read_pool_instances = {}
+
+  continuous_backup_enabled              = true
+  continuous_backup_recovery_window_days = 14
+  automated_backup_enabled               = true
+  automated_backup_retention_count       = 14
+
+  deletion_protection = false
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    component   = "database"
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/live/dev/asia-south1/application-stack/apps/argocd/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/application-stack/apps/argocd/terragrunt.hcl
@@ -1,0 +1,52 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "gke" {
+  config_path = "../../gke"
+
+  mock_outputs = {
+    cluster_name   = "mock-cluster"
+    location       = "asia-south1"
+    endpoint       = "mock-endpoint"
+    ca_certificate = "bW9jaw=="
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "../../../../../..//modules/application-resources/argocd"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+
+  cluster_name     = dependency.gke.outputs.cluster_name
+  cluster_location = dependency.gke.outputs.location
+
+  cluster_endpoint       = dependency.gke.outputs.endpoint
+  cluster_ca_certificate = dependency.gke.outputs.ca_certificate
+
+  argocd_namespace = "argocd"
+
+  argocd_service_accounts = [
+    "argocd-application-controller",
+    "argocd-applicationset-controller",
+    "argocd-server",
+  ]
+
+  use_existing_k8s_sa = false
+
+  additional_project_roles              = []
+  cross_project_target_service_accounts = []
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    component   = "argocd"
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/live/dev/asia-south1/application-stack/apps/cloud-cdn-sdk/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/application-stack/apps/cloud-cdn-sdk/terragrunt.hcl
@@ -1,0 +1,44 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "sdk_assets" {
+  config_path = "../hyperswitch-sdk-assets"
+
+  mock_outputs = {
+    bucket_name = "mock-bucket"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "../../../../../..//modules/composition/cloud-cdn"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  project_name = include.root.locals.project_name
+  environment  = include.root.locals.environment.short
+
+  name_override = "sdk"
+
+  backend_buckets = {
+    sdk = {
+      bucket_name = dependency.sdk_assets.outputs.bucket_name
+    }
+  }
+
+  ssl                             = true
+  managed_ssl_certificate_domains = ["34-117-162-90.sslip.io"]
+  http_redirect_to_https          = true
+
+  enable_logging = false
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    component   = "cloud-cdn-sdk"
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/live/dev/asia-south1/application-stack/apps/external-secrets-operator/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/application-stack/apps/external-secrets-operator/terragrunt.hcl
@@ -1,0 +1,49 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "gke" {
+  config_path = "../../gke"
+
+  mock_outputs = {
+    cluster_name   = "mock-cluster"
+    location       = "asia-south1"
+    endpoint       = "mock-endpoint"
+    ca_certificate = "bW9jaw=="
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "../../../../../..//modules/application-resources/external-secrets-operator"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+
+  cluster_name     = dependency.gke.outputs.cluster_name
+  cluster_location = dependency.gke.outputs.location
+
+  cluster_endpoint       = dependency.gke.outputs.endpoint
+  cluster_ca_certificate = dependency.gke.outputs.ca_certificate
+
+  k8s_namespace            = "external-secrets-operator"
+  k8s_service_account_name = "external-secrets-sa"
+
+  use_existing_k8s_sa = false
+
+  scope_to_project = true
+  secret_ids       = []
+
+  additional_project_roles = []
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    component   = "external-secrets-operator"
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/live/dev/asia-south1/application-stack/apps/gateway-controller/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/application-stack/apps/gateway-controller/terragrunt.hcl
@@ -1,0 +1,28 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+terraform {
+  source = "../../../../../..//modules/application-resources/gateway-controller"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+
+  create_ssl_policy = true
+
+  ssl_policy_profile         = "MODERN"
+  ssl_policy_min_tls_version = "TLS_1_2"
+
+  create_service_account = false
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    component   = "gateway-controller"
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/live/dev/asia-south1/application-stack/apps/grafana/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/application-stack/apps/grafana/terragrunt.hcl
@@ -1,0 +1,69 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "gke" {
+  config_path = "../../gke"
+
+  mock_outputs = {
+    cluster_name   = "mock-cluster"
+    location       = "asia-south1"
+    endpoint       = "mock-endpoint"
+    ca_certificate = "bW9jaw=="
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+dependency "vpc" {
+
+  config_path = "../../../vpc-network"
+
+  mock_outputs = {
+    network_id = "projects/mock/global/networks/mock-vpc"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "../../../../../..//modules/application-resources/grafana"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+  region       = include.root.locals.region
+
+  cluster_name     = dependency.gke.outputs.cluster_name
+  cluster_location = dependency.gke.outputs.location
+
+  cluster_endpoint       = dependency.gke.outputs.endpoint
+  cluster_ca_certificate = dependency.gke.outputs.ca_certificate
+
+  k8s_namespace            = "monitoring"
+  k8s_service_account_name = "grafana"
+
+  use_existing_k8s_sa = false
+
+  additional_project_roles = [
+    "roles/monitoring.viewer",
+    "roles/logging.viewer",
+  ]
+
+  create_database = false
+  database_config = {
+    network_id = dependency.vpc.outputs.network_id
+  }
+
+  host_domains = {
+    dev = "grafana.${include.root.locals.domains[0]}"
+  }
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    component   = "grafana"
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/live/dev/asia-south1/application-stack/apps/hyperswitch-sdk-assets/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/application-stack/apps/hyperswitch-sdk-assets/terragrunt.hcl
@@ -1,0 +1,32 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+terraform {
+
+  source = "tfr:///terraform-google-modules/cloud-storage/google//modules/simple_bucket?version=12.3.0"
+}
+
+inputs = {
+  project_id = include.root.locals.project_id
+
+  name          = "${include.root.locals.project_id}-${include.root.locals.region}-sdk-assets"
+  location      = include.root.locals.region
+  force_destroy = true
+  versioning    = false
+
+  bucket_policy_only = true
+
+  iam_members = [{
+    role   = "roles/storage.objectViewer"
+    member = "serviceAccount:service-${include.root.locals.project_number}@https-lb.iam.gserviceaccount.com"
+  }]
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    component   = "hyperswitch-web-sdk"
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/live/dev/asia-south1/application-stack/apps/hyperswitch/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/application-stack/apps/hyperswitch/terragrunt.hcl
@@ -1,0 +1,73 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "gke" {
+  config_path = "../../gke"
+
+  mock_outputs = {
+    cluster_name   = "mock-cluster"
+    location       = "asia-south1"
+    endpoint       = "mock-endpoint"
+    ca_certificate = "bW9jaw=="
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "../../../../../..//modules/application-resources/hyperswitch"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+
+  public_domain = include.root.locals.domains[0]
+
+  cluster_name           = dependency.gke.outputs.cluster_name
+  cluster_location       = dependency.gke.outputs.location
+  cluster_endpoint       = dependency.gke.outputs.endpoint
+  cluster_ca_certificate = dependency.gke.outputs.ca_certificate
+
+  kms = {
+    create = true
+
+    location        = "asia"
+    rotation_period = "7776000s"
+  }
+
+  gcs_dashboard_themes = {
+    create             = true
+    location           = include.root.locals.region
+    versioning_enabled = true
+  }
+
+  gcs_file_uploads = {
+    create             = true
+    location           = include.root.locals.region
+    versioning_enabled = true
+  }
+
+  smtp_secret_id = null
+
+  secret_ids = ["hyperswitch-dev-gcp-kms-secrets"]
+
+  cloud_functions = {
+    enabled = false
+  }
+
+  cross_project_assume = {
+    enabled = false
+  }
+
+  additional_custom_role_ids = []
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    component   = "hyperswitch"
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/live/dev/asia-south1/application-stack/apps/istio/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/application-stack/apps/istio/terragrunt.hcl
@@ -1,0 +1,67 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "gke" {
+  config_path = "../../gke"
+
+  mock_outputs = {
+    cluster_name   = "mock-cluster"
+    location       = "asia-south1"
+    endpoint       = "mock-endpoint"
+    ca_certificate = "bW9jaw=="
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+dependency "vpc" {
+  config_path = "../../../vpc-network"
+
+  mock_outputs = {
+    network_self_link = "https://www.googleapis.com/compute/v1/projects/mock/global/networks/mock-vpc"
+    network_name      = "mock-vpc"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "../../../../../..//modules/application-resources/istio"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+  region       = include.root.locals.region
+
+  cluster_name = dependency.gke.outputs.cluster_name
+
+  cluster_endpoint       = dependency.gke.outputs.endpoint
+  cluster_ca_certificate = dependency.gke.outputs.ca_certificate
+
+  network      = dependency.vpc.outputs.network_self_link
+  network_name = dependency.vpc.outputs.network_name
+
+  istio_namespace = "istio-system"
+
+  istio_base    = { enabled = false }
+  istiod        = { enabled = false }
+  istio_gateway = { enabled = false }
+
+  create_gateway_static_ip    = false
+  gateway_service_annotations = {}
+
+  create_firewall_rules = false
+
+  host_domains = {
+    dev = include.root.locals.domains
+  }
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    component   = "istio"
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/live/dev/asia-south1/application-stack/apps/loki/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/application-stack/apps/loki/terragrunt.hcl
@@ -1,0 +1,63 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "gke" {
+  config_path = "../../gke"
+
+  mock_outputs = {
+    cluster_name   = "mock-cluster"
+    location       = "asia-south1"
+    endpoint       = "mock-endpoint"
+    ca_certificate = "bW9jaw=="
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "../../../../../..//modules/application-resources/loki"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+
+  cluster_name     = dependency.gke.outputs.cluster_name
+  cluster_location = dependency.gke.outputs.location
+
+  cluster_endpoint       = dependency.gke.outputs.endpoint
+  cluster_ca_certificate = dependency.gke.outputs.ca_certificate
+
+  k8s_namespace            = "loki"
+  k8s_service_account_name = "loki"
+
+  use_existing_k8s_sa = false
+
+  additional_project_roles = []
+
+  bucket_name          = null
+  bucket_location      = include.root.locals.region
+  bucket_force_destroy = false
+
+  bucket_lifecycle_rules = [
+    {
+      action = {
+        type = "Delete"
+      }
+      condition = {
+        age = 365
+      }
+    },
+  ]
+
+  enable_bucket_notifications = false
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    component   = "loki"
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/live/dev/asia-south1/application-stack/apps/superposition/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/application-stack/apps/superposition/terragrunt.hcl
@@ -1,0 +1,60 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "gke" {
+  config_path = "../../gke"
+
+  mock_outputs = {
+    cluster_name   = "mock-cluster"
+    location       = "asia-south1"
+    endpoint       = "mock-endpoint"
+    ca_certificate = "bW9jaw=="
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+dependency "vpc" {
+
+  config_path = "../../../vpc-network"
+
+  mock_outputs = {
+    network_id = "projects/mock/global/networks/mock-vpc"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "../../../../../..//modules/application-resources/superposition"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+  region       = include.root.locals.region
+
+  cluster_name           = dependency.gke.outputs.cluster_name
+  cluster_location       = dependency.gke.outputs.location
+  cluster_endpoint       = dependency.gke.outputs.endpoint
+  cluster_ca_certificate = dependency.gke.outputs.ca_certificate
+
+  k8s_namespace            = "hyperswitch"
+  k8s_service_account_name = "superposition"
+
+  create_database = false
+  database_config = {
+
+    network_id = dependency.vpc.outputs.network_id
+  }
+
+  additional_project_roles = []
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    component   = "superposition"
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/live/dev/asia-south1/application-stack/apps/vector/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/application-stack/apps/vector/terragrunt.hcl
@@ -1,0 +1,58 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "gke" {
+  config_path = "../../gke"
+
+  mock_outputs = {
+    cluster_name   = "mock-cluster"
+    location       = "asia-south1"
+    endpoint       = "mock-endpoint"
+    ca_certificate = "bW9jaw=="
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "../../../../../..//modules/application-resources/vector"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+
+  cluster_name     = dependency.gke.outputs.cluster_name
+  cluster_location = dependency.gke.outputs.location
+
+  cluster_endpoint       = dependency.gke.outputs.endpoint
+  cluster_ca_certificate = dependency.gke.outputs.ca_certificate
+
+  k8s_namespace            = "vector"
+  k8s_service_account_name = "vector-logging"
+
+  use_existing_k8s_sa = false
+
+  additional_project_roles = []
+
+  create_bucket          = true
+  bucket_name            = null
+  bucket_location        = include.root.locals.region
+  bucket_force_destroy   = false
+  bucket_lifecycle_rules = []
+
+  create_queue                            = true
+  subscription_ack_deadline_seconds       = 60
+  subscription_message_retention_duration = "604800s"
+
+  cross_region_reader_members = []
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    component   = "vector"
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/live/dev/asia-south1/application-stack/gke/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/application-stack/gke/terragrunt.hcl
@@ -1,0 +1,96 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "vpc" {
+
+  config_path = "../../vpc-network"
+
+  mock_outputs = {
+    network_name                      = "mock-vpc"
+    subnets                           = { "asia-south1/hyperswitch-dev-gke-nodes" = { name = "mock-gke-nodes" } }
+    gke_pods_secondary_range_name     = "mock-gke-pods"
+    gke_services_secondary_range_name = "mock-gke-services"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "../../../../..//modules/composition/gke"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+  region       = include.root.locals.region
+
+  cluster_name_version = "01"
+
+  regional = true
+
+  network           = dependency.vpc.outputs.network_name
+  subnetwork        = dependency.vpc.outputs.subnets["asia-south1/hyperswitch-dev-gke-nodes"].name
+  ip_range_pods     = dependency.vpc.outputs.gke_pods_secondary_range_name
+  ip_range_services = dependency.vpc.outputs.gke_services_secondary_range_name
+
+  kubernetes_version = "latest"
+  release_channel    = "REGULAR"
+
+  enable_private_endpoint = false
+  master_ipv4_cidr_block  = include.root.locals.gke_master_ipv4_cidr_block
+
+  master_authorized_networks = include.root.locals.vpn_cidr_blocks
+
+  deletion_protection = false
+
+  create_service_account = false
+
+  enable_node_auto_upgrade = false
+
+  node_pools = [
+    {
+      name         = "system-pool"
+      machine_type = include.root.locals.machine_types.gke_system_pool
+      min_count    = 1
+      max_count    = 2
+      disk_size_gb = 100
+      disk_type    = "pd-balanced"
+      auto_repair  = true
+      auto_upgrade = false
+    },
+    {
+      name         = "app-pool"
+      machine_type = include.root.locals.machine_types.gke_generic_compute
+      min_count    = 1
+      max_count    = 3
+      disk_size_gb = 100
+      disk_type    = "pd-balanced"
+      auto_repair  = true
+      auto_upgrade = false
+    },
+  ]
+
+  node_pools_labels = {
+    system-pool = { role = "system" }
+    app-pool    = { role = "application" }
+  }
+
+  node_pools_taints = {
+    system-pool = [
+      { key = "components.hyperswitch.io/system", value = "true", effect = "NO_SCHEDULE" },
+    ]
+  }
+
+  node_pools_tags = {
+    system-pool = ["gke-node", "hyperswitch-dev", "gke-system-pool"]
+    app-pool    = ["gke-node", "hyperswitch-dev", "gke-app-pool"]
+  }
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/live/dev/asia-south1/artifact-registry/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/artifact-registry/terragrunt.hcl
@@ -1,0 +1,77 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+terraform {
+  source = "../../../..//modules/composition/artifact-registry"
+}
+
+inputs = {
+  project_id  = include.root.locals.project_id
+  environment = include.root.locals.environment.short
+  location    = include.root.locals.region
+
+  repositories = {
+    hyperswitch = {
+      description    = "Hyperswitch application images"
+      format         = "DOCKER"
+      immutable_tags = false
+      cleanup_policies = {
+        keep-recent = {
+          action               = "KEEP"
+          most_recent_versions = 15
+        }
+      }
+    }
+    hyperswitch-router = {
+      description    = "Hyperswitch router application image (mirrors AWS ECR hyperswitch-router)"
+      format         = "DOCKER"
+      immutable_tags = false
+      cleanup_policies = {
+        keep-recent = {
+          action               = "KEEP"
+          most_recent_versions = 15
+        }
+      }
+    }
+    hyperswitch-consumer = {
+      description    = "Hyperswitch consumer application image (mirrors AWS ECR hyperswitch-consumer)"
+      format         = "DOCKER"
+      immutable_tags = false
+      cleanup_policies = {
+        keep-recent = {
+          action               = "KEEP"
+          most_recent_versions = 15
+        }
+      }
+    }
+    hyperswitch-producer = {
+      description    = "Hyperswitch producer application image (mirrors AWS ECR hyperswitch-producer)"
+      format         = "DOCKER"
+      immutable_tags = false
+      cleanup_policies = {
+        keep-recent = {
+          action               = "KEEP"
+          most_recent_versions = 15
+        }
+      }
+    }
+    hyperswitch-drainer = {
+      description    = "Hyperswitch drainer application image (mirrors AWS ECR hyperswitch-drainer)"
+      format         = "DOCKER"
+      immutable_tags = false
+      cleanup_policies = {
+        keep-recent = {
+          action               = "KEEP"
+          most_recent_versions = 15
+        }
+      }
+    }
+  }
+
+  labels = {
+    environment = include.root.locals.environment.short
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/live/dev/asia-south1/bastion-host/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/bastion-host/terragrunt.hcl
@@ -1,0 +1,85 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "vpc" {
+  config_path = "../vpc-network"
+
+  mock_outputs = {
+    network_self_link = "projects/mock/global/networks/mock-vpc"
+    subnets_by_tier   = { management = "projects/mock/regions/asia-south1/subnetworks/mock-management" }
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+dependency "alloydb" {
+  config_path = "../alloydb"
+
+  mock_outputs = {
+    primary_instance_ip = "10.214.0.1"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+dependency "valkey" {
+  config_path = "../memorystore-valkey"
+
+  mock_outputs = {
+    discovery_host = "10.2.74.1"
+    discovery_port = 6379
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "../../../..//modules/composition/bastion-host"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+  region       = include.root.locals.region
+  zone         = "asia-south1-b"
+
+  network = dependency.vpc.outputs.network_self_link
+  subnet  = dependency.vpc.outputs.subnets_by_tier["management"]
+
+  machine_type = include.root.locals.machine_types.bastion
+  disk_size_gb = 20
+  disk_type    = "pd-balanced"
+
+  image = "projects/debian-cloud/global/images/family/debian-12"
+
+  members = include.root.locals.bastion_iap_members
+
+  connection_targets = {
+    alloydb = {
+      host = dependency.alloydb.outputs.primary_instance_ip
+      port = 5432
+
+      description = "AlloyDB primary - psql 'host=127.0.0.1 port=5432 user=hyperswitch_admin sslmode=require'"
+    }
+
+    valkey = {
+      host = dependency.valkey.outputs.discovery_host
+      port = dependency.valkey.outputs.discovery_port
+
+      description = "Memorystore Valkey cluster discovery endpoint - valkey-cli -h 127.0.0.1 -p 6379"
+    }
+  }
+
+  additional_service_account_roles = [
+    "roles/secretmanager.secretAccessor",
+  ]
+
+  enable_session_logging = false
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    component   = "bastion-host"
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/live/dev/asia-south1/certificate-manager/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/certificate-manager/terragrunt.hcl
@@ -1,0 +1,27 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+terraform {
+  source = "../../../..//modules/composition/certificate-manager"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+
+  certificates = {}
+
+  dns_authorization_type = "FIXED_RECORD"
+
+  create_certificate_map = true
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    component   = "certificate-manager"
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/live/dev/asia-south1/cloud-dns/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/cloud-dns/terragrunt.hcl
@@ -1,0 +1,41 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "vpc" {
+  config_path = "../vpc-network"
+
+  mock_outputs = {
+    network_self_link = "projects/mock/global/networks/mock-vpc"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "../../../..//modules/composition/cloud-dns"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+
+  zone_name = "${include.root.locals.environment.short}-${include.root.locals.project_name}-internal"
+
+  domain = "${include.root.locals.domains[0]}."
+
+  type                               = "private"
+  private_visibility_config_networks = [dependency.vpc.outputs.network_self_link]
+
+  enable_dnssec = false
+
+  recordsets = []
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    component   = "cloud-dns"
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/live/dev/asia-south1/envoy-proxy-iap-ssh-firewall/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/envoy-proxy-iap-ssh-firewall/terragrunt.hcl
@@ -1,0 +1,34 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+terraform {
+  source = "../../../..//modules/composition/firewall-rules"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  project_name = include.root.locals.project_name
+  environment  = include.root.locals.environment.short
+  network_name = "hyperswitch-dev-vpc"
+
+  rules = {
+    envoy-proxy = {
+      rules = [
+        {
+          name        = "allow-iap-ssh"
+          description = "IAP-tunneled SSH to envoy-proxy fleet instances"
+          direction   = "INGRESS"
+          priority    = 1000
+          ranges      = ["35.235.240.0/20"]
+          target_tags = ["envoy-proxy"]
+          allow = [{
+            protocol = "tcp"
+            ports    = ["22"]
+          }]
+        },
+      ]
+    }
+  }
+}

--- a/terraform/gcp/live/dev/asia-south1/envoy-proxy/config/envoy.yaml
+++ b/terraform/gcp/live/dev/asia-south1/envoy-proxy/config/envoy.yaml
@@ -1,0 +1,57 @@
+admin:
+  address:
+    socket_address: { address: 127.0.0.1, port_value: 9901 }
+
+static_resources:
+  listeners:
+  - name: listener_http
+    address:
+      socket_address: { address: 0.0.0.0, port_value: 8080 }
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match: { path: "/health" }
+                direct_response:
+                  status: 200
+                  body: { inline_string: "ok\n" }
+              - match: { prefix: "/api/" }
+                route:
+                  cluster: istio_ingressgateway
+                  prefix_rewrite: "/"
+                  timeout: 30s
+              - match: { prefix: "/sdk/" }
+                route:
+                  cluster: istio_ingressgateway
+                  prefix_rewrite: "/"
+                  host_rewrite_literal: "sdk.dev.hyperswitch.local"
+                  timeout: 30s
+              - match: { prefix: "/" }
+                route:
+                  cluster: istio_ingressgateway
+                  host_rewrite_literal: "dashboard.dev.hyperswitch.local"
+                  timeout: 30s
+          http_filters:
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+  - name: istio_ingressgateway
+    type: STRICT_DNS
+    connect_timeout: 5s
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: istio_ingressgateway
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address: { address: 10.2.32.23, port_value: 80 }

--- a/terraform/gcp/live/dev/asia-south1/envoy-proxy/templates/startup-script.sh
+++ b/terraform/gcp/live/dev/asia-south1/envoy-proxy/templates/startup-script.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# GCP equivalent of ../../../../aws/live/sandbox/ap-south-1/envoy-proxy/
+# templates/userdata.sh - pulls envoy.yaml/vector.toml from the config
+# bucket and (re)starts envoy.service/vector.service. Runs as a GCE
+# startup-script (metadata_startup_script) on every boot, not just the
+# first - matching AWS's userdata.sh, which also reruns on every boot
+# cloud-init fires.
+#
+# Unlike AWS's userdata.sh, no {{bucket-name}}-style Terraform-side
+# placeholder substitution is needed here: GCE's instance metadata server
+# is queryable directly at boot, so this script just reads the
+# "config-bucket" key the composition module already sets
+# (hyperswitch-suite/terraform/gcp/modules/composition/envoy-proxy/main.tf)
+# instead of having its value baked in ahead of time.
+set -e
+set -x
+
+MD_FLAVOR_HEADER="Metadata-Flavor: Google"
+MD_BASE="http://metadata.google.internal/computeMetadata/v1/instance"
+
+fetch_meta() {
+  curl -sf -H "$MD_FLAVOR_HEADER" "$1" || echo ""
+}
+
+CONFIG_BUCKET=$(fetch_meta "${MD_BASE}/attributes/config-bucket")
+
+if [ -z "$CONFIG_BUCKET" ]; then
+  echo "startup-script: no config-bucket metadata set, leaving existing config in place"
+  exit 0
+fi
+
+# ------------------------------ Envoy config ------------------------------ #
+gsutil cp "gs://${CONFIG_BUCKET}/envoy.yaml" /etc/envoy/envoy.yaml
+chown envoy:envoy /etc/envoy/envoy.yaml
+chmod 640 /etc/envoy/envoy.yaml
+systemctl restart envoy.service
+
+echo "The config has been changed, please verify"
+
+# ------------------------------ Vector config ------------------------------ #
+# Optional, unlike Envoy's - a fleet can run without a live-layer vector.toml
+# override and just use the image's own baked-in default.
+if gsutil -q stat "gs://${CONFIG_BUCKET}/vector.toml"; then
+  gsutil cp "gs://${CONFIG_BUCKET}/vector.toml" /etc/vector/vector.toml
+  chown root:vector /etc/vector/vector.toml
+  chmod 640 /etc/vector/vector.toml
+fi
+
+# ------------------------------ Instance metadata for Vector -------------- #
+# GCE equivalents of the EC2/ASG/Launch-Template tags AWS's userdata.sh
+# writes to /etc/default/metadata: METADATA_ASG_NAME comes from the
+# "created-by" attribute (the owning MIG's URL, GCE's ASG-name stand-in),
+# METADATA_LT_VERSION from the "instance-template" attribute (GCE's
+# launch-template-version stand-in). vector.toml's get_env_var("METADATA_*")
+# calls read these.
+INSTANCE_ID=$(fetch_meta "${MD_BASE}/id")
+INSTANCE_IP=$(fetch_meta "${MD_BASE}/network-interfaces/0/ip")
+CREATED_BY=$(fetch_meta "${MD_BASE}/attributes/created-by")
+INSTANCE_TEMPLATE=$(fetch_meta "${MD_BASE}/attributes/instance-template")
+ASG_NAME="${CREATED_BY##*/}"
+LT_VERSION="${INSTANCE_TEMPLATE##*/}"
+
+cat > /etc/default/metadata <<EOF
+METADATA_INSTANCE_ID=${INSTANCE_ID:-unknown}
+METADATA_INSTANCE_IP=${INSTANCE_IP:-unknown}
+METADATA_ASG_NAME=${ASG_NAME:-unknown}
+METADATA_LT_VERSION=${LT_VERSION:-unknown}
+EOF
+
+# EnvironmentFile drop-in feeding /etc/default/metadata to vector.service -
+# written here (not baked into the image) so it's environment-specific
+# wiring, matching AWS's userdata.sh writing its own environment.conf drop-in
+# rather than shipping it in the AMI. The image's own drop-in
+# (vector.service.d/gcp-overrides.conf) only fixes the config *path*, which
+# is a fixed fact about this Vector package build, not environment-specific.
+mkdir -p /etc/systemd/system/vector.service.d
+cat > /etc/systemd/system/vector.service.d/environment.conf <<EOF
+[Service]
+EnvironmentFile=-/etc/default/metadata
+EOF
+
+systemctl daemon-reload
+systemctl restart vector.service

--- a/terraform/gcp/live/dev/asia-south1/envoy-proxy/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/envoy-proxy/terragrunt.hcl
@@ -1,0 +1,64 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "vpc" {
+  config_path = "../vpc-network"
+
+  mock_outputs = {
+    network_self_link = "projects/mock/global/networks/mock-vpc"
+    subnets_by_tier   = { management = "projects/mock/regions/asia-south1/subnetworks/mock-management" }
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "../../../..//modules/composition/envoy-proxy"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  project_name = include.root.locals.project_name
+  environment  = include.root.locals.environment.short
+  region       = include.root.locals.region
+
+  network          = dependency.vpc.outputs.network_self_link
+  proxy_subnetwork = dependency.vpc.outputs.subnets_by_tier["management"]
+
+  envoy_image = "projects/hyperswitch-dev/global/images/hyperswitch-envoy-dev-20260820032919"
+
+  deployments = {
+    stable = { weight = 100 }
+
+  }
+
+  listener_rules = []
+
+  envoy_config_content = file("${get_terragrunt_dir()}/config/envoy.yaml")
+
+  additional_config_files_path = "${get_terragrunt_dir()}/config"
+
+  custom_startup_script = file("${get_terragrunt_dir()}/templates/startup-script.sh")
+
+  machine_type = "e2-medium"
+  min_replicas = 1
+  max_replicas = 1
+
+  enable_cloud_armor   = false
+  enable_mtls_listener = false
+
+  enable_cdn = true
+
+  managed_ssl_certificate_domains = ["34-111-119-59.sslip.io"]
+
+  enable_https_redirect = true
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    component   = "envoy-proxy"
+    managed_by  = "terraform"
+    purpose     = "smoke-test"
+  }
+}

--- a/terraform/gcp/live/dev/asia-south1/firewall-rules/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/firewall-rules/terragrunt.hcl
@@ -1,0 +1,158 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "vpc" {
+  config_path = "../vpc-network"
+
+  mock_outputs = {
+    network_name = "mock-vpc"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "../../../..//modules/composition/firewall-rules"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+
+  network_name = dependency.vpc.outputs.network_name
+
+  rules = {
+    bastion-to-locker = {
+      rules = [
+        {
+          name        = "allow-bastion-ssh"
+          description = "Allow bastion IAP SSH to the locker server fleet"
+          direction   = "INGRESS"
+
+          source_tags = ["bastion-host"]
+          target_tags = ["locker-node"]
+          allow       = [{ protocol = "tcp", ports = ["22"] }]
+        },
+      ]
+    }
+
+    bastion-to-data-stack = {
+      rules = [
+        {
+          name        = "allow-bastion-ssh"
+          description = "Allow bastion IAP SSH to the data-stack VM fleets"
+          direction   = "INGRESS"
+          source_tags = ["bastion-host"]
+          target_tags = [
+            "kafka-broker",
+            "kafka-controller",
+            "cassandra-node",
+            "clickhouse-server",
+            "clickhouse-keeper",
+            "opensearch-node",
+          ]
+          allow = [{ protocol = "tcp", ports = ["22"] }]
+        },
+      ]
+    }
+
+    bastion-egress-to-alloydb = {
+      rules = [
+        {
+          name        = "allow-postgres"
+          description = "Allow the bastion to reach AlloyDB over the Private Service Access range, for psql via an IAP SSH port-forward. Range, not instance IP, so it survives a cluster rebuild."
+          direction   = "EGRESS"
+          ranges      = ["10.214.0.0/16"]
+          target_tags = ["bastion-host"]
+          allow       = [{ protocol = "tcp", ports = ["5432"] }]
+          log_config  = { metadata = "INCLUDE_ALL_METADATA" }
+        },
+      ]
+    }
+
+    bastion-egress-to-valkey = {
+      rules = [
+        {
+          name        = "allow-valkey"
+          description = "Allow the bastion to reach the Memorystore Valkey PSC endpoint in the memorystore subnet, for valkey-cli via an IAP SSH port-forward."
+          direction   = "EGRESS"
+          ranges      = ["10.2.74.0/24"]
+          target_tags = ["bastion-host"]
+          allow       = [{ protocol = "tcp", ports = ["6379"] }]
+          log_config  = { metadata = "INCLUDE_ALL_METADATA" }
+        },
+      ]
+    }
+
+    envoy-to-istio-gke = {
+      rules = [
+        {
+          name        = "allow-envoy-to-istio-ingress"
+          description = "Allow the Envoy edge-proxy fleet to reach Istio's ingress gateway (and any GKE-hosted service) on the standard web ports"
+          direction   = "INGRESS"
+          source_tags = ["envoy-proxy"]
+          target_tags = include.root.locals.gke_node_pool_target_tags
+          allow       = [{ protocol = "tcp", ports = ["80", "443", "15021"] }]
+        },
+      ]
+    }
+
+    gke-to-squid-egress = {
+      rules = [
+        {
+          name        = "allow-gke-to-squid-proxy"
+          description = "Allow GKE pods (Hyperswitch app workloads) to reach Squid's internal LB for whitelisted egress"
+          direction   = "INGRESS"
+          ranges      = ["10.100.0.0/16", "10.2.32.0/20"]
+          target_tags = ["squid-proxy"]
+          allow       = [{ protocol = "tcp", ports = ["3128"] }]
+        },
+      ]
+    }
+
+    gke-egress-to-squid = {
+      rules = [
+        {
+          name        = "allow-gke-to-squid-proxy"
+          description = "Allow GKE nodes/pods to reach Squid's internal LB - the only egress path out of the cluster once default-deny-egress is on. Targets node tags (not pod ranges) since GCP firewall enforcement for VPC-native GKE applies at the node's vNIC regardless of whether the source is the node's own IP or a pod alias-range IP."
+          direction   = "EGRESS"
+          ranges      = ["10.2.77.0/24"]
+          target_tags = include.root.locals.gke_node_pool_target_tags
+          allow       = [{ protocol = "tcp", ports = ["3128"] }]
+          log_config  = { metadata = "INCLUDE_ALL_METADATA" }
+        },
+      ]
+    }
+
+    gke-egress-to-alloydb = {
+      rules = [
+        {
+          name        = "allow-postgres"
+          description = "Allow GKE nodes/pods to reach AlloyDB (both the shared cluster and the locker's dedicated PCI-scoped one) over the Private Service Access range. Range, not instance IP, so it survives a cluster rebuild."
+          direction   = "EGRESS"
+          ranges      = ["10.214.0.0/16"]
+          target_tags = include.root.locals.gke_node_pool_target_tags
+          allow       = [{ protocol = "tcp", ports = ["5432"] }]
+          log_config  = { metadata = "INCLUDE_ALL_METADATA" }
+        },
+      ]
+    }
+
+    squid-egress-to-internet = {
+      rules = [
+        {
+
+          name        = "allow"
+          description = "Allow Squid's own subnet to reach the internet on standard web ports - required for it to fulfill proxied requests. This is the designated proxy egress point, not a general internet allow."
+          direction   = "EGRESS"
+          ranges      = ["0.0.0.0/0"]
+          target_tags = ["squid-proxy"]
+          allow       = [{ protocol = "tcp", ports = ["80", "443"] }]
+          log_config  = { metadata = "INCLUDE_ALL_METADATA" }
+        },
+      ]
+    }
+  }
+}

--- a/terraform/gcp/live/dev/asia-south1/iam-infraswitch-federation/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/iam-infraswitch-federation/terragrunt.hcl
@@ -1,0 +1,34 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+terraform {
+  source = "../../../..//modules/application-resources/infraswitch-gcp-federation"
+}
+
+inputs = {
+  project_id = include.root.locals.project_id
+
+  aws_account_id = "123456789012"
+  aws_role_name  = "atlantis-role"
+
+  project_roles = [
+    "roles/compute.admin",
+    "roles/container.admin",
+    "roles/alloydb.admin",
+    "roles/redis.admin",
+    "roles/servicenetworking.networksAdmin",
+    "roles/iam.serviceAccountUser",
+    "roles/iam.serviceAccountAdmin",
+    "roles/cloudkms.admin",
+    "roles/storage.admin",
+    "roles/secretmanager.admin",
+    "roles/iam.workloadIdentityPoolAdmin",
+    "roles/dns.admin",
+    "roles/resourcemanager.projectIamAdmin",
+    "roles/artifactregistry.admin",
+    "roles/networkconnectivity.consumerNetworkAdmin",
+    "roles/memorystore.admin",
+  ]
+}

--- a/terraform/gcp/live/dev/asia-south1/locker/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/locker/terragrunt.hcl
@@ -1,0 +1,88 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "vpc" {
+  config_path = "../vpc-network"
+
+  mock_outputs = {
+    network_id                        = "projects/mock/global/networks/mock-vpc"
+    private_service_access_range_name = "mock-psa-range"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+dependency "gke" {
+  config_path = "../application-stack/gke"
+
+  mock_outputs = {
+    cluster_name   = "mock-cluster"
+    location       = "asia-south1"
+    endpoint       = "mock-endpoint"
+    ca_certificate = "bW9jaw=="
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "../../../..//modules/composition/locker"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+  region       = include.root.locals.region
+
+  cluster_name     = dependency.gke.outputs.cluster_name
+  cluster_location = dependency.gke.outputs.location
+
+  cluster_endpoint       = dependency.gke.outputs.endpoint
+  cluster_ca_certificate = dependency.gke.outputs.ca_certificate
+
+  k8s_namespace            = "hyperswitch"
+  k8s_service_account_name = "hyperswitch-vault-role"
+
+  use_existing_k8s_sa = true
+
+  annotate_k8s_sa = false
+
+  additional_project_roles = []
+
+  create_database = true
+
+  database_config = {
+    network_id = dependency.vpc.outputs.network_id
+
+    allocated_ip_range = dependency.vpc.outputs.private_service_access_range_name
+
+    availability_type = "ZONAL"
+    cpu_count         = 2
+
+    deletion_protection = false
+
+    master_username = "locker_admin"
+
+    secret_manager = {
+      create = true
+    }
+  }
+
+  create_kms_key = true
+  kms_key_id     = "locker"
+
+  kms_protection_level = "SOFTWARE"
+  kms_rotation_period  = "7776000s"
+
+  kms_prevent_destroy = true
+
+  grant_kms_access = false
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    compliance  = "pci-dss"
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/live/dev/asia-south1/memorystore-valkey/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/memorystore-valkey/terragrunt.hcl
@@ -1,0 +1,62 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "vpc" {
+  config_path = "../vpc-network"
+
+  mock_outputs = {
+    network_name = "mock-vpc"
+    subnets      = { "asia-south1/hyperswitch-dev-memorystore" = { name = "mock-memorystore" } }
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "../../../..//modules/composition/memorystore-valkey"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+  region       = include.root.locals.region
+
+  network      = dependency.vpc.outputs.network_name
+  subnet_names = [dependency.vpc.outputs.subnets["asia-south1/hyperswitch-dev-memorystore"].name]
+
+  mode          = "CLUSTER"
+  shard_count   = 1
+  replica_count = 1
+  node_type     = "SHARED_CORE_NANO"
+
+  engine_version                = "VALKEY_8_0"
+  zone_distribution_config_mode = "MULTI_ZONE"
+
+  persistence_config = {
+    mode       = "RDB"
+    rdb_config = { rdb_snapshot_period = "TWENTY_FOUR_HOURS" }
+  }
+
+  automated_backup_config = {
+    retention  = "604800s"
+    start_time = "23"
+  }
+
+  weekly_maintenance_window = [{
+    day_of_week        = "MONDAY"
+    start_time_hour    = "4"
+    start_time_minutes = "0"
+  }]
+
+  deletion_protection_enabled = false
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    component   = "cache"
+    engine      = "valkey"
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/live/dev/asia-south1/pubsub/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/pubsub/terragrunt.hcl
@@ -1,0 +1,36 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+terraform {
+  source = "../../../..//modules/composition/pubsub"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+
+  topic = "events"
+
+  topic_message_retention_duration = "604800s"
+
+  pull_subscriptions = [
+    {
+      name                 = "events-consumer"
+      ack_deadline_seconds = 60
+    },
+  ]
+
+  grant_token_creator = false
+
+  allowed_persistence_regions = [include.root.locals.region]
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    component   = "pubsub"
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/live/dev/asia-south1/root.hcl
+++ b/terraform/gcp/live/dev/asia-south1/root.hcl
@@ -1,0 +1,81 @@
+locals {
+  environment = { full = "dev", short = "dev" }
+  region      = "asia-south1"
+
+  project_name = "hyperswitch"
+
+  project_id     = "hyperswitch-dev"
+  project_number = "000000000000"
+
+  state_bucket_name = "hyperswitch-dev-asia-south1-terraform-state"
+
+  vpn_cidr_blocks = [
+    { cidr_block = "203.0.113.10/32", display_name = "vpn" },
+    { cidr_block = "203.0.113.11/32", display_name = "vpn" },
+    { cidr_block = "198.51.100.0/30", display_name = "office" },
+    { cidr_block = "203.0.113.12/32", display_name = "vpn" },
+    { cidr_block = "198.51.100.8/29", display_name = "office" },
+    { cidr_block = "198.51.100.16/29", display_name = "office" },
+    { cidr_block = "192.0.2.10/32", display_name = "phantom" },
+    { cidr_block = "192.0.2.11/32", display_name = "phantom" },
+    { cidr_block = "198.51.100.24/32", display_name = "office" },
+    { cidr_block = "192.0.2.12/32", display_name = "phantom" },
+    { cidr_block = "198.51.100.32/29", display_name = "office" },
+    { cidr_block = "198.51.100.40/32", display_name = "office" },
+
+    { cidr_block = "10.2.67.0/24", display_name = "management-subnet-bastion" },
+  ]
+
+  domains = ["dev.hyperswitch.internal"]
+
+  bastion_iap_members = [
+    "group:platform-team@example.com",
+  ]
+
+  gke_master_ipv4_cidr_block = "172.16.0.0/28"
+
+  gke_node_pool_target_tags = ["gke-app-pool", "gke-system-pool"]
+
+  machine_types = {
+    gke_system_pool     = "e2-standard-2"
+    gke_generic_compute = "e2-standard-2"
+    bastion             = "e2-small"
+  }
+}
+
+remote_state {
+  backend = "gcs"
+
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+
+  config = {
+    bucket   = local.state_bucket_name
+    prefix   = "${local.environment.full}/${local.region}/${path_relative_to_include()}"
+    project  = local.project_id
+    location = local.region
+
+    skip_bucket_creation = false
+  }
+
+  disable_init = false
+}
+
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+
+  contents = <<EOF
+provider "google" {
+  project = "${local.project_id}"
+  region  = "${local.region}"
+}
+
+provider "google-beta" {
+  project = "${local.project_id}"
+  region  = "${local.region}"
+}
+EOF
+}

--- a/terraform/gcp/live/dev/asia-south1/squid-proxy/config/allowed-domains.txt
+++ b/terraform/gcp/live/dev/asia-south1/squid-proxy/config/allowed-domains.txt
@@ -1,0 +1,8 @@
+.google.com
+.googleapis.com
+.adyen.com
+.checkout.com
+.cybersource.com
+.paypal.com
+.stripe.com
+.worldpay.com

--- a/terraform/gcp/live/dev/asia-south1/squid-proxy/config/squid.conf
+++ b/terraform/gcp/live/dev/asia-south1/squid-proxy/config/squid.conf
@@ -1,0 +1,17 @@
+cache deny all
+
+acl SSL_ports port 443
+acl SSL_ports port 80
+acl CONNECT method CONNECT
+http_access deny CONNECT !SSL_ports
+
+acl allowed_sites_domain dstdomain "/etc/squid/squid.allowed.sites.txt"
+acl allowed_sites_ip dst 203.0.113.6
+http_access allow allowed_sites_domain
+http_access allow allowed_sites_ip
+
+http_access deny all
+
+http_port 0.0.0.0:3128
+
+coredump_dir /var/spool/squid

--- a/terraform/gcp/live/dev/asia-south1/squid-proxy/templates/startup-script.sh
+++ b/terraform/gcp/live/dev/asia-south1/squid-proxy/templates/startup-script.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# GCP equivalent of ../../../../aws/live/sandbox/ap-south-1/squid-proxy/
+# templates/userdata.sh - unlike that AWS script (and unlike this repo's own
+# ../../envoy-proxy/templates/startup-script.sh), this does NOT fetch
+# squid.conf or the domain whitelist - the squid-proxy Packer image already
+# bakes in squid-config-fetch.service/squid-whitelist-fetch.service
+# (Before=squid.service) for those, plus a whitelist-refresh cron
+# (update-squid-whitelist.sh, every 15 min) - duplicating that here would
+# just be two mechanisms racing to write the same files. See this unit's
+# terragrunt.hcl and the squid-proxy module's variables.tf
+# (custom_startup_script's own description) for the full reasoning.
+#
+# What this DOES do: fetch vector.toml from the config bucket, same pattern
+# as envoy's own startup-script.sh - the Packer image bakes its own
+# vector.toml in at BUILD time only (scripts/vector.toml.pkrtpl.hcl), with
+# no boot-time override path otherwise. Runs as a GCE startup-script
+# (metadata_startup_script) on every boot, not just the first.
+set -e
+set -x
+
+MD_FLAVOR_HEADER="Metadata-Flavor: Google"
+MD_BASE="http://metadata.google.internal/computeMetadata/v1/instance"
+
+fetch_meta() {
+  curl -sf -H "$MD_FLAVOR_HEADER" "$1" || echo ""
+}
+
+CONFIG_BUCKET=$(fetch_meta "${MD_BASE}/attributes/config-bucket")
+
+if [ -z "$CONFIG_BUCKET" ]; then
+  echo "startup-script: no config-bucket metadata set, leaving existing config in place"
+  exit 0
+fi
+
+# ------------------------------ Vector config ------------------------------ #
+# Optional - a fleet can run without a live-layer vector.toml override and
+# just use the image's own baked-in default (this is the current dev
+# posture: vector_config_content is unset in this unit's terragrunt.hcl, so
+# no object exists at this path and this block is a no-op).
+if gsutil -q stat "gs://${CONFIG_BUCKET}/vector.toml"; then
+  gsutil cp "gs://${CONFIG_BUCKET}/vector.toml" /etc/vector/vector.toml
+  chown root:vector /etc/vector/vector.toml
+  chmod 640 /etc/vector/vector.toml
+
+  # ---------------------- Instance metadata for Vector --------------------- #
+  # Same METADATA_* env-var pattern as ../../envoy-proxy/templates/
+  # startup-script.sh - only meaningful if a live-layer vector.toml override
+  # actually references get_env_var("METADATA_*") the way envoy's does; the
+  # image's own default vector.toml doesn't, so this drop-in is harmless
+  # either way.
+  INSTANCE_ID=$(fetch_meta "${MD_BASE}/id")
+  INSTANCE_IP=$(fetch_meta "${MD_BASE}/network-interfaces/0/ip")
+  CREATED_BY=$(fetch_meta "${MD_BASE}/attributes/created-by")
+  INSTANCE_TEMPLATE=$(fetch_meta "${MD_BASE}/attributes/instance-template")
+  ASG_NAME="${CREATED_BY##*/}"
+  LT_VERSION="${INSTANCE_TEMPLATE##*/}"
+
+  cat > /etc/default/metadata <<EOF
+METADATA_INSTANCE_ID=${INSTANCE_ID:-unknown}
+METADATA_INSTANCE_IP=${INSTANCE_IP:-unknown}
+METADATA_ASG_NAME=${ASG_NAME:-unknown}
+METADATA_LT_VERSION=${LT_VERSION:-unknown}
+EOF
+
+  mkdir -p /etc/systemd/system/vector.service.d
+  cat > /etc/systemd/system/vector.service.d/environment.conf <<EOF
+[Service]
+EnvironmentFile=-/etc/default/metadata
+EOF
+
+  systemctl daemon-reload
+  systemctl restart vector.service
+fi

--- a/terraform/gcp/live/dev/asia-south1/squid-proxy/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/squid-proxy/terragrunt.hcl
@@ -1,0 +1,49 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+dependency "vpc" {
+  config_path = "../vpc-network"
+
+  mock_outputs = {
+    network_self_link = "projects/mock/global/networks/mock-vpc"
+    subnets_by_tier   = { outgoing-proxy = "projects/mock/regions/asia-south1/subnetworks/mock-outgoing-proxy" }
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+terraform {
+  source = "../../../..//modules/composition/squid-proxy"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+  region       = include.root.locals.region
+
+  network          = dependency.vpc.outputs.network_self_link
+  proxy_subnetwork = dependency.vpc.outputs.subnets_by_tier["outgoing-proxy"]
+  lb_subnetwork    = dependency.vpc.outputs.subnets_by_tier["outgoing-proxy"]
+
+  squid_image = "projects/${include.root.locals.project_id}/global/images/family/hyperswitch-squid-dev"
+
+  ilb_source_ranges = ["10.100.0.0/16", "10.2.32.0/20"]
+
+  squid_config_content    = file("${get_terragrunt_dir()}/config/squid.conf")
+  squid_allowlist_content = file("${get_terragrunt_dir()}/config/allowed-domains.txt")
+
+  additional_config_files_path = "${get_terragrunt_dir()}/config"
+
+  custom_startup_script = file("${get_terragrunt_dir()}/templates/startup-script.sh")
+
+  min_replicas = 1
+  max_replicas = 1
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    managed_by  = "terraform"
+  }
+}

--- a/terraform/gcp/live/dev/asia-south1/vpc-network/terragrunt.hcl
+++ b/terraform/gcp/live/dev/asia-south1/vpc-network/terragrunt.hcl
@@ -1,0 +1,63 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+terraform {
+  source = "../../../..//modules/composition/vpc-network"
+}
+
+inputs = {
+  project_id   = include.root.locals.project_id
+  environment  = include.root.locals.environment.short
+  project_name = include.root.locals.project_name
+  region       = include.root.locals.region
+
+  network_name = "hyperswitch-dev-vpc"
+  routing_mode = "GLOBAL"
+
+  external_incoming_subnet_cidr = "10.2.64.0/24"
+  management_subnet_cidr        = "10.2.67.0/24"
+
+  gke_nodes_subnet_cidr             = "10.2.32.0/20"
+  gke_pods_secondary_range_cidr     = "10.100.0.0/16"
+  gke_services_secondary_range_cidr = "10.101.0.0/20"
+
+  database_subnet_cidr             = "10.2.73.0/24"
+  memorystore_subnet_cidr          = "10.2.74.0/24"
+  locker_database_subnet_cidr      = "10.2.75.0/24"
+  locker_server_subnet_cidr        = "10.2.76.0/24"
+  outgoing_proxy_subnet_cidr       = "10.2.77.0/24"
+  data_stack_subnet_cidr           = "10.2.80.0/24"
+  serverless_connector_subnet_cidr = "10.2.90.0/28"
+
+  custom_subnets = {}
+
+  enable_flow_logs = false
+
+  router_asn           = 64514
+  nat_min_ports_per_vm = 64
+  nat_subnetwork_tiers = ["outgoing-proxy"]
+  nat_log_filter       = "ALL"
+
+  enable_default_deny_egress = true
+  enable_psc_google_apis     = true
+
+  private_service_access_prefix_length = 16
+
+  vpc_internal_ranges = {
+    primary  = "10.2.0.0/16"
+    gke_pods = "10.100.0.0/16"
+    gke_svcs = "10.101.0.0/20"
+
+    psa = "10.214.0.0/16"
+  }
+  enable_default_deny_ingress = true
+
+  labels = {
+    environment = include.root.locals.environment.short
+    project     = include.root.locals.project_name
+    team        = "infra"
+    managed_by  = "terraform"
+  }
+}


### PR DESCRIPTION
The repo ships GCP composition and application-resources modules but has no GCP live layer. This adds one for dev/asia-south1, covering the components actually deployed in that environment - 26 units plus a region-level root.hcl that owns the GCS backend, the google/google-beta providers, and the shared locals (project, region, VPN CIDRs, GKE master range, node pool tags, machine types).

Units: vpc-network, firewall-rules, envoy-proxy-iap-ssh-firewall, application-stack/gke, alloydb, memorystore-valkey, locker, envoy-proxy, squid-proxy, bastion-host, cloud-dns, certificate-manager, artifact-registry, pubsub, iam-infraswitch-federation, and the application-stack apps (argocd, istio, hyperswitch, superposition, grafana, loki, vector, external-secrets-operator, gateway-controller, cloud-cdn-sdk, hyperswitch-sdk-assets).

Modules are sourced by in-repo relative path with the // root marker, e.g. ../../../..//modules/composition/vpc-network. The marker is required because application-resources/istio references ../../composition/firewall-rules; without it Terragrunt copies only the module's own directory into its cache and that reference escapes it, failing at init.

Values are masked: GCP project number -> 000000000000; office/VPN/phantom CIDRs -> RFC 5737 documentation ranges; the named operator IAP grant -> group:platform-team@example.com; aws_account_id on the federation unit -> 123456789012.

The Squid allowlist is a short representative sample - a few well-known connector domains plus google.com/googleapis.com for connectivity checks. Enumerating every connector and sandbox endpoint the environment talks to is not something this repo should publish; operators supply the real allowlist at deploy time.

Verified: terragrunt hcl fmt clean, terragrunt hcl validate passes, and terragrunt init + terragrunt validate (real terraform validate) pass for all 26 units. Validation ran with the backend temporarily pointed at local so dependency mocks resolve without cloud credentials; the committed root.hcl keeps the GCS backend.

Not apply-ready as-is. terraform validate is offline and does not exercise the masked values. Before applying, substitute at minimum: project_number (feeds the service-<num>@https-lb.iam.gserviceaccount.com IAM member on hyperswitch-sdk-assets), bastion_iap_members (Terraform fails the whole apply on an IAM binding to a principal that does not resolve), vpn_cidr_blocks (documentation ranges will lock real operators out of the GKE control plane), and aws_account_id.