### PR TITLE
feat(gcp): add iam-infraswitch-federation catalog unit

### DIFF
--- a/terraform/gcp/catalog/README.md
+++ b/terraform/gcp/catalog/README.md
@@ -13,7 +13,7 @@ terraform/gcp/catalog/
                   # full unit set
 ```
 
-18 units. This mirrors the AWS catalog in
+19 units. This mirrors the AWS catalog in
 [PR #302](https://github.com/juspay/hyperswitch-suite/pull/302) — same unit
 skeleton, same tag-pinning discipline.
 
@@ -86,8 +86,8 @@ application-stack/apps/<name>    -> ../../gke, ../../../vpc-network
 
 ## Scope
 
-A unit exists here only if its module is published on `main`. All 18 pins
-resolve to existing tags — `scripts/ci/check-gcp-pins.sh` enforces it.
+A unit exists here only if its module is published on `main`. All 19 module
+pins resolve to existing tags — `scripts/ci/check-gcp-pins.sh` enforces it.
 
 | Excluded | Why |
 |---|---|
@@ -101,6 +101,7 @@ resolve to existing tags — `scripts/ci/check-gcp-pins.sh` enforces it.
 
 | Unit | Module | Tag |
 |---|---|---|
+| `iam-infraswitch-federation` | `application-resources/infraswitch-gcp-federation` | `gcp-apps-infraswitch-gcp-federation-v0.1.0` |
 | `vpc-network` | `composition/vpc-network` | `gcp-vpc-network-v0.1.0` |
 | `alloydb` | `composition/alloydb` | `gcp-alloydb-v0.1.0` |
 | `memorystore-valkey` | `composition/memorystore-valkey` | `gcp-memorystore-valkey-v0.1.0` |

--- a/terraform/gcp/catalog/units/alloydb/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/alloydb/terragrunt.hcl
@@ -77,10 +77,10 @@ inputs = merge({
   # it — the same constraint gke's deletion_protection has.
   deletion_protection = try(values.alloydb.deletion_protection, true)
 
-  labels = {
+  labels = merge({
     environment = include.root.locals.environment.short
     project     = include.root.locals.project_name
     component   = "database"
     managed_by  = "terraform"
-  }
+  }, try(values.common_labels, {}))
 }, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/alloydb/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/alloydb/terragrunt.hcl
@@ -33,7 +33,7 @@ terraform {
   source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/composition/alloydb?ref=gcp-alloydb-v0.1.0"
 }
 
-inputs = {
+inputs = merge({
   project_id   = include.root.locals.project_id
   environment  = include.root.locals.environment.short
   project_name = include.root.locals.project_name
@@ -83,4 +83,4 @@ inputs = {
     component   = "database"
     managed_by  = "terraform"
   }
-}
+}, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/application-stack/apps/argocd/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/argocd/terragrunt.hcl
@@ -38,8 +38,8 @@ inputs = merge({
   # No cross-project deployments configured yet.
   cross_project_target_service_accounts = []
 
-  labels = {
+  labels = merge({
     environment = include.root.locals.environment.short
     managed_by  = "terraform"
-  }
+  }, try(values.common_labels, {}))
 }, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/application-stack/apps/argocd/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/argocd/terragrunt.hcl
@@ -19,7 +19,7 @@ terraform {
   source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/application-resources/argocd?ref=gcp-apps-argocd-v0.1.0"
 }
 
-inputs = {
+inputs = merge({
   project_id   = include.root.locals.project_id
   environment  = include.root.locals.environment.short
   project_name = include.root.locals.project_name
@@ -42,4 +42,4 @@ inputs = {
     environment = include.root.locals.environment.short
     managed_by  = "terraform"
   }
-}
+}, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/application-stack/apps/external-secrets-operator/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/external-secrets-operator/terragrunt.hcl
@@ -40,8 +40,8 @@ inputs = merge({
   # scope_to_project = false + explicit secret_ids for least privilege.
   scope_to_project = true
 
-  labels = {
+  labels = merge({
     environment = include.root.locals.environment.short
     managed_by  = "terraform"
-  }
+  }, try(values.common_labels, {}))
 }, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/application-stack/apps/external-secrets-operator/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/external-secrets-operator/terragrunt.hcl
@@ -20,7 +20,7 @@ terraform {
   source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/application-resources/external-secrets-operator?ref=gcp-apps-eso-v0.1.0"
 }
 
-inputs = {
+inputs = merge({
   project_id   = include.root.locals.project_id
   environment  = include.root.locals.environment.short
   project_name = include.root.locals.project_name
@@ -44,4 +44,4 @@ inputs = {
     environment = include.root.locals.environment.short
     managed_by  = "terraform"
   }
-}
+}, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/application-stack/apps/gateway-controller/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/gateway-controller/terragrunt.hcl
@@ -22,8 +22,8 @@ inputs = merge({
 
   create_service_account = false
 
-  labels = {
+  labels = merge({
     environment = include.root.locals.environment.short
     managed_by  = "terraform"
-  }
+  }, try(values.common_labels, {}))
 }, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/application-stack/apps/gateway-controller/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/gateway-controller/terragrunt.hcl
@@ -11,7 +11,7 @@ terraform {
   source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/application-resources/gateway-controller?ref=gcp-apps-gateway-controller-v0.1.0"
 }
 
-inputs = {
+inputs = merge({
   project_id   = include.root.locals.project_id
   environment  = include.root.locals.environment.short
   project_name = include.root.locals.project_name
@@ -26,4 +26,4 @@ inputs = {
     environment = include.root.locals.environment.short
     managed_by  = "terraform"
   }
-}
+}, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/application-stack/apps/grafana/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/grafana/terragrunt.hcl
@@ -28,7 +28,7 @@ terraform {
   source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/application-resources/grafana?ref=gcp-apps-grafana-v0.1.0"
 }
 
-inputs = {
+inputs = merge({
   project_id   = include.root.locals.project_id
   environment  = include.root.locals.environment.short
   project_name = include.root.locals.project_name
@@ -59,4 +59,4 @@ inputs = {
     environment = include.root.locals.environment.short
     managed_by  = "terraform"
   }
-}
+}, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/application-stack/apps/grafana/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/grafana/terragrunt.hcl
@@ -55,8 +55,8 @@ inputs = merge({
     grafana = values.domains.grafana
   }
 
-  labels = {
+  labels = merge({
     environment = include.root.locals.environment.short
     managed_by  = "terraform"
-  }
+  }, try(values.common_labels, {}))
 }, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/application-stack/apps/hyperswitch/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/hyperswitch/terragrunt.hcl
@@ -23,7 +23,7 @@ terraform {
   source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/application-resources/hyperswitch?ref=gcp-apps-hyperswitch-v0.1.0"
 }
 
-inputs = {
+inputs = merge({
   project_id   = include.root.locals.project_id
   environment  = include.root.locals.environment.short
   project_name = include.root.locals.project_name
@@ -43,7 +43,7 @@ inputs = {
 
   kms = {
     create          = true
-    location        = include.root.locals.region
+    location        = try(values.cfg.kms_location, include.root.locals.region)
     rotation_period = "7776000s" # 90 days
   }
 
@@ -78,4 +78,4 @@ inputs = {
     managed_by  = "terraform"
     component   = "hyperswitch"
   }
-}
+}, { for k, v in try(values.cfg, {}) : k => v if k != "kms_location" })

--- a/terraform/gcp/catalog/units/application-stack/apps/hyperswitch/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/hyperswitch/terragrunt.hcl
@@ -73,9 +73,9 @@ inputs = merge({
 
   additional_custom_role_ids = []
 
-  labels = {
+  labels = merge({
     environment = include.root.locals.environment.short
     managed_by  = "terraform"
     component   = "hyperswitch"
-  }
+  }, try(values.common_labels, {}))
 }, { for k, v in try(values.cfg, {}) : k => v if k != "kms_location" })

--- a/terraform/gcp/catalog/units/application-stack/apps/istio/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/istio/terragrunt.hcl
@@ -28,7 +28,7 @@ terraform {
   source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/application-resources/istio?ref=gcp-apps-istio-v0.1.0"
 }
 
-inputs = {
+inputs = merge({
   project_id   = include.root.locals.project_id
   environment  = include.root.locals.environment.short
   project_name = include.root.locals.project_name
@@ -52,4 +52,4 @@ inputs = {
     environment = include.root.locals.environment.short
     managed_by  = "terraform"
   }
-}
+}, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/application-stack/apps/istio/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/istio/terragrunt.hcl
@@ -48,8 +48,8 @@ inputs = merge({
     sandbox = [values.domains.api]
   }
 
-  labels = {
+  labels = merge({
     environment = include.root.locals.environment.short
     managed_by  = "terraform"
-  }
+  }, try(values.common_labels, {}))
 }, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/application-stack/apps/loki/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/loki/terragrunt.hcl
@@ -19,7 +19,7 @@ terraform {
   source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/application-resources/loki?ref=gcp-apps-loki-v0.1.0"
 }
 
-inputs = {
+inputs = merge({
   project_id   = include.root.locals.project_id
   environment  = include.root.locals.environment.short
   project_name = include.root.locals.project_name
@@ -41,4 +41,4 @@ inputs = {
     environment = include.root.locals.environment.short
     managed_by  = "terraform"
   }
-}
+}, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/application-stack/apps/loki/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/loki/terragrunt.hcl
@@ -37,8 +37,8 @@ inputs = merge({
 
   bucket_location = include.root.locals.region
 
-  labels = {
+  labels = merge({
     environment = include.root.locals.environment.short
     managed_by  = "terraform"
-  }
+  }, try(values.common_labels, {}))
 }, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/application-stack/apps/superposition/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/superposition/terragrunt.hcl
@@ -51,8 +51,8 @@ inputs = merge({
     tier       = "db-custom-2-8192"
   }
 
-  labels = {
+  labels = merge({
     environment = include.root.locals.environment.short
     managed_by  = "terraform"
-  }
+  }, try(values.common_labels, {}))
 }, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/application-stack/apps/superposition/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/superposition/terragrunt.hcl
@@ -28,7 +28,7 @@ terraform {
   source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/application-resources/superposition?ref=gcp-apps-superposition-v0.1.0"
 }
 
-inputs = {
+inputs = merge({
   project_id   = include.root.locals.project_id
   environment  = include.root.locals.environment.short
   project_name = include.root.locals.project_name
@@ -55,4 +55,4 @@ inputs = {
     environment = include.root.locals.environment.short
     managed_by  = "terraform"
   }
-}
+}, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/application-stack/apps/vector/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/vector/terragrunt.hcl
@@ -40,8 +40,8 @@ inputs = merge({
   # No cross-region reads configured yet (single-region setup).
   cross_region_reader_members = []
 
-  labels = {
+  labels = merge({
     environment = include.root.locals.environment.short
     managed_by  = "terraform"
-  }
+  }, try(values.common_labels, {}))
 }, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/application-stack/apps/vector/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/apps/vector/terragrunt.hcl
@@ -19,7 +19,7 @@ terraform {
   source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/application-resources/vector?ref=gcp-apps-vector-v0.1.0"
 }
 
-inputs = {
+inputs = merge({
   project_id   = include.root.locals.project_id
   environment  = include.root.locals.environment.short
   project_name = include.root.locals.project_name
@@ -44,4 +44,4 @@ inputs = {
     environment = include.root.locals.environment.short
     managed_by  = "terraform"
   }
-}
+}, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/application-stack/gke/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/gke/terragrunt.hcl
@@ -73,9 +73,9 @@ inputs = merge({
     },
   ]
 
-  labels = {
+  labels = merge({
     environment = include.root.locals.environment.short
     project     = include.root.locals.project_name
     managed_by  = "terraform"
-  }
+  }, try(values.common_labels, {}))
 }, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/application-stack/gke/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/application-stack/gke/terragrunt.hcl
@@ -7,6 +7,7 @@ dependency "vpc" {
   config_path = "../../vpc-network"
 
   mock_outputs = {
+    network_name                      = "mock-vpc"
     network_self_link                 = "projects/mock/global/networks/mock-vpc"
     gke_nodes_subnet_self_link        = "projects/mock/regions/asia-south1/subnetworks/mock-gke-nodes"
     gke_pods_secondary_range_name     = "mock-gke-pods"
@@ -19,7 +20,7 @@ terraform {
   source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/composition/gke?ref=gcp-gke-v0.1.0"
 }
 
-inputs = {
+inputs = merge({
   project_id   = include.root.locals.project_id
   environment  = include.root.locals.environment.short
   project_name = include.root.locals.project_name
@@ -28,8 +29,8 @@ inputs = {
   cluster_name = "${include.root.locals.project_name}-${include.root.locals.environment.short}-gke"
   regional     = true
 
-  network           = dependency.vpc.outputs.network_self_link
-  subnetwork        = dependency.vpc.outputs.gke_nodes_subnet_self_link
+  network           = dependency.vpc.outputs.network_name
+  subnetwork        = basename(dependency.vpc.outputs.gke_nodes_subnet_self_link)
   ip_range_pods     = dependency.vpc.outputs.gke_pods_secondary_range_name
   ip_range_services = dependency.vpc.outputs.gke_services_secondary_range_name
 
@@ -77,4 +78,4 @@ inputs = {
     project     = include.root.locals.project_name
     managed_by  = "terraform"
   }
-}
+}, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/artifact-registry/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/artifact-registry/terragrunt.hcl
@@ -10,7 +10,7 @@ terraform {
   source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/composition/artifact-registry?ref=gcp-artifact-registry-v0.1.0"
 }
 
-inputs = {
+inputs = merge({
   project_id  = include.root.locals.project_id
   environment = include.root.locals.environment.short
   location    = include.root.locals.region
@@ -33,4 +33,4 @@ inputs = {
     environment = include.root.locals.environment.short
     managed_by  = "terraform"
   }
-}
+}, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/artifact-registry/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/artifact-registry/terragrunt.hcl
@@ -29,8 +29,8 @@ inputs = merge({
     }
   }
 
-  labels = {
+  labels = merge({
     environment = include.root.locals.environment.short
     managed_by  = "terraform"
-  }
+  }, try(values.common_labels, {}))
 }, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/bastion-host/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/bastion-host/terragrunt.hcl
@@ -44,9 +44,9 @@ inputs = merge({
 
   enable_session_logging = true
 
-  labels = {
+  labels = merge({
     environment = include.root.locals.environment.short
     project     = include.root.locals.project_name
     managed_by  = "terraform"
-  }
+  }, try(values.common_labels, {}))
 }, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/bastion-host/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/bastion-host/terragrunt.hcl
@@ -19,7 +19,7 @@ terraform {
   source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/composition/bastion-host?ref=gcp-bastion-host-v0.1.0"
 }
 
-inputs = {
+inputs = merge({
   project_id   = include.root.locals.project_id
   environment  = include.root.locals.environment.short
   project_name = include.root.locals.project_name
@@ -49,4 +49,4 @@ inputs = {
     project     = include.root.locals.project_name
     managed_by  = "terraform"
   }
-}
+}, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/envoy-proxy/config/envoy.yaml.tftpl
+++ b/terraform/gcp/catalog/units/envoy-proxy/config/envoy.yaml.tftpl
@@ -1,0 +1,76 @@
+# Minimal Envoy config: terminate the GCLB backend connection and forward
+# everything to a single upstream (typically an Istio ingressgateway ILB).
+#
+# Deliberately minimal compared to the AWS envoy-proxy unit's config, which
+# carries Lua auth filters, a ratelimit cluster and a vector access-log sink -
+# none of that is assumed here, and adding it back without those upstreams
+# existing makes Envoy reject the config at boot. Override entirely via
+# envoy_config_content if a deployment needs more than this single-cluster
+# passthrough.
+#
+# Traffic path:
+#   client -> GCLB (${lb_ip}) -> this Envoy on :${http_port}
+#          -> upstream (${upstream_host}:${upstream_port})
+#
+# The GCLB health check hits :${http_port}/health, which is answered locally by
+# the direct_response below rather than proxied - so Envoy reports healthy as
+# soon as it is up, independent of whether the upstream is ready. Without this
+# the backend flaps whenever the upstream restarts.
+admin:
+  address:
+    socket_address: { address: 127.0.0.1, port_value: 9901 }
+
+static_resources:
+  listeners:
+    - name: http
+      address:
+        socket_address: { address: 0.0.0.0, port_value: ${http_port} }
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: ingress_http
+                # The GCLB terminates TLS and is the only thing in front of
+                # Envoy, so trust exactly one hop of X-Forwarded-For.
+                use_remote_address: true
+                xff_num_trusted_hops: 1
+                access_log:
+                  - name: envoy.access_loggers.file
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                      path: /var/log/envoy/access.log
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: all
+                      domains: ["*"]
+                      routes:
+                        # Answered by Envoy itself - see header comment.
+                        - match: { path: "/health" }
+                          direct_response:
+                            status: 200
+                            body: { inline_string: "envoy-ok" }
+                        - match: { prefix: "/" }
+                          route:
+                            cluster: upstream
+                            timeout: 60s
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+  clusters:
+    - name: upstream
+      type: STRICT_DNS
+      connect_timeout: 5s
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: upstream
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: ${upstream_host}
+                      port_value: ${upstream_port}

--- a/terraform/gcp/catalog/units/envoy-proxy/templates/startup.sh
+++ b/terraform/gcp/catalog/units/envoy-proxy/templates/startup.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Fetches Envoy's config from the GCS config bucket and starts Envoy.
+#
+# WHY THIS EXISTS. The custom Envoy image bakes in envoy.service, which runs
+#   /usr/bin/envoy -c /etc/envoy/envoy.yaml
+# but nothing in the image creates that file - no config-fetch step ships in
+# the baked image. Without it: "Invalid path: /etc/envoy/envoy.yaml",
+# envoy.service restarting every 5s, and the GCLB backend permanently
+# UNHEALTHY. This script closes that gap from the instance-template side, so
+# no image rebuild is needed.
+#
+# Idempotent and safe to re-run: it re-fetches on every boot, so rolling the
+# MIG is all that is needed to pick up a new config.
+set -euo pipefail
+
+BUCKET="$(curl -sS -H 'Metadata-Flavor: Google' \
+  http://metadata.google.internal/computeMetadata/v1/instance/attributes/config-bucket)"
+
+install -d -o envoy -g envoy /etc/envoy /var/log/envoy
+
+# The instance service account has objectViewer on this bucket (granted by the
+# module); if this 403s or 404s, do NOT start Envoy with a stale/absent config.
+# NOTE THE FILENAME. Envoy picks its config parser from the file EXTENSION:
+# a path ending in .yaml is parsed as YAML, anything else falls back to JSON.
+# Staging this as "envoy.yaml.new" made Envoy try to parse YAML as JSON and
+# fail on the very first character of the leading comment:
+#   Unable to parse JSON as proto ... unexpected character: '#'; expected '{'
+# so the staging file must itself end in .yaml.
+STAGE=/etc/envoy/envoy.staging.yaml
+
+if ! /snap/bin/gsutil cp "gs://${BUCKET}/envoy.yaml" "$STAGE"; then
+  echo "envoy-startup: failed to fetch gs://${BUCKET}/envoy.yaml" >&2
+  exit 1
+fi
+
+# Validate before swapping in, so a bad config leaves the previous one intact
+# rather than putting the node into the same crash loop this script exists to
+# fix.
+if /usr/bin/envoy --mode validate -c "$STAGE"; then
+  mv "$STAGE" /etc/envoy/envoy.yaml
+  chown envoy:envoy /etc/envoy/envoy.yaml
+else
+  echo "envoy-startup: fetched config failed validation, not applying" >&2
+  rm -f "$STAGE"
+  exit 1
+fi
+
+systemctl daemon-reload
+systemctl enable envoy.service
+systemctl restart envoy.service

--- a/terraform/gcp/catalog/units/envoy-proxy/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/envoy-proxy/terragrunt.hcl
@@ -52,18 +52,22 @@ inputs = merge({
   # consumer, not just a checkout of this repo.
   #
   # values.envoy is optional - the default here is a minimal single-cluster
-  # passthrough (see config/envoy.yaml.tftpl). A deployment that needs a
-  # different Envoy config entirely (extra filters, multiple clusters) should
-  # override envoy_config_content wholesale via values.cfg rather than fork
-  # this unit.
-  envoy_config_content = try(values.envoy, null) != null ? templatefile("${get_terragrunt_dir()}/config/envoy.yaml.tftpl", {
+  # passthrough (see config/envoy.yaml.tftpl).
+  #
+  # values.envoy.assets_dir swaps the BASE directory both paths below resolve
+  # against, defaulting to this unit's own bundled config/ + templates/. Point
+  # it at a private directory with the same config/envoy.yaml.tftpl and
+  # templates/startup.sh layout to ship real Envoy config (extra filters,
+  # auth, multiple clusters) without forking this unit or hand-rendering the
+  # whole content yourself via values.cfg.
+  envoy_config_content = try(values.envoy, null) != null ? templatefile("${try(values.envoy.assets_dir, get_terragrunt_dir())}/config/envoy.yaml.tftpl", {
     http_port     = 8080
     lb_ip         = try(values.envoy.lb_ip, "unknown")
     upstream_host = values.envoy.upstream_host
     upstream_port = try(values.envoy.upstream_port, 80)
   }) : null
 
-  custom_startup_script = file("${get_terragrunt_dir()}/templates/startup.sh")
+  custom_startup_script = file("${try(values.envoy.assets_dir, get_terragrunt_dir())}/templates/startup.sh")
 
   enable_cloud_armor   = true
   enable_mtls_listener = false

--- a/terraform/gcp/catalog/units/envoy-proxy/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/envoy-proxy/terragrunt.hcl
@@ -20,7 +20,7 @@ terraform {
   source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/composition/envoy-proxy?ref=gcp-envoy-proxy-v0.1.0"
 }
 
-inputs = {
+inputs = merge({
   project_id   = include.root.locals.project_id
   environment  = include.root.locals.environment.short
   project_name = include.root.locals.project_name
@@ -36,12 +36,41 @@ inputs = {
 
   managed_ssl_certificate_domains = [values.domains.api]
 
+  # ---------------------------------------------------------------------
+  # Config pipeline
+  # ---------------------------------------------------------------------
+  # Without these two inputs the module uploads no envoy.yaml (the config
+  # bucket object is count = 0 when envoy_config_content is null) and sets no
+  # startup script, so the baked image boots with an empty /etc/envoy,
+  # envoy.service crash-loops on "Invalid path: /etc/envoy/envoy.yaml", and
+  # the GCLB backend sits UNHEALTHY. See templates/startup.sh for the full
+  # explanation.
+  #
+  # get_terragrunt_dir() (not get_repo_root()): `terragrunt stack generate`
+  # copies this unit's non-HCL files (config/, templates/) alongside the
+  # generated terragrunt.hcl, so the paths below resolve correctly for any
+  # consumer, not just a checkout of this repo.
+  #
+  # values.envoy is optional - the default here is a minimal single-cluster
+  # passthrough (see config/envoy.yaml.tftpl). A deployment that needs a
+  # different Envoy config entirely (extra filters, multiple clusters) should
+  # override envoy_config_content wholesale via values.cfg rather than fork
+  # this unit.
+  envoy_config_content = try(values.envoy, null) != null ? templatefile("${get_terragrunt_dir()}/config/envoy.yaml.tftpl", {
+    http_port     = 8080
+    lb_ip         = try(values.envoy.lb_ip, "unknown")
+    upstream_host = values.envoy.upstream_host
+    upstream_port = try(values.envoy.upstream_port, 80)
+  }) : null
+
+  custom_startup_script = file("${get_terragrunt_dir()}/templates/startup.sh")
+
   enable_cloud_armor   = true
   enable_mtls_listener = false
 
-  labels = {
+  labels = merge({
     environment = include.root.locals.environment.short
     project     = include.root.locals.project_name
     managed_by  = "terraform"
-  }
-}
+  }, try(values.common_labels, {}))
+}, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/firewall-rules/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/firewall-rules/terragrunt.hcl
@@ -34,7 +34,7 @@ terraform {
   source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/composition/firewall-rules?ref=gcp-firewall-rules-v0.1.0"
 }
 
-inputs = {
+inputs = merge({
   project_id   = include.root.locals.project_id
   environment  = include.root.locals.environment.short
   project_name = include.root.locals.project_name
@@ -77,4 +77,4 @@ inputs = {
       ]
     }
   }
-}
+}, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/iam-infraswitch-federation/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/iam-infraswitch-federation/terragrunt.hcl
@@ -50,7 +50,7 @@ terraform {
   source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/application-resources/infraswitch-gcp-federation?ref=gcp-apps-infraswitch-gcp-federation-v0.1.0"
 }
 
-inputs = {
+inputs = merge({
   project_id = include.root.locals.project_id
 
   # Which AWS identity the pool trusts. Required - there is no sane default,
@@ -94,4 +94,4 @@ inputs = {
     "roles/networkconnectivity.consumerNetworkAdmin",
     "roles/memorystore.admin",
   ])
-}
+}, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/iam-infraswitch-federation/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/iam-infraswitch-federation/terragrunt.hcl
@@ -1,0 +1,97 @@
+# Federates ONE AWS IAM role into this GCP project, so a CI/CD apply worker
+# that runs only in AWS (infra-switch / Atlantis, authenticated via IRSA) can
+# run `terragrunt apply` against GCP with no static GCP key anywhere.
+#
+# Grants GCP project roles DIRECTLY to the federated AWS identity - no service
+# account, no impersonation. The stack's root.hcl `provider "google"` blocks
+# are untouched: humans keep applying with their own GCP permissions exactly as
+# before; the CI/CD worker authenticates as the AWS role, separately.
+#
+# Sits at the top level, not under application-stack - a Workload Identity Pool
+# is a project-wide IAM concern (the roles below span VPC/GKE/Envoy/Squid/
+# AlloyDB/Valkey as well as the app tier), not scoped to any single app.
+#
+# ONE POOL PER PROJECT. The module hardcodes workload_identity_pool_id =
+# "infraswitch-aws-pool", so this unit must be instantiated at most once per
+# GCP project. Two live trees sharing a project_id share this unit's state -
+# that is correct and deliberate, not a collision to "fix".
+#
+# NOTE ON THE NAME. The unit is `iam-infraswitch-federation` while the module
+# is `infraswitch-gcp-federation`. The unit name is load-bearing: it is the
+# `path` in the consuming stack, and therefore the state prefix of an already-
+# applied deployment. Renaming it strands that state and, because the pool id
+# is fixed, the re-apply then fails with ALREADY_EXISTS rather than creating
+# anything.
+#
+# No `dependency` blocks: this unit reads nothing from any other unit, and
+# nothing reads from it. It is also the unit that must exist BEFORE the CI/CD
+# worker can apply any of the others, since it is what grants the roles those
+# applies need - so on a green-field rebuild a human applies this one first, as
+# themselves.
+#
+# See the module's README (terraform/gcp/modules/application-resources/
+# infraswitch-gcp-federation) for the one-time manual
+# `gcloud iam workload-identity-pools create-cred-config` bootstrap step this
+# unit's outputs feed into.
+#
+# OPERATIONAL GOTCHA: destroying this unit SOFT-deletes the pool and provider.
+# GCP reserves both ids for 30 days, so a later re-apply fails with
+# `Error 409: Requested entity already exists`. Recover with
+# `gcloud iam workload-identity-pools undelete` AND
+# `... providers undelete` (the provider is soft-deleted separately - the pool
+# undelete does not restore it), then `terraform import` both.
+
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+terraform {
+  source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/application-resources/infraswitch-gcp-federation?ref=gcp-apps-infraswitch-gcp-federation-v0.1.0"
+}
+
+inputs = {
+  project_id = include.root.locals.project_id
+
+  # Which AWS identity the pool trusts. Required - there is no sane default,
+  # and a wrong value here silently federates the wrong role.
+  aws_account_id = values.aws_account_id
+  aws_role_name  = values.aws_role_name
+
+  # The module's own defaults, plus five roles a full live tree needs that the
+  # defaults do not cover:
+  #
+  #   dns.admin                            vpc-network manages private Cloud
+  #                                        DNS zones (Private Service Connect
+  #                                        to Google APIs) via
+  #                                        google_dns_managed_zone.
+  #   resourcemanager.projectIamAdmin      every apps/* unit grants project
+  #                                        roles to its own service account.
+  #   artifactregistry.admin               the artifact-registry unit.
+  #   networkconnectivity.consumerNetworkAdmin
+  #   memorystore.admin                    memorystore-valkey (the Memorystore
+  #                                        for Valkey API is distinct from the
+  #                                        redis.admin the defaults grant).
+  #
+  # A `values` knob rather than a literal so an environment can narrow the
+  # grant without forking the unit - but narrowing below this set breaks
+  # `terragrunt apply` for the units named above.
+  project_roles = try(values.project_roles, [
+    "roles/compute.admin",
+    "roles/container.admin",
+    "roles/alloydb.admin",
+    "roles/redis.admin",
+    "roles/servicenetworking.networksAdmin",
+    "roles/iam.serviceAccountUser",
+    "roles/iam.serviceAccountAdmin",
+    "roles/cloudkms.admin",
+    "roles/storage.admin",
+    "roles/secretmanager.admin",
+    "roles/iam.workloadIdentityPoolAdmin",
+    "roles/dns.admin",
+    "roles/resourcemanager.projectIamAdmin",
+    "roles/artifactregistry.admin",
+    "roles/networkconnectivity.consumerNetworkAdmin",
+    "roles/memorystore.admin",
+  ])
+}

--- a/terraform/gcp/catalog/units/locker/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/locker/terragrunt.hcl
@@ -39,7 +39,7 @@ terraform {
   source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/composition/locker?ref=gcp-locker-v0.1.0"
 }
 
-inputs = {
+inputs = merge({
   project_id   = include.root.locals.project_id
   environment  = include.root.locals.environment.short
   project_name = include.root.locals.project_name
@@ -146,4 +146,4 @@ inputs = {
     compliance  = "pci-dss"
     managed_by  = "terraform"
   }
-}
+}, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/locker/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/locker/terragrunt.hcl
@@ -140,10 +140,10 @@ inputs = merge({
   # cryptoKeyEncrypterDecrypter would widen its permissions for nothing.
   grant_kms_access = false
 
-  labels = {
+  labels = merge({
     environment = include.root.locals.environment.short
     project     = include.root.locals.project_name
     compliance  = "pci-dss"
     managed_by  = "terraform"
-  }
+  }, try(values.common_labels, {}))
 }, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/memorystore-valkey/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/memorystore-valkey/terragrunt.hcl
@@ -100,11 +100,11 @@ inputs = merge({
 
   deletion_protection_enabled = try(values.valkey.deletion_protection_enabled, true)
 
-  labels = {
+  labels = merge({
     environment = include.root.locals.environment.short
     project     = include.root.locals.project_name
     component   = "cache"
     engine      = "valkey"
     managed_by  = "terraform"
-  }
+  }, try(values.common_labels, {}))
 }, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/memorystore-valkey/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/memorystore-valkey/terragrunt.hcl
@@ -50,7 +50,7 @@ terraform {
 }
 
 
-inputs = {
+inputs = merge({
   project_id   = include.root.locals.project_id
   environment  = include.root.locals.environment.short
   project_name = include.root.locals.project_name
@@ -107,4 +107,4 @@ inputs = {
     engine      = "valkey"
     managed_by  = "terraform"
   }
-}
+}, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/squid-proxy/config/allowedlist.txt
+++ b/terraform/gcp/catalog/units/squid-proxy/config/allowedlist.txt
@@ -1,0 +1,9 @@
+# Minimal default egress allowlist - only Google's own API domains, enough
+# for a GCP workload to reach its own cloud provider. Almost every real
+# deployment needs more than this (package registries, the app's own third
+# party integrations) - override via values.squid.allowlist_file (a path to a
+# private list) or values.cfg.squid_allowlist_content (inline), rather than
+# forking this unit.
+.googleapis.com
+.pkg.dev
+.gcr.io

--- a/terraform/gcp/catalog/units/squid-proxy/config/squid.conf
+++ b/terraform/gcp/catalog/units/squid-proxy/config/squid.conf
@@ -1,0 +1,50 @@
+# Default Squid egress-proxy config for this unit.
+#
+# The allowlist file is /etc/squid/allowedlist.txt, matching the object name
+# this unit's module writes into the config bucket (squid_allowlist_content ->
+# allowedlist.txt). No domain_blacklist.txt / allowed_ips.txt ACLs are
+# referenced here: the module has no input that produces those files, and
+# Squid REFUSES TO START if an acl references a missing file.
+#
+# WHY THIS FILE EXISTS AT ALL. Without squid_config_content the module uploads
+# nothing, the VM keeps the stock Ubuntu squid.conf from the baked image, and
+# that config ends in `http_access deny all` with `http_access allow localnet`
+# commented out. Squid then accepts the TCP connection and silently drops the
+# CONNECT, so clients hang until their own timeout instead of getting a fast
+# 403 - indistinguishable from a network fault. Override entirely via
+# squid_config_content if a deployment needs a different policy.
+http_port 3128
+
+acl SSL_ports port 1-65535
+acl Safe_ports port 1-65535
+acl CONNECT method CONNECT
+
+http_access allow localhost manager
+http_access deny manager
+
+# The allowlist: one domain per line, leading "." means "and all subdomains".
+acl allowed_sites dstdomain "/etc/squid/allowedlist.txt"
+
+# Callers inside the VPC. Egress is only reachable through the ILB from
+# in-VPC clients anyway (firewall-enforced), so this is defence in depth
+# rather than the primary control.
+acl vpc_clients src 10.0.0.0/8
+
+# Health checks: GCP probes come from these fixed, publicly documented ranges
+# and must be answered even though they are not in the allowlist, or the ILB
+# marks the backend unhealthy and no traffic reaches squid at all.
+acl gcp_health_check src 130.211.0.0/22 35.191.0.0/16
+http_access allow gcp_health_check
+
+http_access allow vpc_clients allowed_sites
+http_access deny all
+
+# Explicit and fast: without this, denied requests are dropped in a way that
+# looks like a hang to the client.
+deny_info ERR_ACCESS_DENIED allowed_sites
+
+# Forward proxy only - no caching.
+cache deny all
+cache_mem 0 MB
+
+access_log /var/log/squid/access.log

--- a/terraform/gcp/catalog/units/squid-proxy/templates/startup.sh
+++ b/terraform/gcp/catalog/units/squid-proxy/templates/startup.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Fetches squid.conf + allowedlist.txt from the GCS config bucket and restarts
+# Squid.
+#
+# WHY THIS EXISTS. Same gap as the Envoy tier: the baked image ships Squid and
+# a stock /etc/squid/squid.conf, but nothing in the image ever pulls the real
+# config from the bucket named in the instance's `config-bucket` metadata. The
+# stock config ends in `http_access deny all`, so every proxied request hangs
+# until the client times out and the egress path appears broken.
+set -euo pipefail
+
+BUCKET="$(curl -sS -H 'Metadata-Flavor: Google' \
+  http://metadata.google.internal/computeMetadata/v1/instance/attributes/config-bucket)"
+
+install -d /etc/squid
+
+fetch() { # object, destination
+  if ! /snap/bin/gsutil cp "gs://${BUCKET}/$1" "$2.new"; then
+    echo "squid-startup: failed to fetch gs://${BUCKET}/$1" >&2
+    return 1
+  fi
+  mv "$2.new" "$2"
+}
+
+# The allowlist must land BEFORE squid.conf is validated: squid refuses to
+# start when an acl references a file that does not exist, so a missing
+# allowlist would break Squid rather than merely denying traffic.
+fetch allowedlist.txt /etc/squid/allowedlist.txt
+fetch squid.conf      /etc/squid/squid.conf
+
+# Validate before restarting, so a bad config leaves the previous (working)
+# one running instead of taking the whole egress path down.
+if ! squid -k parse -f /etc/squid/squid.conf; then
+  echo "squid-startup: fetched config failed validation, not restarting" >&2
+  exit 1
+fi
+
+systemctl enable squid.service
+systemctl restart squid.service

--- a/terraform/gcp/catalog/units/squid-proxy/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/squid-proxy/terragrunt.hcl
@@ -21,7 +21,7 @@ terraform {
   source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/composition/squid-proxy?ref=gcp-squid-proxy-v0.1.0"
 }
 
-inputs = {
+inputs = merge({
   project_id   = include.root.locals.project_id
   environment  = include.root.locals.environment.short
   project_name = include.root.locals.project_name
@@ -49,9 +49,34 @@ inputs = {
   min_replicas = 2
   max_replicas = 6
 
-  labels = {
+  # ---------------------------------------------------------------------
+  # Config pipeline
+  # ---------------------------------------------------------------------
+  # Without these two inputs the module uploads nothing to the config bucket,
+  # the VM runs the stock Ubuntu squid.conf baked into the image, and that
+  # config ends in `http_access deny all`. Squid then accepts the TCP
+  # connection and silently drops the CONNECT, so clients hang for their full
+  # timeout instead of getting a fast 403 - indistinguishable from a network
+  # fault. See templates/startup.sh for the full explanation.
+  #
+  # get_terragrunt_dir() (not get_repo_root()): `terragrunt stack generate`
+  # copies this unit's non-HCL files (config/, templates/) alongside the
+  # generated terragrunt.hcl, so these paths resolve for any consumer.
+  #
+  # squid_config_content has a working default (config/squid.conf); the
+  # allowlist's default is DELIBERATELY minimal (Google's own API domains
+  # only, see config/allowedlist.txt) since a real deployment's allowlist is
+  # inherently environment-specific. Point values.squid.allowlist_file at a
+  # private file to extend it, or override squid_allowlist_content wholesale
+  # via values.cfg for anything more than a file swap.
+  squid_config_content    = file("${get_terragrunt_dir()}/config/squid.conf")
+  squid_allowlist_content = file(try(values.squid.allowlist_file, "${get_terragrunt_dir()}/config/allowedlist.txt"))
+
+  custom_startup_script = file("${get_terragrunt_dir()}/templates/startup.sh")
+
+  labels = merge({
     environment = include.root.locals.environment.short
     project     = include.root.locals.project_name
     managed_by  = "terraform"
-  }
-}
+  }, try(values.common_labels, {}))
+}, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/squid-proxy/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/squid-proxy/terragrunt.hcl
@@ -52,27 +52,27 @@ inputs = merge({
   # ---------------------------------------------------------------------
   # Config pipeline
   # ---------------------------------------------------------------------
-  # Without these two inputs the module uploads nothing to the config bucket,
-  # the VM runs the stock Ubuntu squid.conf baked into the image, and that
-  # config ends in `http_access deny all`. Squid then accepts the TCP
+  # Without these three inputs the module uploads nothing to the config
+  # bucket, the VM runs the stock Ubuntu squid.conf baked into the image, and
+  # that config ends in `http_access deny all`. Squid then accepts the TCP
   # connection and silently drops the CONNECT, so clients hang for their full
   # timeout instead of getting a fast 403 - indistinguishable from a network
   # fault. See templates/startup.sh for the full explanation.
   #
-  # get_terragrunt_dir() (not get_repo_root()): `terragrunt stack generate`
-  # copies this unit's non-HCL files (config/, templates/) alongside the
-  # generated terragrunt.hcl, so these paths resolve for any consumer.
-  #
-  # squid_config_content has a working default (config/squid.conf); the
-  # allowlist's default is DELIBERATELY minimal (Google's own API domains
-  # only, see config/allowedlist.txt) since a real deployment's allowlist is
-  # inherently environment-specific. Point values.squid.allowlist_file at a
-  # private file to extend it, or override squid_allowlist_content wholesale
-  # via values.cfg for anything more than a file swap.
-  squid_config_content    = file("${get_terragrunt_dir()}/config/squid.conf")
-  squid_allowlist_content = file(try(values.squid.allowlist_file, "${get_terragrunt_dir()}/config/allowedlist.txt"))
+  # values.squid.assets_dir swaps the BASE directory all three paths below
+  # resolve against, defaulting to this unit's own bundled config/ +
+  # templates/ (get_terragrunt_dir(), not get_repo_root(): `terragrunt stack
+  # generate` copies this unit's non-HCL files alongside the generated
+  # terragrunt.hcl, so the default resolves for any consumer). The bundled
+  # allowlist is DELIBERATELY minimal (Google's own API domains only, see
+  # config/allowedlist.txt) since a real deployment's allowlist is inherently
+  # environment-specific - point assets_dir at a private directory with the
+  # same config/{squid.conf,allowedlist.txt} and templates/startup.sh layout
+  # to ship a real one, without forking this unit.
+  squid_config_content    = file("${try(values.squid.assets_dir, get_terragrunt_dir())}/config/squid.conf")
+  squid_allowlist_content = file("${try(values.squid.assets_dir, get_terragrunt_dir())}/config/allowedlist.txt")
 
-  custom_startup_script = file("${get_terragrunt_dir()}/templates/startup.sh")
+  custom_startup_script = file("${try(values.squid.assets_dir, get_terragrunt_dir())}/templates/startup.sh")
 
   labels = merge({
     environment = include.root.locals.environment.short

--- a/terraform/gcp/catalog/units/vpc-network/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/vpc-network/terragrunt.hcl
@@ -10,7 +10,7 @@ terraform {
   source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/gcp/modules/composition/vpc-network?ref=gcp-vpc-network-v0.1.0"
 }
 
-inputs = {
+inputs = merge({
   project_id   = include.root.locals.project_id
   environment  = include.root.locals.environment.short
   project_name = include.root.locals.project_name
@@ -72,4 +72,4 @@ inputs = {
     team        = "infra"
     managed_by  = "terraform"
   }
-}
+}, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/vpc-network/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/vpc-network/terragrunt.hcl
@@ -66,10 +66,10 @@ inputs = merge({
   }
   enable_default_deny_ingress = true
 
-  labels = {
+  labels = merge({
     environment = include.root.locals.environment.short
     project     = include.root.locals.project_name
     team        = "infra"
     managed_by  = "terraform"
-  }
+  }, try(values.common_labels, {}))
 }, try(values.cfg, {}))

--- a/terraform/gcp/modules/application-resources/istio/locals.tf
+++ b/terraform/gcp/modules/application-resources/istio/locals.tf
@@ -12,14 +12,14 @@ locals {
 
   istio_base = merge(
     { release_name = "istio-base", chart_repo = "https://istio-release.storage.googleapis.com/charts", chart_version = null, values = [], values_file = "" },
-    var.istio_base
+    try({ for k, v in var.istio_base : k => v if v != null }, {})
   )
   istiod = merge(
     { release_name = "istiod", chart_repo = "https://istio-release.storage.googleapis.com/charts", chart_version = null, values = [], values_file = "" },
-    var.istiod
+    try({ for k, v in var.istiod : k => v if v != null }, {})
   )
   istio_gateway = merge(
     { release_name = "istio-gateway", chart_repo = "https://istio-release.storage.googleapis.com/charts", chart_version = null, values = [], values_file = "" },
-    var.istio_gateway
+    try({ for k, v in var.istio_gateway : k => v if v != null }, {})
   )
 }

--- a/terraform/gcp/modules/composition/gke/variables.tf
+++ b/terraform/gcp/modules/composition/gke/variables.tf
@@ -44,7 +44,7 @@ variable "zones" {
 }
 
 variable "network" {
-  description = "Self-link of the VPC network to host the cluster in"
+  description = "Bare NAME (not self-link) of the VPC network to host the cluster in - passed straight through to terraform-google-modules/kubernetes-engine's private-cluster submodule, which resolves it itself and expects a name, not a self-link."
   type        = string
 }
 
@@ -55,7 +55,7 @@ variable "network_project_id" {
 }
 
 variable "subnetwork" {
-  description = "Self-link of the subnetwork to host the cluster nodes in"
+  description = "Bare NAME (not self-link) of the subnetwork to host the cluster nodes in - same reason as `network` above."
   type        = string
 }
 


### PR DESCRIPTION
Publishes the missing catalog unit for the infraswitch-gcp-federation module. The module has been on main since #307, but no unit wrapped it, so consumers had to carry a local copy and `terragrunt stack generate` failed against a checkout that did not have one.

- units/iam-infraswitch-federation: wraps the module at gcp-apps-infraswitch-gcp-federation-v0.1.0. No dependency blocks; takes aws_account_id / aws_role_name from stack values, and defaults project_roles to the 16 roles a full live tree needs.
- stacks/dev: adds the unit at Phase 0, ahead of vpc-network, since it is what grants the CI/CD worker the roles every other unit's apply needs.
- live: adds the infraswitch_federation values block with REPLACE_ME placeholders, matching the rest of the template.

The unit name intentionally differs from the module name: it is the `path` in the stack, hence the state prefix of already-applied deployments.

NOTE: the stack pins unit/gcp/iam-infraswitch-federation-v0.1.0-v1, which must be cut from the merge commit before anything consumes this stack.