### PR TITLE
feat: add hyperswitch-ucs application-resources module

### DIFF
--- a/terraform/aws/ARCHITECTURE.md
+++ b/terraform/aws/ARCHITECTURE.md
@@ -107,6 +107,7 @@ Application-specific resources that run on top of EKS. May require Kubernetes cl
 | `eks-iam/` | EKS IAM roles for service accounts (IRSA) |
 | `external-secrets-operator/` | External Secrets Operator deployment |
 | `hyperswitch/` | Hyperswitch application resources (S3, KMS, IAM) |
+| `hyperswitch-ucs/` | Hyperswitch UCS (Unified Connector Service) application resources (IAM/IRSA, Secrets Manager) |
 | `istio/` | Istio service mesh deployment |
 | `shared-policy/` | Shared IAM policies across services |
 

--- a/terraform/aws/catalog/units/application-stack/apps/hyperswitch-ucs/terragrunt.hcl
+++ b/terraform/aws/catalog/units/application-stack/apps/hyperswitch-ucs/terragrunt.hcl
@@ -1,0 +1,55 @@
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+terraform {
+  source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/aws/modules/application-resources/hyperswitch-ucs?ref=apps-hyperswitch-ucs-v0.1.0"
+}
+
+dependency "eks" {
+  config_path = "../../eks-01"
+
+  mock_outputs = {
+    cluster_name = "mock-cluster"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+inputs = {
+  region       = include.root.locals.region
+  environment  = include.root.locals.environment.full
+  project_name = include.root.locals.project_name
+  app_name     = "ucs"
+
+  # OIDC/IRSA Configuration. The hyperswitch-ucs chart names the service
+  # account after the release (<release>-hyperswitch-ucs) unless
+  # serviceAccount.name is set; pass the name the deployment actually uses.
+  cluster_service_accounts = {
+    "${dependency.eks.outputs.cluster_name}" = [
+      {
+        namespace = try(values.kubernetes_namespace, "hyperswitch")
+        name      = try(values.service_account_name, "hyperswitch-ucs")
+      }
+    ]
+  }
+
+  assume_role_principals   = []
+  aws_managed_policy_names = []
+
+  # Secrets Manager: the chart's External Secrets Operator resources
+  # authenticate as the service account above and read these secrets
+  # (e.g. the Superposition API token). Disabled when no ARNs are given.
+  secrets_manager = {
+    enabled     = length(try(values.secrets_manager_secret_arns, [])) > 0
+    secret_arns = try(values.secrets_manager_secret_arns, [])
+  }
+
+  tags = {
+    Project     = include.root.locals.project_name
+    Environment = include.root.locals.environment.full
+    Component   = "hyperswitch-ucs"
+    ManagedBy   = "terraform-IaC"
+    Region      = include.root.locals.region
+  }
+}

--- a/terraform/aws/modules/application-resources/hyperswitch-ucs/README.md
+++ b/terraform/aws/modules/application-resources/hyperswitch-ucs/README.md
@@ -1,0 +1,72 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy.secrets_manager_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.inline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.aws_managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.customer_managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.secrets_manager_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_eks_cluster.eks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
+| [aws_iam_openid_connect_provider.oidc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_openid_connect_provider) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_additional_assume_role_statements"></a> [additional\_assume\_role\_statements](#input\_additional\_assume\_role\_statements) | Additional IAM assume role policy statements to append | `list(any)` | `[]` | no |
+| <a name="input_app_name"></a> [app\_name](#input\_app\_name) | Application name, used in resource names (the role is named {environment}-{project}-{app}-role) | `string` | `"ucs"` | no |
+| <a name="input_assume_role_principals"></a> [assume\_role\_principals](#input\_assume\_role\_principals) | List of AWS principal ARNs allowed to assume this role (e.g., ['arn:aws:iam::123456789012:root']) | `list(string)` | `[]` | no |
+| <a name="input_aws_managed_policy_names"></a> [aws\_managed\_policy\_names](#input\_aws\_managed\_policy\_names) | List of AWS managed policy names to attach | `list(string)` | `[]` | no |
+| <a name="input_cluster_service_accounts"></a> [cluster\_service\_accounts](#input\_cluster\_service\_accounts) | Map of EKS cluster names to their respective list of Kubernetes service accounts (namespace and service account name) allowed to assume the role via IRSA | <pre>map(list(object({<br/>    namespace = string<br/>    name      = string<br/>  })))</pre> | `{}` | no |
+| <a name="input_customer_managed_policy_arns"></a> [customer\_managed\_policy\_arns](#input\_customer\_managed\_policy\_arns) | List of customer managed policy ARNs to attach | `list(string)` | `[]` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (e.g., sandbox, dev, prod) | `string` | n/a | yes |
+| <a name="input_force_detach_policies"></a> [force\_detach\_policies](#input\_force\_detach\_policies) | Whether to force detaching policies when destroying the role | `bool` | `true` | no |
+| <a name="input_inline_policies"></a> [inline\_policies](#input\_inline\_policies) | Map of inline policy names to JSON policy documents to attach to the role | `map(string)` | `{}` | no |
+| <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum session duration for the role (in seconds) | `number` | `3600` | no |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name for resource naming and tagging | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | AWS region | `string` | `null` | no |
+| <a name="input_role_description"></a> [role\_description](#input\_role\_description) | Custom IAM role description | `string` | `null` | no |
+| <a name="input_role_name"></a> [role\_name](#input\_role\_name) | Custom IAM role name. If null, auto-generated as {environment}-{project}-{app}-role | `string` | `null` | no |
+| <a name="input_role_path"></a> [role\_path](#input\_role\_path) | IAM role path | `string` | `"/"` | no |
+| <a name="input_secrets_manager"></a> [secrets\_manager](#input\_secrets\_manager) | Secrets Manager configuration. Set to {} to disable Secrets Manager policy. | <pre>object({<br/>    enabled     = optional(bool, false)<br/>    secret_arns = optional(list(string), [])<br/>  })</pre> | `{}` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Common tags to apply to all resources | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_account_id"></a> [account\_id](#output\_account\_id) | AWS account ID |
+| <a name="output_assume_role_principals_enabled"></a> [assume\_role\_principals\_enabled](#output\_assume\_role\_principals\_enabled) | Whether assume role principals feature is enabled |
+| <a name="output_aws_managed_policies_enabled"></a> [aws\_managed\_policies\_enabled](#output\_aws\_managed\_policies\_enabled) | Whether AWS managed policy attachments feature is enabled |
+| <a name="output_customer_managed_policies_enabled"></a> [customer\_managed\_policies\_enabled](#output\_customer\_managed\_policies\_enabled) | Whether customer managed policy attachments feature is enabled |
+| <a name="output_inline_policies_enabled"></a> [inline\_policies\_enabled](#output\_inline\_policies\_enabled) | Whether inline policies feature is enabled |
+| <a name="output_oidc_enabled"></a> [oidc\_enabled](#output\_oidc\_enabled) | Whether OIDC/IRSA feature is enabled |
+| <a name="output_region"></a> [region](#output\_region) | AWS region where resources are created |
+| <a name="output_role_arn"></a> [role\_arn](#output\_role\_arn) | ARN of the IAM role for the UCS application (annotate the UCS service account with it) |
+| <a name="output_role_id"></a> [role\_id](#output\_role\_id) | ID of the IAM role for the UCS application |
+| <a name="output_role_name"></a> [role\_name](#output\_role\_name) | Name of the IAM role for the UCS application |
+| <a name="output_secrets_manager_enabled"></a> [secrets\_manager\_enabled](#output\_secrets\_manager\_enabled) | Whether the Secrets Manager policy is enabled |
+| <a name="output_secrets_manager_policy_arn"></a> [secrets\_manager\_policy\_arn](#output\_secrets\_manager\_policy\_arn) | ARN of the Secrets Manager IAM policy attached to the UCS role (if enabled) |
+<!-- END_TF_DOCS -->

--- a/terraform/aws/modules/application-resources/hyperswitch-ucs/data.tf
+++ b/terraform/aws/modules/application-resources/hyperswitch-ucs/data.tf
@@ -1,0 +1,19 @@
+# =========================================================================
+# DATA SOURCES
+# =========================================================================
+
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+# EKS Cluster data for OIDC
+# =========================================================================
+data "aws_eks_cluster" "eks" {
+  for_each = var.cluster_service_accounts
+  name     = each.key
+}
+
+data "aws_iam_openid_connect_provider" "oidc" {
+  for_each = data.aws_eks_cluster.eks
+  url      = each.value.identity[0].oidc[0].issuer
+}

--- a/terraform/aws/modules/application-resources/hyperswitch-ucs/locals.tf
+++ b/terraform/aws/modules/application-resources/hyperswitch-ucs/locals.tf
@@ -1,0 +1,51 @@
+locals {
+  name_prefix = "${var.environment}-${var.project_name}-${var.app_name}"
+
+  common_tags = merge(
+    {
+      "Environment" = var.environment
+      "Project"     = var.project_name
+      "Application" = var.app_name
+      "Service"     = "Hyperswitch UCS (Unified Connector Service)"
+      "ManagedBy"   = "terraform"
+    },
+    var.region != null ? { "Region" = var.region } : {},
+    var.tags
+  )
+
+  # =========================================================================
+  # Feature Enablement Flags
+  # =========================================================================
+
+  # OIDC/IRSA feature
+  oidc_enabled = length(var.cluster_service_accounts) > 0
+
+  # Assume role principals feature
+  assume_role_principals_enabled = length(var.assume_role_principals) > 0
+
+  # AWS managed policies feature
+  aws_managed_policies_enabled = length(var.aws_managed_policy_names) > 0
+
+  # Customer managed policies feature
+  customer_managed_policies_enabled = length(var.customer_managed_policy_arns) > 0
+
+  # Inline policies feature
+  inline_policies_enabled = length(var.inline_policies) > 0
+
+  # Secrets Manager feature
+  secrets_manager_enabled = try(var.secrets_manager.enabled, false) && length(try(var.secrets_manager.secret_arns, [])) > 0
+  secrets_manager_arns    = local.secrets_manager_enabled ? var.secrets_manager.secret_arns : []
+
+  # =========================================================================
+  # OIDC Configuration
+  # =========================================================================
+  cluster_oidc_statements = {
+    for cluster_name, service_accounts in var.cluster_service_accounts : cluster_name => {
+      oidc_arn = data.aws_iam_openid_connect_provider.oidc[cluster_name].arn
+      oidc_url = data.aws_iam_openid_connect_provider.oidc[cluster_name].url
+      subjects = [
+        for sa in service_accounts : "system:serviceaccount:${sa.namespace}:${sa.name}"
+      ]
+    }
+  }
+}

--- a/terraform/aws/modules/application-resources/hyperswitch-ucs/main.tf
+++ b/terraform/aws/modules/application-resources/hyperswitch-ucs/main.tf
@@ -1,0 +1,120 @@
+# =========================================================================
+# Hyperswitch UCS (Unified Connector Service) application resources.
+#
+# The IAM role the UCS pods run as, following the router pattern: the
+# hyperswitch-ucs Helm chart's External Secrets Operator resources
+# authenticate as the UCS service account, and this role lets the operator
+# read the UCS secrets (e.g. the Superposition API token) from Secrets
+# Manager. UCS keeps no other AWS state, so there is no KMS key, bucket or
+# SES access here; generic policy hooks cover anything environment-specific.
+# =========================================================================
+
+# =========================================================================
+# IAM - ROLE
+# =========================================================================
+resource "aws_iam_role" "this" {
+  name                  = var.role_name != null ? var.role_name : "${local.name_prefix}-role"
+  description           = var.role_description != null ? var.role_description : "IAM role for ${title(var.project_name)} ${title(var.environment)} UCS (Unified Connector Service)"
+  path                  = var.role_path
+  max_session_duration  = var.max_session_duration
+  force_detach_policies = var.force_detach_policies
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat(
+      # OIDC trust relationships for EKS IRSA
+      [
+        for cluster_name, statement in local.cluster_oidc_statements : {
+          Effect = "Allow"
+          Principal = {
+            Federated = statement.oidc_arn
+          }
+          Action = "sts:AssumeRoleWithWebIdentity"
+          Condition = {
+            StringEquals = {
+              "${statement.oidc_url}:aud" = "sts.amazonaws.com"
+              "${statement.oidc_url}:sub" = statement.subjects
+            }
+          }
+        }
+      ],
+      # Additional AWS principal trust relationships
+      local.assume_role_principals_enabled ? [
+        {
+          Effect = "Allow"
+          Principal = {
+            AWS = var.assume_role_principals
+          }
+          Action = "sts:AssumeRole"
+        }
+      ] : [],
+      # Additional custom trust statements
+      var.additional_assume_role_statements
+    )
+  })
+
+  tags = local.common_tags
+}
+
+# =========================================================================
+# IAM - AWS MANAGED POLICY ATTACHMENTS
+# =========================================================================
+resource "aws_iam_role_policy_attachment" "aws_managed" {
+  for_each = local.aws_managed_policies_enabled ? toset(var.aws_managed_policy_names) : toset([])
+
+  role       = aws_iam_role.this.name
+  policy_arn = "arn:aws:iam::aws:policy/${each.value}"
+}
+
+# =========================================================================
+# IAM - CUSTOMER MANAGED POLICY ATTACHMENTS
+# =========================================================================
+resource "aws_iam_role_policy_attachment" "customer_managed" {
+  for_each = local.customer_managed_policies_enabled ? toset(var.customer_managed_policy_arns) : toset([])
+
+  role       = aws_iam_role.this.name
+  policy_arn = each.value
+}
+
+# =========================================================================
+# IAM - INLINE POLICIES
+# =========================================================================
+resource "aws_iam_role_policy" "inline" {
+  for_each = local.inline_policies_enabled ? var.inline_policies : {}
+
+  name   = each.key
+  role   = aws_iam_role.this.name
+  policy = each.value
+}
+
+# =========================================================================
+# IAM - SECRETS MANAGER POLICY
+# =========================================================================
+resource "aws_iam_policy" "secrets_manager_policy" {
+  count = local.secrets_manager_enabled ? 1 : 0
+
+  name = "${local.name_prefix}-secrets-policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowSecretsManagerAccess"
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret"
+        ]
+        Resource = local.secrets_manager_arns
+      }
+    ]
+  })
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "secrets_manager_policy_attachment" {
+  count = local.secrets_manager_enabled ? 1 : 0
+
+  role       = aws_iam_role.this.name
+  policy_arn = aws_iam_policy.secrets_manager_policy[0].arn
+}

--- a/terraform/aws/modules/application-resources/hyperswitch-ucs/outputs.tf
+++ b/terraform/aws/modules/application-resources/hyperswitch-ucs/outputs.tf
@@ -1,0 +1,71 @@
+# =========================================================================
+# GENERAL OUTPUTS
+# =========================================================================
+output "region" {
+  description = "AWS region where resources are created"
+  value       = data.aws_region.current.region
+}
+
+output "account_id" {
+  description = "AWS account ID"
+  value       = data.aws_caller_identity.current.account_id
+}
+
+# =========================================================================
+# IAM ROLE OUTPUTS
+# =========================================================================
+output "role_arn" {
+  description = "ARN of the IAM role for the UCS application (annotate the UCS service account with it)"
+  value       = aws_iam_role.this.arn
+}
+
+output "role_name" {
+  description = "Name of the IAM role for the UCS application"
+  value       = aws_iam_role.this.name
+}
+
+output "role_id" {
+  description = "ID of the IAM role for the UCS application"
+  value       = aws_iam_role.this.id
+}
+
+# =========================================================================
+# FEATURE ENABLEMENT OUTPUTS
+# =========================================================================
+output "oidc_enabled" {
+  description = "Whether OIDC/IRSA feature is enabled"
+  value       = local.oidc_enabled
+}
+
+output "assume_role_principals_enabled" {
+  description = "Whether assume role principals feature is enabled"
+  value       = local.assume_role_principals_enabled
+}
+
+output "aws_managed_policies_enabled" {
+  description = "Whether AWS managed policy attachments feature is enabled"
+  value       = local.aws_managed_policies_enabled
+}
+
+output "customer_managed_policies_enabled" {
+  description = "Whether customer managed policy attachments feature is enabled"
+  value       = local.customer_managed_policies_enabled
+}
+
+output "inline_policies_enabled" {
+  description = "Whether inline policies feature is enabled"
+  value       = local.inline_policies_enabled
+}
+
+output "secrets_manager_enabled" {
+  description = "Whether the Secrets Manager policy is enabled"
+  value       = local.secrets_manager_enabled
+}
+
+# =========================================================================
+# SECRETS MANAGER IAM POLICY OUTPUTS
+# =========================================================================
+output "secrets_manager_policy_arn" {
+  description = "ARN of the Secrets Manager IAM policy attached to the UCS role (if enabled)"
+  value       = local.secrets_manager_enabled ? aws_iam_policy.secrets_manager_policy[0].arn : null
+}

--- a/terraform/aws/modules/application-resources/hyperswitch-ucs/variables.tf
+++ b/terraform/aws/modules/application-resources/hyperswitch-ucs/variables.tf
@@ -1,0 +1,133 @@
+variable "environment" {
+  description = "Environment name (e.g., sandbox, dev, prod)"
+  type        = string
+}
+
+variable "project_name" {
+  description = "Project name for resource naming and tagging"
+  type        = string
+}
+
+variable "app_name" {
+  description = "Application name, used in resource names (the role is named {environment}-{project}-{app}-role)"
+  type        = string
+  default     = "ucs"
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "Common tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+# =========================================================================
+# EKS OIDC Configuration
+# =========================================================================
+
+variable "cluster_service_accounts" {
+  description = "Map of EKS cluster names to their respective list of Kubernetes service accounts (namespace and service account name) allowed to assume the role via IRSA"
+  type = map(list(object({
+    namespace = string
+    name      = string
+  })))
+  default = {}
+}
+
+variable "additional_assume_role_statements" {
+  description = "Additional IAM assume role policy statements to append"
+  type        = list(any)
+  default     = []
+}
+
+# =========================================================================
+# IAM Role Configuration
+# =========================================================================
+
+variable "role_name" {
+  description = "Custom IAM role name. If null, auto-generated as {environment}-{project}-{app}-role"
+  type        = string
+  default     = null
+}
+
+variable "role_description" {
+  description = "Custom IAM role description"
+  type        = string
+  default     = null
+}
+
+variable "role_path" {
+  description = "IAM role path"
+  type        = string
+  default     = "/"
+}
+
+variable "max_session_duration" {
+  description = "Maximum session duration for the role (in seconds)"
+  type        = number
+  default     = 3600
+}
+
+variable "force_detach_policies" {
+  description = "Whether to force detaching policies when destroying the role"
+  type        = bool
+  default     = true
+}
+
+# =========================================================================
+# Assume Role Principals
+# =========================================================================
+
+variable "assume_role_principals" {
+  description = "List of AWS principal ARNs allowed to assume this role (e.g., ['arn:aws:iam::123456789012:root'])"
+  type        = list(string)
+  default     = []
+}
+
+# =========================================================================
+# Policy Attachments
+# =========================================================================
+
+variable "aws_managed_policy_names" {
+  description = "List of AWS managed policy names to attach"
+  type        = list(string)
+  default     = []
+}
+
+variable "customer_managed_policy_arns" {
+  description = "List of customer managed policy ARNs to attach"
+  type        = list(string)
+  default     = []
+}
+
+# =========================================================================
+# Inline Policies
+# =========================================================================
+
+variable "inline_policies" {
+  description = "Map of inline policy names to JSON policy documents to attach to the role"
+  type        = map(string)
+  default     = {}
+}
+
+# =========================================================================
+# Feature: Secrets Manager
+# =========================================================================
+# Set to {} to disable the Secrets Manager policy. The hyperswitch-ucs Helm
+# chart's External Secrets Operator resources authenticate as the UCS service
+# account, so the role needs read access to the secrets they materialise
+# (e.g. the Superposition API token).
+
+variable "secrets_manager" {
+  description = "Secrets Manager configuration. Set to {} to disable Secrets Manager policy."
+  type = object({
+    enabled     = optional(bool, false)
+    secret_arns = optional(list(string), [])
+  })
+  default = {}
+}

--- a/terraform/aws/modules/application-resources/hyperswitch-ucs/versions.tf
+++ b/terraform/aws/modules/application-resources/hyperswitch-ucs/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds the application-resources module for **Hyperswitch UCS (Unified Connector Service)**: the IAM role the UCS pods run as via IRSA, plus a Secrets Manager read policy, following the same pattern as the `hyperswitch` and `decision-engine` modules.

The `hyperswitch-ucs` Helm chart (juspay/hyperswitch-helm#341, chart 0.1.9) now supports `_secretRef` config values and External Secrets Operator resources, mirroring `hyperswitch-app`. Its SecretStore authenticates as the UCS service account, so that service account needs a role that can read the UCS secrets from Secrets Manager (first use: the Superposition API token). This module provides that role, so deployments can consume it by tag exactly the way they consume `application-resources/hyperswitch`.

## Changes

- `terraform/aws/modules/application-resources/hyperswitch-ucs/`
  - IAM role with OIDC trust built from `cluster_service_accounts`, optional `assume_role_principals` and `additional_assume_role_statements`; `role_name` / `role_description` / `role_path` / `max_session_duration` / `force_detach_policies` overrides (same interface as `decision-engine`).
  - Generic policy hooks: `aws_managed_policy_names`, `customer_managed_policy_arns`, `inline_policies`.
  - `secrets_manager = { enabled, secret_arns }` (same object as the `hyperswitch` module) → `secretsmanager:GetSecretValue` / `DescribeSecret` policy and attachment.
  - `app_name` defaults to `ucs`, so the role is `{env}-{project}-ucs-role`.
  - No KMS key, bucket, SES or Lambda access: UCS keeps no other AWS state. If UCS gains a KMS decrypt path later, a `kms` block can be added the way `hyperswitch` has it.
  - README generated with terraform-docs (repo config).
- `terraform/aws/catalog/units/application-stack/apps/hyperswitch-ucs/terragrunt.hcl`: catalog unit wrapping the module by tag, `eks-01` dependency with mock outputs, `values.kubernetes_namespace` / `values.service_account_name` / `values.secrets_manager_secret_arns` with generic defaults. Not added to the dev stack yet.
- `terraform/aws/ARCHITECTURE.md`: table row for the new module.

## After merge

Tags to create from the merge commit, per the repo conventions:

- `apps-hyperswitch-ucs-v0.1.0` (module; the unit pins this ref)
- `unit/aws/hyperswitch-ucs-v0.1.0-v1` (catalog unit)

## Testing

Run locally with the same tools CI uses:

- `terraform fmt -check`, `terraform init -backend=false && terraform validate` (terraform 1.9): clean.
- `tflint` (built-in rules, no config, as in CI): no issues.
- `terragrunt hcl format --check` on the catalog unit: clean.
- `terraform-docs` with `terraform/aws/modules/.terraform-docs.yml`: README committed, so the docs workflow has nothing to push.
- `scripts/ci/check-sensitive.sh`: no hits.
