### PR TITLE
feat: add cluster-autoscaler application-resources module

### DIFF
--- a/terraform/aws/modules/application-resources/cluster-autoscaler/README.md
+++ b/terraform/aws/modules/application-resources/cluster-autoscaler/README.md
@@ -1,0 +1,2 @@
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->

--- a/terraform/aws/modules/application-resources/cluster-autoscaler/README.md
+++ b/terraform/aws/modules/application-resources/cluster-autoscaler/README.md
@@ -1,2 +1,59 @@
 <!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.additional](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_eks_cluster.eks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
+| [aws_iam_openid_connect_provider.eks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_openid_connect_provider) | data source |
+| [aws_iam_policy_document.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_policy_arns"></a> [additional\_policy\_arns](#input\_additional\_policy\_arns) | Additional IAM policy ARNs to attach to the role | `list(string)` | `[]` | no |
+| <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | Common tags to apply to all resources | `map(string)` | `{}` | no |
+| <a name="input_eks_cluster_name"></a> [eks\_cluster\_name](#input\_eks\_cluster\_name) | Name of the EKS cluster the Cluster Autoscaler scales | `string` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (e.g., sandbox, integ, prod) | `string` | n/a | yes |
+| <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum session duration (in seconds) for the IAM role | `number` | `3600` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace the Cluster Autoscaler is deployed into | `string` | `"kube-system"` | no |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name for resource naming and tagging | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | AWS region | `string` | n/a | yes |
+| <a name="input_role_description"></a> [role\_description](#input\_role\_description) | Description of the IAM role | `string` | `"IAM role for the Cluster Autoscaler (IRSA)"` | no |
+| <a name="input_role_name"></a> [role\_name](#input\_role\_name) | Name of the IAM role. Defaults to <environment>-<project\_name>-cluster-autoscaler when null. | `string` | `null` | no |
+| <a name="input_role_path"></a> [role\_path](#input\_role\_path) | Path for the IAM role and policy | `string` | `"/"` | no |
+| <a name="input_service_account_name"></a> [service\_account\_name](#input\_service\_account\_name) | Name of the Cluster Autoscaler service account the IAM role is scoped to. Must match the service account created by the Helm chart deployed via ArgoCD. | `string` | `"cluster-autoscaler"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_namespace"></a> [namespace](#output\_namespace) | Namespace the Cluster Autoscaler is deployed into |
+| <a name="output_policy_arn"></a> [policy\_arn](#output\_policy\_arn) | ARN of the Cluster Autoscaler IAM policy |
+| <a name="output_region"></a> [region](#output\_region) | AWS region where resources are created |
+| <a name="output_role_arn"></a> [role\_arn](#output\_role\_arn) | ARN of the Cluster Autoscaler IAM role, consumed by the Helm chart service account annotation |
+| <a name="output_role_name"></a> [role\_name](#output\_role\_name) | Name of the Cluster Autoscaler IAM role |
+| <a name="output_service_account_name"></a> [service\_account\_name](#output\_service\_account\_name) | Name of the service account the IAM role is scoped to |
 <!-- END_TF_DOCS -->

--- a/terraform/aws/modules/application-resources/cluster-autoscaler/data.tf
+++ b/terraform/aws/modules/application-resources/cluster-autoscaler/data.tf
@@ -1,0 +1,14 @@
+# ============================================================================
+# Data Sources
+# ============================================================================
+
+data "aws_region" "current" {}
+
+data "aws_eks_cluster" "eks" {
+  name = var.eks_cluster_name
+}
+
+# OIDC provider of the EKS cluster, used for the IRSA trust relationship.
+data "aws_iam_openid_connect_provider" "eks" {
+  url = data.aws_eks_cluster.eks.identity[0].oidc[0].issuer
+}

--- a/terraform/aws/modules/application-resources/cluster-autoscaler/locals.tf
+++ b/terraform/aws/modules/application-resources/cluster-autoscaler/locals.tf
@@ -1,0 +1,20 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}-cluster-autoscaler"
+
+  common_tags = merge(
+    {
+      "Environment" = var.environment
+      "Project"     = var.project_name
+      "Component"   = "cluster-autoscaler"
+      "ManagedBy"   = "terraform"
+    },
+    var.common_tags
+  )
+
+  role_name = coalesce(var.role_name, "${local.name_prefix}")
+
+  # Service account the IRSA trust policy is scoped to. The Kubernetes side of
+  # this (ServiceAccount, RBAC, Deployment) is managed by ArgoCD via the
+  # upstream cluster-autoscaler Helm chart.
+  service_account_subject = "system:serviceaccount:${var.namespace}:${var.service_account_name}"
+}

--- a/terraform/aws/modules/application-resources/cluster-autoscaler/main.tf
+++ b/terraform/aws/modules/application-resources/cluster-autoscaler/main.tf
@@ -1,0 +1,99 @@
+# ============================================================================
+# IAM - ROLE (IRSA)
+# ============================================================================
+# Trust policy scoped to the cluster-autoscaler ServiceAccount. The workload
+# itself is deployed by ArgoCD using the upstream cluster-autoscaler Helm
+# chart, which annotates its ServiceAccount with this role ARN.
+resource "aws_iam_role" "this" {
+  name                 = local.role_name
+  description          = var.role_description
+  path                 = var.role_path
+  max_session_duration = var.max_session_duration
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = data.aws_iam_openid_connect_provider.eks.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${data.aws_iam_openid_connect_provider.eks.url}:aud" = "sts.amazonaws.com"
+            "${data.aws_iam_openid_connect_provider.eks.url}:sub" = local.service_account_subject
+          }
+        }
+      }
+    ]
+  })
+
+  tags = local.common_tags
+}
+
+# ============================================================================
+# IAM - CLUSTER AUTOSCALER POLICY
+# ============================================================================
+# Discovery permissions are cluster-wide, while the scaling actions are
+# restricted to Auto Scaling groups tagged for this cluster.
+data "aws_iam_policy_document" "cluster_autoscaler" {
+  statement {
+    sid    = "ClusterAutoscalerDiscovery"
+    effect = "Allow"
+    actions = [
+      "autoscaling:DescribeAutoScalingGroups",
+      "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeScalingActivities",
+      "autoscaling:DescribeTags",
+      "ec2:DescribeImages",
+      "ec2:DescribeInstanceTypes",
+      "ec2:DescribeLaunchTemplateVersions",
+      "ec2:GetInstanceTypesFromInstanceRequirements",
+      "eks:DescribeNodegroup"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "ClusterAutoscalerScaling"
+    effect = "Allow"
+    actions = [
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:TerminateInstanceInAutoScalingGroup",
+      "autoscaling:UpdateAutoScalingGroup"
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/${var.eks_cluster_name}"
+      values   = ["owned"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "cluster_autoscaler" {
+  name        = "${local.name_prefix}-policy"
+  description = "Permissions for the Cluster Autoscaler to scale node groups of ${var.eks_cluster_name}"
+  path        = var.role_path
+  policy      = data.aws_iam_policy_document.cluster_autoscaler.json
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_autoscaler" {
+  role       = aws_iam_role.this.name
+  policy_arn = aws_iam_policy.cluster_autoscaler.arn
+}
+
+# ============================================================================
+# IAM - ADDITIONAL POLICY ATTACHMENTS
+# ============================================================================
+resource "aws_iam_role_policy_attachment" "additional" {
+  for_each = toset(var.additional_policy_arns)
+
+  role       = aws_iam_role.this.name
+  policy_arn = each.value
+}

--- a/terraform/aws/modules/application-resources/cluster-autoscaler/outputs.tf
+++ b/terraform/aws/modules/application-resources/cluster-autoscaler/outputs.tf
@@ -1,0 +1,33 @@
+# ============================================================================
+# Outputs
+# ============================================================================
+
+output "role_arn" {
+  description = "ARN of the Cluster Autoscaler IAM role, consumed by the Helm chart service account annotation"
+  value       = aws_iam_role.this.arn
+}
+
+output "role_name" {
+  description = "Name of the Cluster Autoscaler IAM role"
+  value       = aws_iam_role.this.name
+}
+
+output "policy_arn" {
+  description = "ARN of the Cluster Autoscaler IAM policy"
+  value       = aws_iam_policy.cluster_autoscaler.arn
+}
+
+output "service_account_name" {
+  description = "Name of the service account the IAM role is scoped to"
+  value       = var.service_account_name
+}
+
+output "namespace" {
+  description = "Namespace the Cluster Autoscaler is deployed into"
+  value       = var.namespace
+}
+
+output "region" {
+  description = "AWS region where resources are created"
+  value       = data.aws_region.current.region
+}

--- a/terraform/aws/modules/application-resources/cluster-autoscaler/variables.tf
+++ b/terraform/aws/modules/application-resources/cluster-autoscaler/variables.tf
@@ -1,0 +1,79 @@
+# ============================================================================
+# Environment & Project Configuration
+# ============================================================================
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (e.g., sandbox, integ, prod)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for resource naming and tagging"
+  type        = string
+}
+
+variable "eks_cluster_name" {
+  description = "Name of the EKS cluster the Cluster Autoscaler scales"
+  type        = string
+}
+
+# ============================================================================
+# Service Account Configuration
+# ============================================================================
+variable "namespace" {
+  description = "Namespace the Cluster Autoscaler is deployed into"
+  type        = string
+  default     = "kube-system"
+}
+
+variable "service_account_name" {
+  description = "Name of the Cluster Autoscaler service account the IAM role is scoped to. Must match the service account created by the Helm chart deployed via ArgoCD."
+  type        = string
+  default     = "cluster-autoscaler"
+}
+
+# ============================================================================
+# IAM Role Configuration
+# ============================================================================
+variable "role_name" {
+  description = "Name of the IAM role. Defaults to <environment>-<project_name>-cluster-autoscaler when null."
+  type        = string
+  default     = null
+}
+
+variable "role_description" {
+  description = "Description of the IAM role"
+  type        = string
+  default     = "IAM role for the Cluster Autoscaler (IRSA)"
+}
+
+variable "role_path" {
+  description = "Path for the IAM role and policy"
+  type        = string
+  default     = "/"
+}
+
+variable "max_session_duration" {
+  description = "Maximum session duration (in seconds) for the IAM role"
+  type        = number
+  default     = 3600
+}
+
+variable "additional_policy_arns" {
+  description = "Additional IAM policy ARNs to attach to the role"
+  type        = list(string)
+  default     = []
+}
+
+# ============================================================================
+# Tags
+# ============================================================================
+variable "common_tags" {
+  description = "Common tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/aws/modules/application-resources/cluster-autoscaler/versions.tf
+++ b/terraform/aws/modules/application-resources/cluster-autoscaler/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds a `cluster-autoscaler` module under `terraform/aws/modules/application-resources/`, which provisions the IAM role the Cluster Autoscaler assumes through IRSA.

The intent is to let the Cluster Autoscaler be deployed by ArgoCD using the [upstream Helm chart](https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler), leaving only the IAM to terraform. Today the equivalent resources are created by the `eks-kubernetes-resources` composition, which builds the ServiceAccount, RBAC and Deployment with the kubernetes provider and additionally manages an ECR repository and a docker-based image sync.

## Details

- Trust policy is scoped to one service account, defaulting to `cluster-autoscaler` in `kube-system`. This must match the service account the Helm chart creates, since the chart annotates it with the exported `role_arn`.
- The attached policy follows the upstream reference: discovery actions (`Describe*`) are cluster wide, while the scaling actions (`SetDesiredCapacity`, `TerminateInstanceInAutoScalingGroup`, `UpdateAutoScalingGroup`) are restricted by an `autoscaling:ResourceTag/k8s.io/cluster-autoscaler/<cluster>` = `owned` condition, so one cluster's autoscaler cannot resize another's node groups.
- Layout follows the `alb-controller` module: `data.tf` / `locals.tf` / `main.tf` / `outputs.tf` / `variables.tf` / `versions.tf`, with a `README.md` stub for terraform-docs to fill.
- No ECR resources and no Kubernetes resources.

## Notes

- `role_name` defaults to `<environment>-<project_name>-cluster-autoscaler` and can be overridden.
- `additional_policy_arns` is available for clusters that need extra permissions.
- Nothing in this repository references the module yet, so this is additive only and no existing plan changes.

## Testing

`terraform validate` and `terraform fmt -check` pass. Rendered against the upstream chart, the resulting deployment matches what `eks-kubernetes-resources` produces today: same image, auto-discovery tags, expander, `balance-similar-node-groups`, skip flags, resources and node selector.