### PR TITLE
fix(hyperswitch-ucs): IAM-safe Service tag value; unit pins v0.1.1

### DIFF
--- a/terraform/aws/catalog/units/application-stack/apps/hyperswitch-ucs/terragrunt.hcl
+++ b/terraform/aws/catalog/units/application-stack/apps/hyperswitch-ucs/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 terraform {
-  source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/aws/modules/application-resources/hyperswitch-ucs?ref=apps-hyperswitch-ucs-v0.1.0"
+  source = "git::https://github.com/juspay/hyperswitch-suite.git//terraform/aws/modules/application-resources/hyperswitch-ucs?ref=apps-hyperswitch-ucs-v0.1.1"
 }
 
 dependency "eks" {

--- a/terraform/aws/modules/application-resources/hyperswitch-ucs/locals.tf
+++ b/terraform/aws/modules/application-resources/hyperswitch-ucs/locals.tf
@@ -6,8 +6,9 @@ locals {
       "Environment" = var.environment
       "Project"     = var.project_name
       "Application" = var.app_name
-      "Service"     = "Hyperswitch UCS (Unified Connector Service)"
-      "ManagedBy"   = "terraform"
+      # IAM tag values allow only letters, digits, spaces and _.:/=+-@ — no parentheses.
+      "Service"   = "Hyperswitch UCS Unified Connector Service"
+      "ManagedBy" = "terraform"
     },
     var.region != null ? { "Region" = var.region } : {},
     var.tags


### PR DESCRIPTION
## Description

Applying the `hyperswitch-ucs` module (`apps-hyperswitch-ucs-v0.1.0`) fails at `aws_iam_role` / `aws_iam_policy` creation:

```
api error ValidationError: Value at 'tags.4.member.value' failed to satisfy constraint:
Member must satisfy regular expression pattern: [\p{L}\p{Z}\p{N}_.:/=+\-@]*
```

The module's `Service` tag value `Hyperswitch UCS (Unified Connector Service)` contains parentheses, which IAM tag values do not allow. This drops them.

## Changes

- `locals.tf`: `Service = "Hyperswitch UCS Unified Connector Service"`.
- Catalog unit pins `apps-hyperswitch-ucs-v0.1.1`.

## After merge

Tags from the merge commit: `apps-hyperswitch-ucs-v0.1.1` (module) and `unit/aws/hyperswitch-ucs-v0.1.1-v1` (catalog unit).

## Testing

`terraform fmt`/`validate`, tflint, `terragrunt hcl format --check`, terraform-docs and the sensitive scan are clean locally, same tools as CI.