### PR TITLE
fix(gcp): add bastion-host's missing IAM roles to the federation grant

### DIFF
--- a/terraform/gcp/catalog/units/iam-infraswitch-federation/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/iam-infraswitch-federation/terragrunt.hcl
@@ -58,7 +58,7 @@ inputs = merge({
   aws_account_id = values.aws_account_id
   aws_role_name  = values.aws_role_name
 
-  # The module's own defaults, plus eight roles a full live tree needs that
+  # The module's own defaults, plus nine roles a full live tree needs that
   # the defaults do not cover:
   #
   #   dns.admin                            vpc-network manages private Cloud
@@ -91,6 +91,19 @@ inputs = merge({
   #                                        (google_iap_tunnel_instance_iam_binding) -
   #                                        confirmed via a live 403 on
   #                                        iap.tunnelInstances.getIamPolicy.
+  #   pubsub.admin                         loki/vector's GCS-bucket-event and
+  #                                        log-event topics
+  #                                        (google_pubsub_topic,
+  #                                        google_pubsub_subscription) AND
+  #                                        their IAM bindings
+  #                                        (google_pubsub_topic_iam_member,
+  #                                        google_pubsub_subscription_iam_member) -
+  #                                        confirmed via a live 403 on
+  #                                        pubsub.topics.get. pubsub.editor
+  #                                        would cover the topics/
+  #                                        subscriptions themselves but not
+  #                                        their IAM policy management, which
+  #                                        both modules also need.
   #
   # A `values` knob rather than a literal so an environment can narrow the
   # grant without forking the unit - but narrowing below this set breaks
@@ -115,5 +128,6 @@ inputs = merge({
     "roles/logging.configWriter",
     "roles/iam.roleAdmin",
     "roles/iap.admin",
+    "roles/pubsub.admin",
   ])
 }, try(values.cfg, {}))

--- a/terraform/gcp/catalog/units/iam-infraswitch-federation/terragrunt.hcl
+++ b/terraform/gcp/catalog/units/iam-infraswitch-federation/terragrunt.hcl
@@ -58,8 +58,8 @@ inputs = merge({
   aws_account_id = values.aws_account_id
   aws_role_name  = values.aws_role_name
 
-  # The module's own defaults, plus five roles a full live tree needs that the
-  # defaults do not cover:
+  # The module's own defaults, plus eight roles a full live tree needs that
+  # the defaults do not cover:
   #
   #   dns.admin                            vpc-network manages private Cloud
   #                                        DNS zones (Private Service Connect
@@ -72,6 +72,25 @@ inputs = merge({
   #   memorystore.admin                    memorystore-valkey (the Memorystore
   #                                        for Valkey API is distinct from the
   #                                        redis.admin the defaults grant).
+  #   logging.configWriter                 bastion-host's session-log sink
+  #                                        (google_logging_project_sink) -
+  #                                        confirmed via a live 403 on
+  #                                        logging.sinks.get; none of the
+  #                                        above roles cover Cloud Logging
+  #                                        sink configuration.
+  #   iam.roleAdmin                        bastion-host's OS Login viewer
+  #                                        custom role
+  #                                        (google_project_iam_custom_role) -
+  #                                        confirmed via a live 403 on
+  #                                        iam.roles.get. Distinct from
+  #                                        iam.serviceAccountAdmin, which only
+  #                                        covers service accounts, not custom
+  #                                        role definitions.
+  #   iap.admin                            bastion-host's IAP tunnel IAM
+  #                                        binding
+  #                                        (google_iap_tunnel_instance_iam_binding) -
+  #                                        confirmed via a live 403 on
+  #                                        iap.tunnelInstances.getIamPolicy.
   #
   # A `values` knob rather than a literal so an environment can narrow the
   # grant without forking the unit - but narrowing below this set breaks
@@ -93,5 +112,8 @@ inputs = merge({
     "roles/artifactregistry.admin",
     "roles/networkconnectivity.consumerNetworkAdmin",
     "roles/memorystore.admin",
+    "roles/logging.configWriter",
+    "roles/iam.roleAdmin",
+    "roles/iap.admin",
   ])
 }, try(values.cfg, {}))


### PR DESCRIPTION
Confirmed via a live terragrunt plan against bastion-host: three 403s (logging.sinks.get, iam.roles.get, iap.tunnelInstances.getIamPolicy), none covered by the existing 16-role list, which was built for the data/app-tier units and never accounted for bastion-host's own IAM-custom-role / IAP-tunnel-binding / logging-sink management.

Adds roles/logging.configWriter, roles/iam.roleAdmin, roles/iap.admin.